### PR TITLE
localvolumeprovisioner: single storageclass with flag for default

### DIFF
--- a/stable/localvolumeprovisioner/Chart.yaml
+++ b/stable/localvolumeprovisioner/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Local persistent volume provisioner for konvoy
 name: localvolumeprovisioner
-version: 0.1.0
+version: 0.1.1

--- a/stable/localvolumeprovisioner/templates/NOTES.txt
+++ b/stable/localvolumeprovisioner/templates/NOTES.txt
@@ -1,9 +1,6 @@
-The following directories have been created on worker nodes:
+The following directory has been created on worker nodes:
 
-{{- range .Values.storageclasses }}
-/mnt/{{ .name }}
-{{- end }}
+/mnt/disks/
 
-The directory names match their corresponding storage classes.
-By mounting volumes into these directories, they will be made available
-as persistent volume in their respective storage class.
+Volumes that are mounted into this directory show up as persistent volumes. Their
+`storageClassName` is set to `"localvolumeprovisioner"`.

--- a/stable/localvolumeprovisioner/templates/deployment.yaml
+++ b/stable/localvolumeprovisioner/templates/deployment.yaml
@@ -45,16 +45,14 @@ metadata:
   namespace: kubeaddons
 data:
   storageClassMap: |
-    {{- range .Values.storageclasses }}
-    {{ .name }}:
-       hostDir: /mnt/{{ .name }}
-       mountDir: /mnt/{{ .name }}
+    localvolumeprovisioner:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
        blockCleanerCommand:
          - "/scripts/shred.sh"
          - "2"
        volumeMode: Filesystem
        fsType: ext4
-    {{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -102,11 +100,9 @@ spec:
               readOnly: true
             - name: local-volume-provisioner-dev
               mountPath: /dev
-            {{- range .Values.storageclasses }}
-            - name: {{ .name }}
-              mountPath: /mnt/{{ .name }}
+            - name: disks
+              mountPath: /mnt/disks
               mountPropagation: "HostToContainer"
-            {{- end }}
       volumes:
         - name: provisioner-config
           configMap:
@@ -114,8 +110,6 @@ spec:
         - name: local-volume-provisioner-dev
           hostPath:
             path: /dev
-        {{- range .Values.storageclasses }}
-        - name: {{ .name }}
+        - name: disks
           hostPath:
-            path: /mnt/{{ .name }}
-        {{- end }}
+            path: /mnt/disks

--- a/stable/localvolumeprovisioner/templates/storageclass.yaml
+++ b/stable/localvolumeprovisioner/templates/storageclass.yaml
@@ -1,16 +1,11 @@
-{{- range .Values.storageclasses }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .name }}
-  {{- if .annotations }}
+  name: localvolumeprovisioner
   annotations:
-  {{- range $key, $value := .annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
+    storageclass.kubernetes.io/is-default-class: {{ .Values.storageclassdefault | default "true" | quote }}
+    kubernetes.io/description: Local volume provisioner StorageClass
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
-{{- end }}

--- a/stable/localvolumeprovisioner/values.yaml
+++ b/stable/localvolumeprovisioner/values.yaml
@@ -1,5 +1,1 @@
-storageclasses:
-  - name: disks
-    annotations:
-      storageclass.kubernetes.op/is-default-class: "false"
-      kubernetes.io/description: Local volume storage class
+storageclassdefault: true


### PR DESCRIPTION
Modify the localvolumeprovisioner to specify a hardcoded StorageClass.
The StorageClass has a single configuration option,
'storageclassdefault: true|false' that specifies whether or not it
should be annotated as the default StorageClass.