### PR TITLE
[WIP] localvolumeprovisionerdefault: add new storage class

### DIFF
--- a/stable/localvolumeprovisionerdefault/Chart.yaml
+++ b/stable/localvolumeprovisionerdefault/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Local persistent volume provisioner as the default storageclass for konvoy
+name: localvolumeprovisionerdefault
+version: 0.1.0

--- a/stable/localvolumeprovisionerdefault/templates/NOTES.txt
+++ b/stable/localvolumeprovisionerdefault/templates/NOTES.txt
@@ -1,0 +1,9 @@
+The following directories have been created on worker nodes:
+
+{{- range .Values.storageclasses }}
+/mnt/{{ .name }}
+{{- end }}
+
+The directory names match their corresponding storage classes.
+By mounting volumes into these directories, they will be made available
+as persistent volume in their respective storage class.

--- a/stable/localvolumeprovisionerdefault/templates/deployment.yaml
+++ b/stable/localvolumeprovisionerdefault/templates/deployment.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-volume-provisioner-service-account
+  namespace: kubeaddons
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-volume-provisioner-role
+  namespace: kubeaddons
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "persistentvolumes", "pods"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-volume-provisioner-bind
+  namespace: kubeaddons
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-volume-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: local-volume-provisioner-service-account
+  namespace: kubeaddons
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-volume-provisioner-config
+  namespace: kubeaddons
+data:
+  storageClassMap: |
+    {{- range .Values.storageclasses }}
+    {{ .name }}:
+       hostDir: /mnt/{{ .name }}
+       mountDir: /mnt/{{ .name }}
+       blockCleanerCommand:
+         - "/scripts/shred.sh"
+         - "2"
+       volumeMode: Filesystem
+       fsType: ext4
+    {{- end }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: kubeaddons
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-volume-provisioner-service-account
+      containers:
+        - name: local-volume-provisioner
+          image: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+          securityContext:
+            privileged: true
+          imagePullPolicy: Always
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: JOB_CONTAINER_IMAGE
+              value: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: provisioner-config
+              mountPath: /etc/provisioner/config
+              readOnly: true
+            - name: local-volume-provisioner-dev
+              mountPath: /dev
+            {{- range .Values.storageclasses }}
+            - name: {{ .name }}
+              mountPath: /mnt/{{ .name }}
+              mountPropagation: "HostToContainer"
+            {{- end }}
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-volume-provisioner-config
+        - name: local-volume-provisioner-dev
+          hostPath:
+            path: /dev
+        {{- range .Values.storageclasses }}
+        - name: {{ .name }}
+          hostPath:
+            path: /mnt/{{ .name }}
+        {{- end }}

--- a/stable/localvolumeprovisionerdefault/templates/service.yaml
+++ b/stable/localvolumeprovisionerdefault/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: local-volume-provisioner-kubeaddons-metrics
+  namespace: kubeaddons
+  labels:
+    app: local-volume-provisioner
+    release: local-volume-provisioner-kubeaddons
+    servicemonitor.kubeaddons.mesosphere.io/path: metrics
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+  - port: 8080
+    targetPort: metrics
+    name: metrics
+    protocol: TCP
+  selector:
+    app: local-volume-provisioner

--- a/stable/localvolumeprovisionerdefault/templates/storageclass.yaml
+++ b/stable/localvolumeprovisionerdefault/templates/storageclass.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.storageclasses }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .name }}
+  {{- if .annotations }}
+  annotations:
+  {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+{{- end }}

--- a/stable/localvolumeprovisionerdefault/values.yaml
+++ b/stable/localvolumeprovisionerdefault/values.yaml
@@ -1,0 +1,5 @@
+storageclasses:
+  - name: disks
+    annotations:
+      storageclass.kubernetes.op/is-default-class: "true"
+      kubernetes.io/description: Local volume storage class


### PR DESCRIPTION
This PR clones the `./stable/localvolumeprovisioner` storage class to `./stable/localvolumeprovisionerdefault`. It follows https://github.com/mesosphere/charts/pull/2 

A superior strategy would be to make refactor the two, to have `default` be a subchart of the main one:

- `./stable/localvolumeprovisioner/charts/default`: 
    Declares the LVP chart with `is-default-class: true`.
- `./stable/localvolumeprovisioner`: 
    imports the subchart but overrides `is-default-class: false`.

However, that goes against current convention where we distinguish storage classes as either "additional" or "default" as follows:

```
awsebscsidriverstorageclass / awsebscsidriverstorageclassdefault
awsstorageclass / awsstorageclassdefault
localstorageclass / localstorageclassdefault
```
~ https://github.com/mesosphere/kubeaddons-configs/tree/4b1681663f60b3a537492e07f5ebcfb4b3d5e5e3/templates

For this PR, we stick to convention, though the duplication is painful - and leave a refactor of this pattern (and concurrent cleanup of the quoted example classes) as future work.