### PR TITLE
Add ingress to kommander

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.24.2"
 description: Kommander
 name: kommander
-version: 0.1.1
+version: 0.1.2

--- a/stable/kommander/templates/_helpers.tpl
+++ b/stable/kommander/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kommander.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kommander.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kommander.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/kommander/templates/crd.yaml
+++ b/stable/kommander/templates/crd.yaml
@@ -3,6 +3,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: observableclusters.stable.mesosphere.com
+  labels:
+    app: {{ template "kommander.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   group: stable.mesosphere.com
   versions:

--- a/stable/kommander/templates/deployment.yaml
+++ b/stable/kommander/templates/deployment.yaml
@@ -2,41 +2,50 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kommander-deployment
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "kommander.fullname" . }}
   labels:
-    app: kommander
+    app: {{ template "kommander.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
-  replicas: {{ .Values.kommander.replicas }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: kommander
   template:
     metadata:
       labels:
-        app: kommander
+        app: {{ template "kommander.fullname" . }}
       namespace: {{ .Release.Namespace }}
     spec:
       serviceAccountName: admin-user-kommander
       imagePullSecrets:
         - name: dockerhub
+      initContainers:
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
-        - name: kommander
-          image: "{{ .Values.kommander.image.repository }}:{{ .Values.kommander.image.tag }}"
-          imagePullPolicy: "{{ .Values.kommander.image.pullPolicy }}"
+        - name: {{ template "kommander.fullname" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           ports:
             - name: http
               containerPort: 4000
           resources:
-            requests:
-              memory: "128Mi"
-              cpu: "1000m"
-            limits:
-              memory: "512Mi"
-              cpu: "4000m"
+            {{ with .Values.resources }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           livenessProbe:
             httpGet:
               path: /health
               port: 4000
-            initialDelaySeconds: 15
-            periodSeconds: 3
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/stable/kommander/templates/ingress.yaml
+++ b/stable/kommander/templates/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "kommander.fullname" . }}
+  labels:
+    app: {{ template "kommander.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.frontend.rule.type: PathPrefixStrip
+    ingress.kubernetes.io/auth-secret: ops-portal-htpasswd
+    ingress.kubernetes.io/auth-type: basic
+    ingress.kubernetes.io/auth-header-field: X-WebAuth-User
+    {{- with .Values.ingress.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - http:
+        paths:
+          {{- with .Values.ingress.paths }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}

--- a/stable/kommander/templates/service.yaml
+++ b/stable/kommander/templates/service.yaml
@@ -2,10 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ .Values.service.name }}
   labels:
-    app: kommander
-  name: kommander-svc
-  namespace: {{ .Release.Namespace }}
+    app: {{ template "kommander.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   ports:
     - name: metrics
@@ -13,6 +15,6 @@ spec:
       protocol: TCP
       targetPort: 4000
   selector:
-    app: kommander
+    app: {{ template "kommander.fullname" . }}
   sessionAffinity: None
   type: ClusterIP

--- a/stable/kommander/templates/serviceaccount.yaml
+++ b/stable/kommander/templates/serviceaccount.yaml
@@ -2,18 +2,27 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: admin-user-kommander
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "kommander.fullname" . }}
+  labels:
+    app: {{ template "kommander.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: admin-user-binding
+  name: {{ template "kommander.fullname" . }}
+  labels:
+    app: {{ template "kommander.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: admin-user-kommander
+    name: {{ template "kommander.fullname" . }}
     namespace: {{ .Release.Namespace }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -1,6 +1,38 @@
-kommander:
-  image:
-    repository: mesosphere/kommander
-    tag: 1.24.2
-    pullPolicy: IfNotPresent
-  replicas: 1
+image:
+  repository: mesosphere/kommander
+  tag: 1.24.2
+  pullPolicy: IfNotPresent
+replicas: 1
+
+extraInitContainers:
+
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "1000m"
+  limits:
+    memory: "512Mi"
+    cpu: "4000m"
+
+readinessProbe:
+  initialDelaySeconds: 15
+  periodSeconds: 3
+livenessProbe:
+  initialDelaySeconds: 15
+  periodSeconds: 3
+
+### This must match the serviceName set in the ingress backend below
+service:
+  name: kommander
+
+ingress:
+  # extraAnnotations:
+  #   ingress.kubernetes.io/foo: bar
+  paths:
+    # kommander
+    - backend:
+        ### This must match the service name set above
+        serviceName: kommander
+        servicePort: 4000
+      path: /ops/portal/kommander
+

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -12,7 +12,7 @@ resources:
     cpu: "1000m"
   limits:
     memory: "512Mi"
-    cpu: "4000m"
+    cpu: "2000m"
 
 readinessProbe:
   initialDelaySeconds: 15


### PR DESCRIPTION
Add an ingress record so we can allow access to the kommander
application.

Changed to more closely follow chart design guidelines.