### PR TITLE
charts/staging: add dex-k8s-authenticator repository

### DIFF
--- a/staging/dex-k8s-authenticator/.helmignore
+++ b/staging/dex-k8s-authenticator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -6,6 +6,9 @@ version: 1.1.1
 sources:
 - https://github.com/mintel/dex-k8s-authenticator
 maintainers:
+- name: Martin Hrabovcin
+  email: mhrabovcin.c@mesosphere.com
+# Original maintainers from `mintel/dex-k8s-authenticator` repository
 - name: Aaron Roydhouse
   email: aaron@roydhouse.com
 - name: Nick Badger

--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+appVersion: "v1.1.0"
+description: "Authenticator for using Dex with Kubernetes"
+name: dex-k8s-authenticator
+version: 1.1.1
+sources:
+- https://github.com/mintel/dex-k8s-authenticator
+maintainers:
+- name: Aaron Roydhouse
+  email: aaron@roydhouse.com
+- name: Nick Badger
+  email: nbadger@mintel.com

--- a/staging/dex-k8s-authenticator/LICENSE
+++ b/staging/dex-k8s-authenticator/LICENSE
@@ -1,0 +1,25 @@
+Source of this code is https://github.com/mintel/dex-k8s-authenticator
+
+===========
+
+MIT License
+
+Copyright (c) 2018 Mintel Group Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/staging/dex-k8s-authenticator/README.md
+++ b/staging/dex-k8s-authenticator/README.md
@@ -1,0 +1,118 @@
+# Helm chart for dex-k8s-authenticator
+
+This chart installs [`dex-k8s-authenticator`](https://github.com/mintel/dex-k8s-authenticator) in a Kubernetes cluster. 
+`dex-k8s-authenticator` is a helper application for [`dex`](https://github.com/coreos/dex). `dex` lets you use external 
+Identify Providers (like Google, Microsoft, GitHUb, LDAP) to authenticate access to Kubernetes cluster
+(e.g. for `kubectl`). This helper makes it easy to provide a web UI for one or more clusters.
+It give uses the information and commands to configure `kubectl` to work with the credentials `dex` provides.
+
+You can configure one or more clusters in this chart configuration, for the one or more `dex` installs you may have.
+
+```yaml
+# Default values for dex-k8s-authenticator.
+
+# Deploy environment label, e.g. dev, test, prod
+global:
+  deployEnv: dev
+
+replicaCount: 1
+
+image:
+  repository: mintel/dex-k8s-authenticator
+  tag: latest
+  pullPolicy: Always
+
+dexK8sAuthenticator:
+  port: 5555
+  debug: false
+  web_path_prefix: /
+  #logoUrl: http://<path-to-your-logo.png>
+  #kubectl_version: v1.11.2
+  #tlsCert: /path/to/dex-client.crt
+  #tlsKey: /path/to/dex-client.key
+  clusters:
+  - name: my-cluster
+    short_description: "My Cluster"
+    description: "Example Cluster Long Description..."
+    client_secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
+    issuer: https://dex.example.com
+    k8s_master_uri: https://my-cluster.example.com
+    client_id: my-cluster
+    redirect_uri: https://login.example.com/callback/my-cluster
+    k8s_ca_uri: https://url-to-your-ca.crt
+
+service:
+  type: ClusterIP
+  port: 5555
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+caCerts: 
+  enabled: false
+  secrets: {}
+  # Array of Self Signed Certificates
+  # cat CA.crt | base64 -w 0
+  #
+  #     name: The internal k8s name of the secret we create. It's also used in 
+  #     the volumeMount name. It must respect the k8s naming convension (avoid 
+  #     upper-case and '.' to be safe).
+  #
+  #     filename: The filename of the CA to be mounted. It must end in .crt for
+  #     update-ca-certificates to work
+  #
+  #     value: The base64 encoded value of the CA
+  #
+  #secrets:
+  #- name: ca-cert1
+  #  filename: ca1.crt
+  #  value: LS0tLS1......X2F
+  #- name: ca-cert2
+  #  filename: ca2.crt
+  #  value: DS1tFA1......X2F
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+```
+
+## SSL
+
+Additional reading [here](./ssl.md)
+
+### Adding Trusted Certs
+
+Multiple trusted certs can be added using the `caCerts` option. Make sure to `base64` encode each CA.
+
+### Service Requests on SSL
+
+Define the filepath to your cert and key using the following options in your helm chart.
+  - `dexK8sAuthenticator.tlsCert`
+  - `dexK8sAuthenticator.tlsKey`
+
+TODO: Requires more work as we don't have a way deploy self-signed certs or change to https scheme.

--- a/staging/dex-k8s-authenticator/out.yaml
+++ b/staging/dex-k8s-authenticator/out.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+items:
+- apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    creationTimestamp: 2018-12-12T08:25:45Z
+    generation: 1
+    labels:
+      app: dex
+      chart: dex-1.0.0
+      env: dev
+      heritage: Tiller
+      release: eerie-prawn
+    name: eerie-prawn-dex
+    namespace: default
+    resourceVersion: "1587"
+    selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/eerie-prawn-dex
+    uid: 85781253-fde7-11e8-8e75-702bb32bc8e5
+  spec:
+    rules:
+    - host: dex.minikube.test
+      http:
+        paths:
+        - backend:
+            serviceName: eerie-prawn-dex
+            servicePort: 5556
+          path: /
+  status:
+    loadBalancer:
+      ingress:
+      - ip: 192.168.122.205
+- apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    creationTimestamp: 2018-12-12T08:27:36Z
+    generation: 1
+    labels:
+      app: dex-k8s-authenticator
+      chart: dex-k8s-authenticator-1.0.0
+      env: dev
+      heritage: Tiller
+      release: wobbly-greyhound
+    name: wobbly-greyhound-dex-k8s-authenticator
+    namespace: default
+    resourceVersion: "1586"
+    selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/wobbly-greyhound-dex-k8s-authenticator
+    uid: c7d4ad02-fde7-11e8-8e75-702bb32bc8e5
+  spec:
+    rules:
+    - host: dexauth.minikube.test
+      http:
+        paths:
+        - backend:
+            serviceName: wobbly-greyhound-dex-k8s-authenticator
+            servicePort: 5555
+          path: /
+  status:
+    loadBalancer:
+      ingress:
+      - ip: 192.168.122.205
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/staging/dex-k8s-authenticator/templates/NOTES.txt
+++ b/staging/dex-k8s-authenticator/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "dex-k8s-authenticator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "dex-k8s-authenticator.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dex-k8s-authenticator.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "dex-k8s-authenticator.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/staging/dex-k8s-authenticator/templates/_helpers.tpl
+++ b/staging/dex-k8s-authenticator/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dex-k8s-authenticator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dex-k8s-authenticator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dex-k8s-authenticator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the healthCheckPath for readiness and liveness probes.
+
+Based on the following template values:
+    - healthCheckPath
+    - ingress.path
+    - dexK8sAuthenticator.web_path_prefix
+
+The default is '/healthz'
+*/}}
+
+{{- define "dex-k8s-authenticator.healthCheckPath" -}}
+{{- if .Values.healthCheckPath -}}
+  {{ .Values.healthCheckPath }}
+{{- else -}}
+  {{- if .Values.ingress.enabled -}}
+    {{ default "" .Values.ingress.path | trimSuffix "/" }}/healthz
+  {{- else -}}
+    {{- if .Values.dexK8sAuthenticator.web_path_prefix -}}
+      {{ .Values.dexK8sAuthenticator.web_path_prefix | trimSuffix "/" }}/healthz
+    {{- else -}}
+      {{ "/healthz" }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/staging/dex-k8s-authenticator/templates/ca_secrets.yaml
+++ b/staging/dex-k8s-authenticator/templates/ca_secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.caCerts.enabled }}
+{{- range .Values.caCerts.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
+  labels:
+    app: {{ template "dex-k8s-authenticator.name" $ }}
+    env: {{ default "dev" $.Values.global.deployEnv }}
+    chart: {{ template "dex-k8s-authenticator.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+type: Opaque
+data:
+  {{ .name }}: {{ .value }}
+---
+{{- end }}
+{{- end }}

--- a/staging/dex-k8s-authenticator/templates/configmap.yaml
+++ b/staging/dex-k8s-authenticator/templates/configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dex-k8s-authenticator.fullname" . }}
+  labels:
+    app: {{ template "dex-k8s-authenticator.fullname" . }}
+    env: {{ default "dev" .Values.global.deployEnv }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  config.yaml: |-
+    {{- with .Values.dexK8sAuthenticator }}
+    listen: http://0.0.0.0:{{ default "5555" .port }}
+    web_path_prefix: {{ default "/" .web_path_prefix }}
+    debug: {{ default "false" .debug }}
+    {{- if .logoUrl }}
+    logo_uri: {{ .logoUrl }}
+    {{- end }}
+    {{- if .idpCaURI }}
+    idp_ca_uri: {{ .idpCaURI }}
+    {{- end }}
+    {{- if .idpCaPem }}
+    idp_ca_pem: {{ toYaml .idpCaPem | indent 4 }}
+    {{- end }}
+    {{- if and .tlsCert .tlsKey }} 
+    tls_cert: "{{ .tlsCert }}"
+    tls_key: "{{ .tlsKey }}"
+    {{- end }}
+    clusters:
+{{ toYaml .clusters | indent 4 }}
+    {{- end }}
+

--- a/staging/dex-k8s-authenticator/templates/deployment.yaml
+++ b/staging/dex-k8s-authenticator/templates/deployment.yaml
@@ -1,0 +1,85 @@
+{{- if semverCompare ">= 1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: apps/v1
+{{- else if semverCompare ">= 1.8-0, <= 1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: apps/v1beta2
+{{- else -}}
+apiVersion: apps/v1beta1
+{{- end }}
+kind: Deployment
+metadata:
+  name: {{ template "dex-k8s-authenticator.fullname" . }}
+  labels:
+    app: {{ template "dex-k8s-authenticator.name" . }}
+    env: {{ default "dev" .Values.global.deployEnv }}
+    chart: {{ template "dex-k8s-authenticator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "dex-k8s-authenticator.name" . }}
+      env: {{ default "dev" .Values.global.deployEnv }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "dex-k8s-authenticator.name" . }}
+        env: {{ default "dev" .Values.global.deployEnv }}
+        release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: [ "--config", "config.yaml" ]
+        ports:
+        - name: http
+          containerPort: {{ default "5555" .Values.dexK8sAuthenticator.port }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: {{ template "dex-k8s-authenticator.healthCheckPath" . }}
+            port: http
+        readinessProbe:
+          httpGet:
+            path: {{ template "dex-k8s-authenticator.healthCheckPath" . }}
+            port: http
+        volumeMounts:
+        - name: config
+          subPath: config.yaml
+          mountPath: /app/config.yaml
+{{- if .Values.caCerts.enabled }}
+{{- range .Values.caCerts.secrets }}
+        - name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
+          subPath: {{ .name }}
+          mountPath: /certs/{{ .filename }}
+{{- end }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 6 }}
+    {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "dex-k8s-authenticator.fullname" . }}
+{{- if .Values.caCerts.enabled }}
+{{- range .Values.caCerts.secrets }}
+      - name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
+        secret:
+          secretName: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
+{{- end }}
+{{- end }}

--- a/staging/dex-k8s-authenticator/templates/ingress.yaml
+++ b/staging/dex-k8s-authenticator/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dex-k8s-authenticator.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "dex-k8s-authenticator.name" . }}
+    env: {{ default "dev" .Values.global.deployEnv }}
+    chart: {{ template "dex-k8s-authenticator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+  - hosts:
+    {{- range .hosts }}
+    - {{ . }}
+    {{- end }}
+    secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  - host: {{ . }}
+    http:
+      paths:
+      - path: {{ $ingressPath }}
+        backend:
+          serviceName: {{ $fullName }}
+          servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/staging/dex-k8s-authenticator/templates/service.yaml
+++ b/staging/dex-k8s-authenticator/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dex-k8s-authenticator.fullname" . }}
+  labels:
+    app: {{ template "dex-k8s-authenticator.name" . }}
+    env: {{ default "dev" .Values.global.deployEnv }}
+    chart: {{ template "dex-k8s-authenticator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+{{- if and  .Values.service.nodePort (eq "NodePort" .Values.service.type) }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+  selector:
+    app: {{ template "dex-k8s-authenticator.name" . }}
+    release: {{ .Release.Name }}

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -1,0 +1,94 @@
+# Default values for dex-k8s-authenticator.
+
+# Deploy environment label, e.g. dev, test, prod
+global:
+  deployEnv: dev
+
+replicaCount: 1
+
+image:
+  repository: mintel/dex-k8s-authenticator
+  tag: 1.1.0
+  pullPolicy: Always
+
+dexK8sAuthenticator:
+  port: 5555
+  debug: false
+  web_path_prefix: /
+  #logoUrl: http://<path-to-your-logo.png>
+  #tlsCert: /path/to/dex-client.crt
+  #tlsKey: /path/to/dex-client.key
+  clusters:
+  - name: my-cluster
+    short_description: "My Cluster"
+    description: "Example Cluster Long Description..."
+    client_secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
+    issuer: https://dex.example.com
+    k8s_master_uri: https://my-cluster.example.com
+    client_id: my-cluster
+    redirect_uri: https://login.example.com/callback/my-cluster
+    k8s_ca_uri: https://url-to-your-ca.crt
+
+service:
+  annotations: {}
+  type: ClusterIP
+  port: 5555
+
+  # For nodeport, specify the following:
+  #   type: NodePort
+  #   nodePort: <port-number>
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+caCerts:
+  enabled: false
+  secrets: {}
+  # Array of Self Signed Certificates
+  # cat CA.crt | base64 -w 0
+  #
+  #     name: The internal k8s name of the secret we create. It's also used in
+  #     the volumeMount name. It must respect the k8s naming convension (avoid
+  #     upper-case and '.' to be safe).
+  #
+  #     filename: The filename of the CA to be mounted. It must end in .crt for
+  #     update-ca-certificates to work
+  #
+  #     value: The base64 encoded value of the CA
+  #
+  #secrets:
+  #- name: ca-cert1
+  #  filename: ca1.crt
+  #  value: LS0tLS1......X2F
+  #- name: ca-cert2
+  #  filename: ca2.crt
+  #  value: DS1tFA1......X2F
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This chart is copied from https://github.com/mintel/dex-k8s-authenticator which does not provide URL structure so that the chart can be directly added as a helm repo.

I've created `LICENSE` file which copies original license and adds a reference to the source repository.