### PR TITLE
Makefile: pull latest changes and rebase using our changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ publish:
 	@git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1 || true
 	@git branch -d master >/dev/null 2>&1 || true
 	@git checkout -B master
+	@git pull --rebase publish master -s recursive -X theirs
 	@make all
 	@git add .
 	@git commit -m "$(LAST_COMMIT_MESSAGE)"


### PR DESCRIPTION
PROBLEM: We found that the charts repo was overwriting the old published charts so old versions weren't respected for the same chart 😢 .

The master branch could have been checked out before and being out-dated. So I recommend to pull the latest changes and rebase taking the latest changes.

If we do so, we need to enforce GH to only allow merging PRs which has been rebased.


related to: https://jira.mesosphere.com/browse/DCOS-56035

