### PR TITLE
charts: update index.yaml for stable and staging

### DIFF
--- a/docs/stable/index.yaml
+++ b/docs/stable/index.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 entries: {}
-generated: 1970-01-01T00:00:00.000000000-00:00
+generated: 2019-07-02T14:48:03.19939+02:00

--- a/docs/staging/index.yaml
+++ b/docs/staging/index.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 entries: {}
-generated: 1970-01-01T00:00:00.000000000-00:00
+generated: 2019-07-02T14:48:03.083093+02:00


### PR DESCRIPTION
```
/usr/local/bin/helm --home /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm init --client-only
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm/repository
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm/repository/cache
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm/repository/local
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm/plugins
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm/starters
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm/cache/archive
Creating /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm/repository/repositories.yaml
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
Adding local repo with URL: http://127.0.0.1:8879/charts
$HELM_HOME has been configured at /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm.
Not installing Tiller due to 'client-only' flag having been set
Happy Helming!
/usr/local/bin/helm --home /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm repo index docs/staging
/usr/local/bin/helm --home /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm package staging/test -d docs/staging
Successfully packaged chart and saved it to: docs/staging/test-0.1.0.tgz
/usr/local/bin/helm --home /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm repo index docs/stable
/usr/local/bin/helm --home /var/folders/b3/gql3fhrn2_x4h91gnhh817nw0000gn/T/tmp.coXvqYeu/.helm package stable/localvolumeprovisioner -d docs/stable
Successfully packaged chart and saved it to: docs/stable/localvolumeprovisioner-0.1.0.tgz
```