### PR TITLE
Makefile: don't update system-wide known hosts file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,12 @@ publish:
 	@make all
 	@git add .
 	@git commit -m "$(LAST_COMMIT_MESSAGE)"
-	@ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
-	@chmod 0644 /etc/ssh/ssh_known_hosts
+	@mkdir -p $(HOME)/.ssh
+	@chmod 0700 $(HOME)/.ssh
+	@touch $(HOME)/.ssh/known_hosts
+	@ssh-keygen -R github.com -f $(HOME)/.ssh/known_hosts
+	@ssh-keyscan github.com >> $(HOME)/.ssh/known_hosts
+	@chmod 0644 $(HOME)/.ssh/known_hosts
 	@git push -f publish master
 	@git checkout -
 


### PR DESCRIPTION
The publish target currently modifies the system-wide `/etc/ssh/ssh_known_hosts` file when adding github keys. This is an invasive change that typically requires root privileges. This commit changes that to use the user's `$HOME/.ssh/known_hosts` file instead, which typically requires no extra permissions.

It also fixes an issue where running `make publish` multiple times adds multiple github keys to the known_hosts file. It does so by using `ssh-keygen -R` to remove all keys for github.com from the known_hosts file before using `ssh-keyscan` to add it back again.