### PR TITLE
Makefile: restore and fix old remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ STABLE_TARGETS = $(shell hack/chart_destination.sh $(STABLE_CHARTS))
 STAGING_CHARTS = $(wildcard staging/*/Chart.yaml)
 STAGING_TARGETS = $(shell hack/chart_destination.sh $(STAGING_CHARTS))
 
-GIT_REMOTE_URL := $(shell git remote get-url origin)
+GIT_REMOTE_URL := git@github.com:mesosphere/charts
 # Extract the github user from the origin remote url.
 # This let's the 'publish' task work with forks.
 # Supports both SSH and HTTPS git url formats:


### PR DESCRIPTION
the pipeline is failing since we merged https://github.com/mesosphere/charts/pull/10, with the following error:` [19:06:32][Step 1/1] fatal: could not read Username for 'https://github.com': No such device or address`


https://teamcity.mesosphere.io/viewLog.html?buildId=2053248&buildTypeId=ClosedSource_Konvoy_Chart&tab=buildLog&_focus=255