### PR TITLE
staging: temporary add traefik

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+name: traefik
+version: 1.71.3
+appVersion: 1.7.12
+description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
+keywords:
+- traefik
+- ingress
+- acme
+- letsencrypt
+home: https://traefik.io/
+sources:
+- https://github.com/containous/traefik
+- https://github.com/helm/charts/tree/master/stable/traefik
+maintainers:
+- name: krancour
+  email: kent.rancourt@microsoft.com
+- name: emilevauge
+  email: emile@vauge.com
+- name: dtomcej
+  email: daniel.tomcej@gmail.com
+- name: ldez
+  email: ludovic@containo.us
+engine: gotpl
+icon: https://docs.traefik.io/img/traefik.logo.png

--- a/staging/traefik/OWNERS
+++ b/staging/traefik/OWNERS
@@ -1,0 +1,26 @@
+approvers:
+- emilevauge
+- dtomcej
+- timoreimann
+- vdemeester
+- nmengin
+- mmatur
+- ldez
+- Juliens
+- jbdoumenjou
+- geraldcroes
+- SantoDE
+- errm
+reviewers:
+- emilevauge
+- dtomcej
+- timoreimann
+- vdemeester
+- nmengin
+- mmatur
+- ldez
+- Juliens
+- jbdoumenjou
+- geraldcroes
+- SantoDE
+- errm

--- a/staging/traefik/README.md
+++ b/staging/traefik/README.md
@@ -1,0 +1,429 @@
+# Traefik
+
+[Traefik](https://traefik.io/) is a modern HTTP reverse proxy and load balancer made to deploy
+microservices with ease.
+
+## Introduction
+
+This chart bootstraps Traefik as a Kubernetes ingress controller with optional support for SSL and
+Let's Encrypt.
+
+__NOTE:__ Operators will typically wish to install this component into the `kube-system` namespace
+where that namespace's default service account will ensure adequate privileges to watch `Ingress`
+resources _cluster-wide_.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.6+ if you want to enable RBAC
+- You are deploying the chart to a cluster with a cloud provider capable of provisioning an
+external load balancer (e.g. AWS or GKE)
+- You control DNS for the domain(s) you intend to route through Traefik
+- __Suggested:__ PV provisioner support in the underlying infrastructure
+
+## A Quick Note on Versioning
+
+Up until version 1.2.1-b of this chart, the semantic version of the chart was
+kept in-sync with the semantic version of the (default) version of Traefik
+installed by the chart. A dash and a letter were appended to Traefik's
+semantic version to indicate incrementally improved versions of the chart
+itself. For example, chart version 1.2.1-a and 1.2.1-b _both_ provide Traefik
+1.2.1, but 1.2.1-b is a chart that is incrementally improved in some way from
+its immediate predecessor-- 1.2.1-a.
+
+This convention, in practice, suffered from a few problems, not the least of
+which was that it defied what was permitted by
+[semver 2.0.0](http://semver.org/spec/v2.0.0.html). This, in turn, lead to some
+difficulty in Helm understanding the versions of this chart.
+
+Beginning with version 1.3.0 of this chart, the version references _only_
+the revision of the chart itself. The `appVersion` field in `chart.yaml` now
+conveys information regarding the revision of Traefik that the chart provides.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install stable/traefik --name my-release --namespace kube-system
+```
+
+After installing the chart, create DNS records for applicable domains to direct inbound traffic to
+the load balancer. You can use the commands below to find the load balancer's IP/hostname:
+
+__NOTE:__ It may take a few minutes for this to become available.
+
+You can watch the status by running:
+
+```bash
+$ kubectl get svc my-release-traefik --namespace kube-system -w
+```
+
+Once `EXTERNAL-IP` is no longer `<pending>`:
+
+```bash
+$ kubectl describe service my-release-traefik -n kube-system | grep Ingress | awk '{print $3}'
+```
+
+__NOTE:__ If ACME support is enabled, it is only _after_ this step is complete that Traefik will be
+able to successfully use the ACME protocol to obtain certificates from Let's Encrypt.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the
+release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Traefik chart and their default values.
+
+| Parameter                              | Description                                                                                                                  | Default                                           |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `fullnameOverride`                     | Override the full resource names                                                                                             | `{release-name}-traefik` (or traefik if release-name is traefik) |
+| `image`                                | Traefik image name                                                                                                           | `traefik`                                         |
+| `imageTag`                             | The version of the official Traefik image to use                                                                             | `1.7.12`                                           |
+| `imagePullSecrets`                     | A list of image pull secrets (if needed)                                                                                     | None                                           |
+| `serviceType`                          | A valid Kubernetes service type                                                                                              | `LoadBalancer`                                    |
+| `loadBalancerIP`                       | An available static IP you have reserved on your cloud platform                                                              | None                                              |
+| `startupArguments`                       | A list of startup arguments which are passed to traefik                                                              | `[]`                                              |
+| `loadBalancerSourceRanges`             | List of IP CIDRs allowed access to load balancer (if supported)                                                              | None                                              |
+| `externalIP`                           | Static IP for the service                                                                                                    | None                                              |
+| `whiteListSourceRange`                 | Enable IP whitelisting at the entrypoint level.                                                                              | `false`                                           |
+| `externalTrafficPolicy`                | Set the externalTrafficPolicy in the Service to either Cluster or Local                                                      | `Cluster`                                         |
+| `replicas`                             | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
+| `podDisruptionBudget`                  | Pod disruption budget                                                                                                        | `{}`                                              |
+| `priorityClassName`                    | Pod priority class name                                                                                                      | `""`                                              |
+| `rootCAs`                              | Register Certificates in the RootCA. These certificates will be use for backends calls. __NOTE:__ You can use file path or cert content directly | `[]`                          |
+| `resources`                            | Resource definitions for the generated pods                                                                                  | `{}`                                              |
+| `cpuRequest`                           | **DEPRECATED**: use `resources` instead. Initial share of CPU requested per Traefik pod                                      | None                                              |
+| `memoryRequest`                        | **DEPRECATED**: use `resources` instead. Initial share of memory requested per Traefik pod                                   | None                                              |
+| `cpuLimit`                             | **DEPRECATED**: use `resources` instead. CPU limit per Traefik pod                                                           | None                                              |
+| `memoryLimit`                          | **DEPRECATED**: use `resources` instead. Memory limit per Traefik pod                                                        | None                                              |
+| `rbac.enabled`                         | Whether to enable RBAC with a specific cluster role and binding for Traefik                                                  | `false`                                           |
+| `deploymentStrategy`                   | Specify deployment spec rollout strategy                                                                                     | `{}`                                              |
+| `securityContext`                      | Security context                                                                                                             | `{}`                                              |
+| `env`                                  | Environment variables for the container                                                                                      | `{}`                                              |
+| `nodeSelector`                         | Node labels for pod assignment                                                                                               | `{}`                                              |
+| `affinity`                             | Affinity settings                                                                                                            | `{}`                                              |
+| `tolerations`                          | List of node taints to tolerate                                                                                              | `[]`                                              |
+| `proxyProtocol.enabled`                | Enable PROXY protocol support.                                                                                               | `false`                                           |
+| `proxyProtocol.trustedIPs`             | List of PROXY IPs (CIDR ranges) trusted to accurately convey the end-user IP.                                                | `[]`                                              |
+| `forwardedHeaders.enabled`             | Enable support specify trusted clients for forwarded headers.                                                                | `false`                                           |
+| `forwardedHeaders.trustedIPs`          | List of IPs (CIDR ranges) to be authorized to trust the client forwarded headers (X-Forwarded-*).                            | `[]`                                              |
+| `debug.enabled`                        | Turn on/off Traefik's debug mode. Enabling it will override the logLevel to `DEBUG` and provide `/debug/vars` endpoint that allows Go runtime stats to be inspected, such as number of Goroutines and memory stats | `false`                                   |
+| `logLevel`                             | Accepted values, in order of severity: "debug", "info", "warn", "error", "fatal", "panic". Messages at and above the selected level will be logged. | `info` |
+| `ssl.enabled`                          | Whether to enable HTTPS                                                                                                      | `false`                                           |
+| `ssl.enforced`                         | Whether to redirect HTTP requests to HTTPS                                                                                   | `false`                                           |
+| `ssl.permanentRedirect`                | When ssl.enforced is set, use a permanent (301) redirect instead of a temporary redirect (302)                               | `false`                                           |
+| `ssl.upstream`                         | Whether to skip configuring certs (ie: SSL is terminated by L4 ELB)                                                          | `false`                                           |
+| `ssl.insecureSkipVerify`               | Whether to verify certs on SSL connections                                                                                   | `false`                                           |
+| `ssl.tlsMinVersion`                    | Minimum TLS version for https entrypoint                                                                                     | None                                              |
+| `ssl.cipherSuites`                     | Specify a non-empty list of TLS ciphers to override the default one | None |
+| `ssl.sniStrict`                        | Enable strict SNI checking, so that connections cannot be made if a matching certificate does not exist.                     | false                                             |
+| `ssl.generateTLS`                      | Generate self sign cert by Helm. If it's `true` the `defaultCert` and the `defaultKey` parameters will be ignored.           | false                                             |
+| `ssl.defaultCN`                        | Specify generated self sign cert CN                                                                                          | ""                                                |
+| `ssl.defaultSANList`                   | Specify generated self sign cert SAN list                                                                                    | `[]`                                              |
+| `ssl.defaultIPList`                    | Specify generated self sign cert IP list                                                                                     | `[]`                                              |
+| `ssl.defaultCert`                      | Base64 encoded default certificate                                                                                           | A self-signed certificate                         |
+| `ssl.defaultKey`                       | Base64 encoded private key for the certificate above                                                                         | The private key for the certificate above         |
+| `ssl.auth.basic`                       | Basic auth for all SSL endpoints, see Authentication section                                          | unset by default; this means basic auth is disabled |
+| `acme.enabled`                         | Whether to use Let's Encrypt to obtain certificates                                                                          | `false`                                           |
+| `acme.keyType`                         | KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'.                                                                          | `RSA4096`                                           |
+| `acme.challengeType`                   | Type of ACME challenge to perform domain validation. `tls-sni-01` (deprecated), `tls-alpn-01` (recommended), `http-01` or `dns-01` | `tls-sni-01`                                |
+| `acme.delayBeforeCheck`         | By default, the provider will verify the TXT DNS challenge record before letting ACME verify. If delayBeforeCheck is greater than zero, this check is delayed for the configured duration in seconds. Useful when Traefik cannot resolve external DNS queries. | `0` |
+| `acme.dnsProvider.name`                | Which DNS provider to use. See [here](https://github.com/xenolf/lego/tree/master/providers/dns) for the list of possible values. | `nil`                                         |
+| `acme.dnsProvider.existingSecretName`  | Don't create a secret for DNS provider configuration environment variables, but use the specified one instead. Secret should contain the required environment variables. Useful to avoid storing secrets in helm | `""`                   |
+| `acme.dnsProvider.$name`               | The configuration environment variables (encoded as a secret) needed for the DNS provider to do DNS challenge. Example configuration: [AWS Route 53](#example-aws-route-53), [Google Cloud DNS](#example-gcloud). | `{}` |
+| `acme.email`                           | Email address to be used in certificates obtained from Let's Encrypt                                                         | `admin@example.com`                               |
+| `acme.onHostRule`                      | Whether to generate a certificate for each frontend with Host rule                                                           | `true`                                            |
+| `acme.staging`                         | Whether to get certs from Let's Encrypt's staging environment                                                                | `true`                                            |
+| `acme.logging`                         | Display debug log messages from the ACME client library                                                                      | `false`                                           |
+| `acme.domains.enabled`                 | Enable certificate creation by default for specific domain                                                                   | `false`                                           |
+| `acme.domains.domainsList`             | List of domains & (optional) subject names                                                                                   | `[]`                                              |
+| `acme.domains.domainsList.main`        | Main domain name of the generated certificate                                                                                | *.example.com                                     |
+| `acme.domains.domainsList.sans`        | optional list of alternative subject names to give to the certificate                                                        | `[]`                                              |
+| `acme.resolvers`                       | DNS servers list to use for DNS challenge                                                                                    | `[]`                                              |
+| `acme.persistence.enabled`             | Create a volume to store ACME certs (if ACME is enabled)                                                                     | `true`                                            |
+| `acme.persistence.annotations`         | PVC annotations                                                                                                              | `{}`                                              |
+| `acme.persistence.storageClass`        | Type of `StorageClass` to request, will be cluster-specific                                                                  | `nil` (uses alpha storage class annotation)       |
+| `acme.persistence.accessMode`          | `ReadWriteOnce` or `ReadOnly`                                                                                                | `ReadWriteOnce`                                   |
+| `acme.persistence.existingClaim`       | An Existing PVC name                                                                                                         | `nil`                                             |
+| `acme.persistence.size`                | Minimum size of the volume requested                                                                                         | `1Gi`                                             |
+| `kvprovider.storeAcme`                 | Store acme certificates in KV Provider (needed for [HA](https://docs.traefik.io/configuration/acme/#as-a-key-value-store-entry)) | `false`                                       |
+| `kvprovider.importAcme`                | Import acme certificates from acme.json of a mounted pvc (see: acme.persistence.existingClaim)                               | `false`                                           |
+| `kvprovider.$name.endpoint`            | Endpoint of the provider like \<kv-provider-fqdn>:\<port>                                                                    | None                                              |
+| `kvprovider.$name.watch`               | Wether traefik should watch for changes                                                                                      | `true`                                            |
+| `kvprovider.$name.prefix`              | Prefix where traefik data will be stored                                                                                     | traefik                                           |
+| `kvprovider.$name.filename`            | Advanced configuration. See: https://docs.traefik.io/                                                                        | provider default                                  |
+| `kvprovider.$name.username`            | Optional username                                                                                                            | None                                              |
+| `kvprovider.$name.password`            | Optional password                                                                                                            | None                                              |
+| `kvprovider.$name.tls.ca`              | Optional TLS certificate authority                                                                                           | None                                              |
+| `kvprovider.$name.tls.cert`            | Optional TLS certificate                                                                                                     | None                                              |
+| `kvprovider.$name.tls.key`             | Optional TLS keyfile                                                                                                         | None                                              |
+| `kvprovider.$name.tls.insecureSkipVerify`    | Optional Wether to skip verify                                                                                         | None                                              |
+| `kvprovider.etcd.useAPIV3`             | Use V3 or use V2 API of ETCD                                                                                                 | `false`                                           |
+| `dashboard.enabled`                    | Whether to enable the Traefik dashboard                                                                                      | `false`                                           |
+| `dashboard.domain`                     | Domain for the Traefik dashboard                                                                                             | `traefik.example.com`                             |
+| `dashboard.serviceType`                | ServiceType for the Traefik dashboard Service                                                                                | `ClusterIP`                                       |
+| `dashboard.service.annotations`        | Annotations for the Traefik dashboard Service definition, specified as a map                                                 | None                                              |
+| `dashboard.ingress.annotations`        | Annotations for the Traefik dashboard Ingress definition, specified as a map                                                 | None                                              |
+| `dashboard.ingress.labels`             | Labels for the Traefik dashboard Ingress definition, specified as a map                                                      | None                                              |
+| `dashboard.ingress.tls`                | TLS settings for the Traefik dashboard Ingress definition                                                                    | None                                              |
+| `dashboard.auth.basic`                 | Basic auth for the Traefik dashboard specified as a map, see Authentication section                                          | unset by default; this means basic auth is disabled |
+| `dashboard.statistics.recentErrors`    | Number of recent errors to show in the ‘Health’ tab                                                                          | None                                              |
+| `service.annotations`                  | Annotations for the Traefik Service definition, specified as a map                                                           | None                                              |
+| `service.labels`                       | Additional labels for the Traefik Service definition, specified as a map.                                                    | None                                              |
+| `service.nodePorts.http`               | Desired nodePort for service of type NodePort used for http requests                                                         | blank ('') - will assign a dynamic node port      |
+| `service.nodePorts.https`              | Desired nodePort for service of type NodePort used for https requests                                                        | blank ('') - will assign a dynamic node port      |
+| `gzip.enabled`                         | Whether to use gzip compression                                                                                              | `true`                                            |
+| `kubernetes.namespaces`                | List of Kubernetes namespaces to watch                                                                                       | All namespaces                                    |
+| `kubernetes.labelSelector`             | Valid Kubernetes ingress label selector to watch (e.g `realm=public`).                                                       | No label filter                                   |
+| `kubernetes.ingressClass`              | Value of `kubernetes.io/ingress.class` annotation to watch - must start with `traefik` if set                                | None                                              |
+| `kubernetes.ingressEndpoint.hostname`  | Desired static hostname to update for ingress status spec                                                                    | None                                              |
+| `kubernetes.ingressEndpoint.ip`        | Desired static IP to update for ingress status spec                                                                          | None                                              |
+| `kubernetes.ingressEndpoint.publishedService` | Desired `namespace/service` to source ingress status spec from                                                        | None                                              |
+| `kubernetes.ingressEndpoint.useDefaultPublishedService` | Whether to source `namespace/service` status spec from the service created by this chart. Mutually exclusive with `kubernetes.ingressEndpoint.publishedService`                   | None                                              |
+| `fileBackend`                          | File Backend configuration                                                                                                   | None                                           |
+| `accessLogs.enabled`                   | Whether to enable Traefik's access logs                                                                                      | `false`                                           |
+| `accessLogs.filePath`                  | The path to the log file. Logs to stdout if omitted                                                                          | None                                              |
+| `accessLogs.format`                    | What format the log entries should be in. Either `common` or `json`                                                          | `common`                                          |
+| `accessLogs.fields.defaultMode`        | The default behaviour for fields logged in JSON access logs, other than headers. Either `keep` or `drop`                     | `keep`                                            |
+| `accessLogs.fields.names`              | A map of field-specific logging behaviours in JSON access logs, with field names as keys, and either `keep` or `drop` as the value for each map entry | None                     |
+| `accessLogs.fields.headers.defaultMode`| The default behaviour for logging HTTP headers in JSON access logs. Either `keep`, `drop` or `redact`                        | `keep`                                            |
+| `accessLogs.fields.headers.names`      | A map of HTTP-header-specific logging behaviours in JSON access logs, with HTTP header names as keys, and `keep`, `drop` or `redact` as the value for each map entry | None      |
+| `metrics.prometheus.enabled`           | Whether to enable the `/metrics` endpoint for metric collection by Prometheus.                                               | `false`                                           |
+| `metrics.prometheus.restrictAccess`    | Whether to limit access to the metrics port (8080) to the dashboard service. When `false`, it is accessible on the main Traefik service as well. | `false`                       |
+| `metrics.prometheus.buckets`           | A list of response times (in seconds) - for each list element, Traefik will report all response times less than the element. | `[0.1,0.3,1.2,5]`                                 |
+| `metrics.datadog.enabled`              | Whether to enable pushing metrics to Datadog.                                                                                | `false`                                           |
+| `metrics.datadog.address`              | Datadog host in the format <hostname>:<port>                                                                                 | `localhost:8125`                                  |
+| `metrics.datadog.pushInterval`         | How often to push metrics to Datadog.                                                                                        | `10s`                                             |
+| `metrics.statsd.enabled`               | Whether to enable pushing metrics to Statsd.                                                                                 | `false`                                           |
+| `metrics.statsd.address`               | Statsd host in the format <hostname>:<port>                                                                                  | `localhost:8125`                                  |
+| `metrics.statsd.pushInterval`          | How often to push metrics to Statsd.                                                                                         | `10s`                                             |
+| `deployment.podAnnotations`            | Annotations for the Traefik pod definition                                                                                   | None                                              |
+| `deployment.podLabels`                 | Labels for the Traefik pod definition                                                                                        | None                                              |
+| `deployment.hostPort.httpEnabled`      | Whether to enable hostPort binding to host for http.                                                                         | `false`                                           |
+| `deployment.hostPort.httpPort`         | Desired host port used for http requests.                                                                                    | `80`                                              |
+| `deployment.hostPort.httpsEnabled`     | Whether to enable hostPort binding to host for https.                                                                        | `false`                                           |
+| `deployment.hostPort.httpsPort`        | Desired host port used for https requests.                                                                                   | `443`                                             |
+| `deployment.hostPort.dashboardEnabled` | Whether to enable hostPort binding to host for dashboard.                                                                    | `false`                                           |
+| `deployment.hostPort.dashboardPort`    | Desired host port used for accessing dashboard.                                                                              | `8080`                                            |
+| `sendAnonymousUsage`                   | Send anonymous usage statistics.                                                                                             | `false`                                           |
+| `tracing.enabled`                      | Whether to enable request tracing                                                                                            | `false`                                           |
+| `tracing.backend`                      | Tracing backend to use, either `jaeger` or `zipkin` or `datadog`                                                             | None                                              |
+| `tracing.serviceName`                  | Service name to be used in tracing backend                                                                                   | `traefik`                                         |
+| `tracing.jaeger.localAgentHostPort`    | Location of the Jaeger agent where spans will be sent                                                                        | `127.0.0.1:6831`                                  |
+| `tracing.jaeger.samplingServerUrl`     | Address of the Jaeger agent HTTP sampling server                                                                             | `http://localhost:5778/sampling`                  |
+| `tracing.jaeger.samplingType`          | Type of Jaeger sampler to use, one of: `const`, `probabilistic`, `ratelimiting`                                              | `const`                                           |
+| `tracing.jaeger.samplingParam`         | Value passed to the Jaeger sampler                                                                                           | `1.0`                                             |
+| `tracing.zipkin.httpEndpoint`          | Zipkin HTTP endpoint                                                                                                         | `http://localhost:9411/api/v1/spans`              |
+| `tracing.zipkin.debug`                 | Enables Zipkin debugging                                                                                                     | `false`                                           |
+| `tracing.zipkin.sameSpan`              | Use Zipkin SameSpan RPC style traces                                                                                         | `false`                                           |
+| `tracing.zipkin.id128Bit`              | Use Zipkin 128 bit root span IDs                                                                                             | `true`                                            |
+| `tracing.datadog.localAgentHostPort`   | Location of the Datadog agent where spans will be sent                                                                       | `127.0.0.1:8126`                                  |
+| `tracing.datadog.debug`                | Enables Datadog debugging                                                                                                    | `false`                                           |
+| `tracing.datadog.globalTag`            | Apply shared tag in a form of Key:Value to all the traces                                                                    | `""`                                              |
+| `timeouts.responding.readTimeout`      | The maximum duration for reading the entire request, including the body. If zero, no timeout exists.                         | `"0s"`                                            |
+| `timeouts.responding.writeTimeout`     | The maximum duration before timing out writes of the response. If zero, no timeout exists.                                   | `"0s"`                                            |
+| `timeouts.responding.idleTimeout`      | The maximum duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout exists.     | `"0s"`                                            |
+| `timeouts.forwarding.dialTimeout`      | The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists.            | `"30s"`                                           |
+| `timeouts.forwarding.responseHeaderTimeout` | The amount of time to wait for a server's response headers after fully writing the request (including its body, if any). If zero, no timeout exists. | `"30s"`              |
+| `autoscaling`                          | HorizontalPodAutoscaler for the traefik Deployment                                                                           | `{}`                                              |
+| `configFiles`                          | Config files to make available in the deployment. key=filename, value=file contents                                          | `{}`                                              |
+| `secretFiles`                          | Secret files to make available in the deployment. key=filename, value=file contents                                          | `{}`                                              |
+| `testFramework.image`                  | `test-framework` image repository.                                                                                           | `dduportal/bats`                                  |
+| `testFramework.tag`                    | `test-framework` image tag.                                                                                                  | `0.4.0`                                           |
+| `forwardAuth.entryPoints`              | Enable forward authentication for these entryPoints: "http", "https", "httpn"                                                |                                                   |
+| `forwardAuth.address`                  | URL for forward authentication                                                                                               |                                                   |
+| `forwardAuth.trustForwardHeader`       | Trust X-Forwarded-* headers                                                                                                  |                                                   |
+| `forwardAuth.authResponseHeaders`      | Set authentication response headers                                                                                                  |  `[]`                                                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+$ helm install --name my-release --namespace kube-system \
+  --set dashboard.enabled=true,dashboard.domain=traefik.example.com stable/traefik
+```
+
+The above command enables the Traefik dashboard on the domain `traefik.example.com`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example:
+
+```bash
+$ helm install --name my-release --namespace kube-system --values values.yaml stable/traefik
+```
+
+### Clustering / High Availability
+
+To enable cluster support, you need one of:
+* etcd
+* consul
+* boltdb
+* zookeeper
+
+as kvprovider, especially when you are using Let's Encrypt.
+If you have already certificates stored as acme.json in an existing persistent volume claim, you can import it.
+
+Given you have:
+* a running [etcd operator](https://github.com/helm/charts/tree/master/stable/etcd-operator):
+* you have created a master chart requiring this traefik chart
+* an existing pvc with an `acme.json` called `acme-certs-pvc`
+* you have an etcd template like:
+  ```
+  apiVersion: "etcd.database.coreos.com/v1beta2"
+  kind: "EtcdCluster"
+  metadata:
+    name: {{ .Values.etcdCluster.name }}
+    labels:
+       app: {{ .Values.etcdCluster.name }}
+    annotations:
+       etcd.database.coreos.com/scope: clusterwide
+  spec:
+    size: 3
+    version: "3.1.8"
+  ```
+* and these values in your values.yaml
+  ```
+  etcdCluster:
+    name: traefik-etcd-cluster
+
+  traefik:
+    replicas: 3
+    acme:
+      persistence:
+        enabled: true
+        existingClaim: acme-certs-pvc
+    kvprovider:
+      storeAcme: true
+      importAcme: true
+      etcd:
+        endpoint: "traefik-etcd-cluster-client:2379"
+        useAPIV3: false
+        watch: true
+        prefix: traefik
+  ```
+
+Then you are good to migrate your old certs into the kvprovider and run traefik in HA/Cluster-Mode.
+
+
+### Dashboard Basic Auth
+
+[Basic auth](https://docs.traefik.io/configuration/entrypoints/#authentication) can be specified via `dashboard.auth.basic` as a map of usernames to passwords as below.
+See the linked Traefik documentation for accepted passwords encodings.
+It is advised to single quote passwords to avoid issues with special characters:
+
+```bash
+$ helm install --name my-release --namespace kube-system \
+  --set dashboard.enabled=true,dashboard.auth.basic.test='$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/' \
+  stable/traefik
+```
+
+Alternatively in YAML form:
+
+```yaml
+dashboard:
+  enabled: true
+  domain: traefik.example.com
+  auth:
+    basic:
+      test: $apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
+```
+
+### Let's Encrypt domain verification using DNS challenge
+
+When obtaining an ACME (Let's Encrypt) certificate, sometimes it's more desirable to do DNS challenge, for example, if the
+server you want to obtain a certificate for does not have a public IP address.
+
+First, check if your DNS provider is supported by [lego](https://github.com/xenolf/lego/tree/master/providers/dns)(the ACME library that Traefik is using).
+Next, you will need to configure the Traefik chart to use DNS challenge. In the ACME section:
+
+```yaml
+acme:
+  enabled: true
+  challengeType: "dns-01"
+  dnsProvider:
+    name:  # name of the dns provider to use
+    $name: # the configuration of the dns provider. See the following section for an example
+      # variables that the specific dns provider requires
+```
+
+### Let's Encrypt wildcard certificate
+
+To obtain an ACME (Let's Encrypt) wildcard certificate you must use a DNS challenge as explained above.
+Then you need to specify the wildcard domain name in the `acme.domains` section like this :
+
+```yaml
+acme:
+  enabled: true
+  challengeType: "dns-01"
+  dnsProvider:
+    name:  # name of the dns provider to use
+    $name: # the configuration of the dns provider. See the following section for an example
+      # variables that the specific dns provider requires
+  domains:
+    enabled: true
+    domainsList:
+      - main: "*.example.com" # name of the wildcard domain name for the certificate
+      - sans:
+        - "example.com" # OPTIONAL: Alternative name(s) for the certificate, if you want the same certificate for the root of the domain name for example
+      - main: "*.example2.com" # name of the wildcard domain name for the certificate
+```
+
+#### Example: AWS Route 53
+
+Using `route53` as DNS provider requires the following configuration variables to be set:
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+
+The configuration would look like this:
+
+```yaml
+acme:
+  enabled: true
+  dnsProvider:
+    name: route53
+    route53:
+      AWS_ACCESS_KEY_ID: ...
+      AWS_SECRET_ACCESS_KEY: ...
+      AWS_REGION: us-east-1
+```
+
+#### Example: Google Cloud DNS
+
+Using `gcloud` as DNS provider requires the following configuration variables to be set:
+- `GCE_PROJECT`
+- `GCE_SERVICE_ACCOUNT_FILE`
+
+The configuration would look like this:
+
+```yaml
+
+secretFiles:
+  gcloud-credentials.json: '{"type":"service_account","project_id":"<projectName>","private_key_id":"<hash>",...}'
+
+acme:
+  enabled: true
+  dnsProvider:
+    name: gcloud
+    gcloud:
+      GCE_PROJECT: <projectName>
+      GCE_SERVICE_ACCOUNT_FILE: /secrets/gcloud-credentials.json
+```
+
+### Proxy Protocol
+
+In situations where Traefik lives behind an Internet-facing loadbalancer (like an AWS ELB) and you still want it to see the actual source IP of the visitor instead of the internal IP of the loadbalancer, you can enable the loadbalancer to use the Proxy protocol to talk to Traefik. This effectively makes the loadbalancer transparent, as Traefik will still get the actual visitor IP address for each request. This only works if Traefik knows it's receiving traffic via the Proxy Protocol and the loadbalancer IP addresses need to be whitelisted as well.
+
+How to set this up on AWS is described in the Kubernetes documentation [here](https://kubernetes.io/docs/concepts/services-networking/service/#proxy-protocol-support-on-aws), it can easily be done by adding an annotation to the Service definition.
+
+**Caution**
+
+If only one of the components (either the loadbalancer or Traefik) is set to use the Proxy protocol and the other is not, this will break badly as they will not be able to communicate with each other.

--- a/staging/traefik/templates/NOTES.txt
+++ b/staging/traefik/templates/NOTES.txt
@@ -1,0 +1,30 @@
+{{- if eq .Values.serviceType "LoadBalancer" }}
+1. Get Traefik's load balancer IP/hostname:
+
+     NOTE: It may take a few minutes for this to become available.
+
+     You can watch the status by running:
+
+         $ kubectl get svc {{ template "traefik.fullname" . }} --namespace {{ .Release.Namespace }} -w
+
+     Once 'EXTERNAL-IP' is no longer '<pending>':
+
+         $ kubectl describe svc {{ template "traefik.fullname" . }} --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
+
+2. Configure DNS records corresponding to Kubernetes ingress resources to point to the load balancer IP/hostname found in step 1
+{{- end }}
+{{- if eq .Values.serviceType "NodePort" }}
+{{- if (and (not (empty .Values.service.nodePorts.https)) (not (empty .Values.service.nodePorts.http)))}}
+1. Traefik is listening on the following ports on the host machine:
+
+     http - {{ .Values.service.nodePorts.http }}
+     https - {{ .Values.service.nodePorts.https }}
+{{- else }}
+1. Traefik has been started. You can find out the port numbers being used by traefik by running:
+
+          $ kubectl describe svc {{ template "traefik.fullname" . }} --namespace {{ .Release.Namespace }}
+
+{{- end }}
+
+2. Configure DNS records corresponding to Kubernetes ingress resources to point to the NODE_IP/NODE_HOST
+{{- end }}

--- a/staging/traefik/templates/_helpers.tpl
+++ b/staging/traefik/templates/_helpers.tpl
@@ -1,0 +1,125 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "traefik.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "traefik.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "traefik.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the block for the ProxyProtocol's Trusted IPs.
+*/}}
+{{- define "traefik.trustedips" -}}
+         trustedIPs = [
+	   {{- range $idx, $ips := .Values.proxyProtocol.trustedIPs }}
+	     {{- if $idx }}, {{ end }}
+	     {{- $ips | quote }}
+	   {{- end -}}
+         ]
+{{- end -}}
+
+{{/*
+Create the block for the forwardedHeaders's Trusted IPs.
+*/}}
+{{- define "traefik.forwardedHeadersTrustedIPs" -}}
+         trustedIPs = [
+	   {{- range $idx, $ips := .Values.forwardedHeaders.trustedIPs }}
+	     {{- if $idx }}, {{ end }}
+	     {{- $ips | quote }}
+	   {{- end -}}
+         ]
+{{- end -}}
+
+{{/*
+Create the block for whiteListSourceRange.
+*/}}
+{{- define "traefik.whiteListSourceRange" -}}
+       whiteListSourceRange = [
+	   {{- range $idx, $ips := .Values.whiteListSourceRange }}
+	     {{- if $idx }}, {{ end }}
+	     {{- $ips | quote }}
+	   {{- end -}}
+         ]
+{{- end -}}
+
+{{/*
+Create the block for acme.domains.
+*/}}
+{{- define "traefik.acme.domains" -}}
+{{- range $idx, $value := .Values.acme.domains.domainsList }}
+    {{- if $value.main }}
+    [[acme.domains]]
+       main = {{- range $mainIdx, $mainValue := $value }} {{ $mainValue | quote }}{{- end -}}
+    {{- end -}}
+{{- if $value.sans }}
+       sans = [
+  {{- range $sansIdx, $domains := $value.sans }}
+			 {{- if $sansIdx }}, {{ end }}
+	     {{- $domains | quote }}
+  {{- end -}}
+	     ]
+	{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the block for acme.resolvers.
+*/}}
+{{- define "traefik.acme.dnsResolvers" -}}
+         resolvers = [
+	   {{- range $idx, $ips := .Values.acme.resolvers }}
+	     {{- if $idx }},{{ end }}
+	     {{- $ips | quote }}
+	   {{- end -}}
+         ]
+{{- end -}}
+
+{{/*
+Create custom cipherSuites block
+*/}}
+{{- define "traefik.ssl.cipherSuites" -}}
+          cipherSuites = [
+          {{- range $idx, $cipher := .Values.ssl.cipherSuites }}
+            {{- if $idx }},{{ end }}
+            {{ $cipher | quote }}
+          {{- end }}
+          ]
+{{- end -}}
+
+Create the block for RootCAs.
+*/}}
+{{- define "traefik.rootCAs" -}}
+         rootCAs = [
+	   {{- range $idx, $ca := .Values.rootCAs }}
+	     {{- if $idx }}, {{ end }}
+	     {{- $ca | quote }}
+	   {{- end -}}
+         ]
+{{- end -}}

--- a/staging/traefik/templates/_helpers.tpl
+++ b/staging/traefik/templates/_helpers.tpl
@@ -123,3 +123,15 @@ Create the block for RootCAs.
 	   {{- end -}}
          ]
 {{- end -}}
+
+{{/*
+Create the blocks for authResponseHeaders.
+*/}}
+{{- define "traefik.authResponseHeaders" -}}
+        authResponseHeaders = [
+        {{- range $idx, $header := .Values.forwardAuth.authResponseHeaders }}
+          {{- if $idx }}, {{ end }}
+          {{- $header | quote }}
+        {{- end -}}
+        ]
+{{- end -}}

--- a/staging/traefik/templates/acme-pvc.yaml
+++ b/staging/traefik/templates/acme-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.acme.enabled .Values.acme.persistence.enabled (not .Values.acme.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+{{- if .Values.acme.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.acme.persistence.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "traefik.fullname" . }}-acme
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.acme.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.acme.persistence.size | quote }}
+{{- if .Values.acme.persistence.storageClass }}
+{{- if (eq "-" .Values.acme.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.acme.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/staging/traefik/templates/config-files.yaml
+++ b/staging/traefik/templates/config-files.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.configFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "traefik.fullname" . }}-configs
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- range $filename, $fileContents := .Values.configFiles }}
+  {{ $filename }}: |-
+{{ $fileContents | indent 4 }}
+{{- end }}
+{{- end }}

--- a/staging/traefik/templates/configmap.yaml
+++ b/staging/traefik/templates/configmap.yaml
@@ -1,0 +1,418 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+  traefik.toml: |
+    # traefik.toml
+    {{- if .Values.debug.enabled }}
+    debug = true
+    {{- else }}
+    logLevel = {{ .Values.logLevel | default "info" | quote }}
+    {{- end }}
+    {{- if .Values.sendAnonymousUsage }}
+    sendAnonymousUsage = true
+    {{- end }}
+    {{- if .Values.rootCAs }}
+    {{ template "traefik.rootCAs" . }}
+    {{- end }}
+    {{- if .Values.ssl.insecureSkipVerify }}
+    InsecureSkipVerify = true
+    {{- end }}
+    {{- if .Values.ssl.enabled }}
+    defaultEntryPoints = ["http","https"]
+    {{- else }}
+    defaultEntryPoints = ["http", "httpn"]
+    {{- end }}
+    [entryPoints]
+      [entryPoints.http]
+      address = ":80"
+      compress = {{ .Values.gzip.enabled }}
+      {{- if .Values.forwardAuth }}
+      {{- if has "http" .Values.forwardAuth.entryPoints }}
+        [entryPoints.http.auth.forward]
+        address = {{ .Values.forwardAuth.address | quote }}
+        trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
+        authResponseHeaders = {{ .Values.forwardAuth.authResponseHeaders }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.whiteListSourceRange }}
+      {{ template "traefik.whiteListSourceRange" . }}
+      {{- end }}
+      {{- if .Values.proxyProtocol.enabled }}
+        [entryPoints.http.proxyProtocol]
+        {{ template "traefik.trustedips" . }}
+      {{- end }}
+      {{- if .Values.forwardedHeaders.enabled }}
+        [entryPoints.http.forwardedHeaders]
+        {{ template "traefik.forwardedHeadersTrustedIPs" . }}
+      {{- end }}
+        {{- if .Values.ssl.enforced }}
+        [entryPoints.http.redirect]
+          regex = "^http://(.*)"
+          replacement = "https://$1"
+          {{- if .Values.ssl.permanentRedirect }}
+          permanent = true
+          {{- end }}
+        {{- end }}
+      {{- if .Values.ssl.enabled }}
+      [entryPoints.https]
+      {{- if .Values.whiteListSourceRange }}
+      {{ template "traefik.whiteListSourceRange" . }}
+      {{- end }}
+      address = ":443"
+      compress = {{ .Values.gzip.enabled }}
+      {{- if .Values.forwardAuth }}
+      {{- if has "https" .Values.forwardAuth.entryPoints }}
+        [entryPoints.https.auth.forward]
+        address = {{ .Values.forwardAuth.address | quote }}
+        trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
+        authResponseHeaders = {{ .Values.forwardAuth.authResponseHeaders }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.proxyProtocol.enabled }}
+        [entryPoints.https.proxyProtocol]
+        {{ template "traefik.trustedips" . }}
+      {{- end }}
+      {{- if .Values.forwardedHeaders.enabled }}
+        [entryPoints.https.forwardedHeaders]
+        {{ template "traefik.forwardedHeadersTrustedIPs" . }}
+      {{- end }}
+      {{- if not .Values.ssl.upstream }}
+        [entryPoints.https.tls]
+          {{- if .Values.ssl.tlsMinVersion }}
+          minVersion = {{ .Values.ssl.tlsMinVersion | quote }}
+          {{- end }}
+          {{- if .Values.ssl.cipherSuites }}
+          {{ template "traefik.ssl.cipherSuites" . }}
+          {{- end }}
+          {{- if .Values.ssl.sniStrict }}
+          sniStrict = true
+          {{- end }}
+          [[entryPoints.https.tls.certificates]]
+          CertFile = "/ssl/tls.crt"
+          KeyFile = "/ssl/tls.key"
+      {{- end }}
+        {{- if .Values.ssl.auth }}
+        {{- if .Values.ssl.auth.basic }}
+        [entryPoints.https.auth]
+          [entryPoints.https.auth.basic]
+            users = [{{ range $key, $value := .Values.ssl.auth.basic }}"{{ $key }}:{{ $value }}",{{ end }}]
+        {{- end }}
+        {{- end }}
+      {{- else }}
+      [entryPoints.httpn]
+      {{- if .Values.whiteListSourceRange }}
+      {{ template "traefik.whiteListSourceRange" . }}
+      {{- end }}
+      address = ":8880"
+      compress = {{ .Values.gzip.enabled }}
+      {{- if .Values.proxyProtocol.enabled }}
+        [entryPoints.httpn.proxyProtocol]
+        {{ template "traefik.trustedips" . }}
+      {{- if .Values.forwardAuth }}
+      {{- if has "httpn" .Values.forwardAuth.entryPoints }}
+        [entryPoints.httpn.auth.forward]
+        address = {{ .Values.forwardAuth.address | quote }}
+        trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
+        authResponseHeaders = {{ .Values.forwardAuth.authResponseHeaders }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.forwardedHeaders.enabled }}
+        [entryPoints.httpn.forwardedHeaders]
+        {{ template "traefik.forwardedHeadersTrustedIPs" . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.dashboard.enabled }}
+      [entryPoints.traefik]
+      address = ":8080"
+        {{- if .Values.dashboard.auth }}
+        {{- if .Values.dashboard.auth.basic }}
+        [entryPoints.traefik.auth]
+          [entryPoints.traefik.auth.basic]
+            users = [{{ range $key, $value := .Values.dashboard.auth.basic }}"{{ $key }}:{{ $value }}",{{ end }}]
+        {{- end }}
+        {{- end }}
+      {{- end }}
+    [ping]
+    entryPoint = "http"
+    [kubernetes]
+    {{- if .Values.kubernetes}}
+      {{- if .Values.kubernetes.endpoint }}
+    endpoint = {{ .Values.kubernetes.endpoint | quote }}
+      {{- end}}
+      {{- if .Values.kubernetes.namespaces }}
+    namespaces = [
+        {{- range $idx, $element := .Values.kubernetes.namespaces }}
+            {{- if $idx }}, {{ end }}
+            {{- $element | quote }}
+        {{- end -}}
+        ]
+      {{- end}}
+      {{- if .Values.kubernetes.labelSelector }}
+    labelselector = {{ .Values.kubernetes.labelSelector | quote }}
+      {{- end}}
+      {{- if .Values.kubernetes.ingressClass }}
+    ingressClass = {{ .Values.kubernetes.ingressClass | quote }}
+      {{- end}}
+      {{- if .Values.kubernetes.ingressEndpoint }}
+      [kubernetes.ingressEndpoint]
+        {{- if .Values.kubernetes.ingressEndpoint.hostname }}
+      hostname = {{ .Values.kubernetes.ingressEndpoint.hostname | quote }}
+        {{- end}}
+        {{- if .Values.kubernetes.ingressEndpoint.ip }}
+      ip = {{ .Values.kubernetes.ingressEndpoint.ip | quote }}
+        {{- end}}
+        {{- if .Values.kubernetes.ingressEndpoint.publishedService }}
+      publishedService = {{ .Values.kubernetes.ingressEndpoint.publishedService | quote }}
+        {{- else if .Values.kubernetes.ingressEndpoint.useDefaultPublishedService }}
+      publishedService = "{{ .Release.Namespace }}/{{ template "traefik.fullname" . }}"
+        {{- end}}
+      {{- end}}
+    {{- end}}
+    {{- if .Values.fileBackend }}
+    [file]
+    {{- .Values.fileBackend | nindent 4 }}
+    {{- end }}
+    {{- if .Values.traefikLogFormat }}
+    [traefikLog]
+      format = {{ .Values.traefikLogFormat | quote }}
+    {{- end }}
+    {{- if .Values.accessLogs.enabled }}
+    [accessLog]
+    {{- if .Values.accessLogs.filePath }}
+    filePath = {{ .Values.accessLogs.filePath | quote }}
+    {{- end}}
+      format = {{ .Values.accessLogs.format | quote }}
+    [accessLog.fields]
+      defaultMode = {{ .Values.accessLogs.fields.defaultMode | quote }}
+    [accessLog.fields.names]
+    {{- range $field, $action := .Values.accessLogs.fields.names }}
+      {{ printf "\"%s\" = \"%s\"" $field $action }}
+    {{- end}}
+    [accessLog.fields.headers]
+      defaultMode = {{ .Values.accessLogs.fields.headers.defaultMode | quote }}
+    [accessLog.fields.headers.names]
+    {{- range $header, $action := .Values.accessLogs.fields.headers.names }}
+      {{ printf "\"%s\" = \"%s\"" $header $action }}
+    {{- end}}
+    {{- end}}
+    {{- if .Values.kvprovider.etcd }}
+    [etcd]
+    endpoint = {{ .Values.kvprovider.etcd.endpoint | quote }}
+    watch = {{ .Values.kvprovider.etcd.watch }}
+    prefix = {{ .Values.kvprovider.etcd.prefix | quote }}
+    useAPIV3 = {{ .Values.kvprovider.etcd.useAPIV3 }}
+    {{- if .Values.kvprovider.etcd.username }}username = {{ .Values.kvprovider.etcd.username }}{{- end }}
+    {{- if .Values.kvprovider.etcd.password }}password = {{ .Values.kvprovider.etcd.password }}{{- end }}
+      {{- if .Values.kvprovider.etcd.tls }}
+      [etcd.tls]
+      {{ range $key, $value := .Values.kvprovider.etcd.tls }}
+      {{ $key }} = {{ $value | quote }}
+      {{ end }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.kvprovider.consul }}
+    [consul]
+    endpoint = {{ .Values.kvprovider.consul.endpoint | quote }}
+    watch = {{ .Values.kvprovider.consul.watch }}
+    prefix = {{ .Values.kvprovider.consul.prefix | quote }}
+    {{- if .Values.kvprovider.consul.username }}username = {{ .Values.kvprovider.consul.username | quote }}{{- end }}
+    {{- if .Values.kvprovider.consul.password }}password = {{ .Values.kvprovider.consul.password | quote  }}{{- end }}
+      {{- if .Values.kvprovider.consul.tls }}
+      [consul.tls]
+      {{ range $key, $value := .Values.kvprovider.consul.tls }}
+      {{ $key }} = {{ $value | quote }}
+      {{ end }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.kvprovider.boltdb }}
+    [boltdb]
+    endpoint = {{ .Values.kvprovider.boltdb.endpoint | quote }}
+    watch = {{ .Values.kvprovider.boltdb.watch }}
+    prefix = {{ .Values.kvprovider.boltdb.prefix | quote }}
+    {{- if .Values.kvprovider.boltdb.username }}username = {{ .Values.kvprovider.boltdb.username }}{{- end }}
+    {{- if .Values.kvprovider.boltdb.password }}password = {{ .Values.kvprovider.boltdb.password }}{{- end }}
+      {{- if .Values.kvprovider.boltdb.tls }}
+      [boltdb.tls]
+      {{ range $key, $value := .Values.kvprovider.boltdb.tls }}
+      {{ $key }} = {{ $value }}
+      {{ end }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.kvprovider.zookeeper }}
+    [zookeeper]
+    endpoint = {{ .Values.kvprovider.zookeeper.endpoint | quote }}
+    watch = {{ .Values.kvprovider.zookeeper.watch }}
+    prefix = {{ .Values.kvprovider.zookeeper.prefix | quote }}
+    {{- if .Values.kvprovider.zookeeper.username }}username = {{ .Values.kvprovider.zookeeper.username }}{{- end }}
+    {{- if .Values.kvprovider.zookeeper.password }}password = {{ .Values.kvprovider.zookeeper.password }}{{- end }}
+      {{- if .Values.kvprovider.zookeeper.tls }}
+      [zookeeper.tls]
+      {{ range $key, $value := .Values.kvprovider.zookeeper.tls }}
+      {{ $key }} = {{ $value }}
+      {{ end }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.acme.enabled }}
+    [acme]
+    KeyType = {{ .Values.acme.keyType | quote }}
+    email = {{ .Values.acme.email | quote }}
+    {{- if .Values.kvprovider.storeAcme }}
+    storage = "traefik/acme/account"
+    {{- if .Values.kvprovider.importAcme }}
+    storageFile = "/acme/acme.json"
+    {{- end }}
+    {{- if or (.Values.kvprovider.importAcme) (eq .Release.Revision 1) }}
+    OverrideCertificates = true
+    {{- end }}
+    {{- else }}
+    storage = "/acme/acme.json"
+    {{- end }}
+    entryPoint = "https"
+    onHostRule = {{ .Values.acme.onHostRule }}
+    {{- if .Values.acme.staging }}
+    caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
+    {{- end }}
+    {{- if .Values.acme.logging }}
+    acmeLogging = true
+    {{- end }}
+    {{- if eq .Values.acme.challengeType "dns-01" }}
+      [acme.dnsChallenge]
+      provider = {{ .Values.acme.dnsProvider.name | quote }}
+      {{- if .Values.acme.resolvers }}
+      {{ template "traefik.acme.dnsResolvers" . }}
+      {{- end }}
+      {{- if .Values.acme.delayBeforeCheck }}
+      delayBeforeCheck = {{ .Values.acme.delayBeforeCheck }}
+      {{- end }}
+    {{- else if eq .Values.acme.challengeType "http-01" }}
+      [acme.httpChallenge]
+      entryPoint = "http"
+    {{- else if eq .Values.acme.challengeType "tls-alpn-01" }}
+      [acme.tlsChallenge]
+    {{- end }}
+    {{- if .Values.acme.domains.enabled }}
+    {{- if .Values.acme.domains.domainsList }}{{ template "traefik.acme.domains" . }}{{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.dashboard.enabled }}
+    [api]
+      entryPoint = "traefik"
+      dashboard = true
+      {{- if .Values.dashboard.statistics }}
+      {{- if .Values.dashboard.statistics.recentErrors }}
+      [api.statistics]
+        recentErrors = {{ .Values.dashboard.statistics.recentErrors }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if or .Values.metrics.prometheus.enabled .Values.metrics.statsd.enabled .Values.metrics.datadog.enabled }}
+    [metrics]
+    {{- end }}
+      {{- if .Values.metrics.prometheus.enabled }}
+      [metrics.prometheus]
+        entryPoint = "traefik"
+        {{- if .Values.metrics.prometheus.buckets }}
+        buckets = [
+          {{- range $idx, $element := .Values.metrics.prometheus.buckets }}
+              {{- if $idx }},{{ end }}
+              {{- printf "%.1f" $element }}
+          {{- end -}}
+          ]
+        {{- end -}}
+      {{- end }}
+      {{- if .Values.metrics.datadog.enabled }}
+      [metrics.datadog]
+        {{- if .Values.metrics.datadog.address }}
+        address = {{ .Values.metrics.datadog.address | quote }}
+        {{- end}}
+        {{- if .Values.metrics.datadog.pushinterval }}
+        pushinterval = {{ .Values.metrics.datadog.pushinterval | quote }}
+        {{- end}}
+      {{- end }}
+      {{- if .Values.metrics.statsd.enabled }}
+      [metrics.statsd]
+        {{- if .Values.metrics.statsd.address }}
+        address = {{ .Values.metrics.statsd.address | quote }}
+        {{- end}}
+        {{- if .Values.metrics.statsd.pushinterval }}
+        pushinterval = {{ .Values.metrics.statsd.pushinterval | quote }}
+        {{- end}}
+      {{- end }}
+    {{- if .Values.tracing.enabled }}
+    [tracing]
+      backend = {{ .Values.tracing.backend | quote }}
+      serviceName = {{ .Values.tracing.serviceName | quote}}
+      {{- if eq .Values.tracing.backend "jaeger" }}
+      [tracing.jaeger]
+        {{- if .Values.tracing.jaeger.localAgentHostPort }}
+        localAgentHostPort = {{ .Values.tracing.jaeger.localAgentHostPort | quote }}
+        {{- end }}
+        {{- if .Values.tracing.jaeger.samplingServerUrl }}
+        samplingServerUrl = {{ .Values.tracing.jaeger.samplingServerUrl | quote }}
+        {{- end }}
+        {{- if .Values.tracing.jaeger.samplingType }}
+        samplingType = {{ .Values.tracing.jaeger.samplingType | quote }}
+        {{- end }}
+        {{- if ne (.Values.tracing.jaeger.samplingParam | quote) "" }}
+        samplingParam = {{ .Values.tracing.jaeger.samplingParam }}
+        {{- end }}
+      {{- end }}
+      {{- if eq .Values.tracing.backend "zipkin" }}
+      [tracing.zipkin]
+        {{- if .Values.tracing.zipkin.httpEndpoint }}
+        httpEndpoint = {{ .Values.tracing.zipkin.httpEndpoint | quote }}
+        {{- end }}
+        {{- if ne (.Values.tracing.zipkin.debug | quote) "" }}
+        debug = {{ .Values.tracing.zipkin.debug }}
+        {{- end }}
+        {{- if ne (.Values.tracing.zipkin.sameSpan | quote) "" }}
+        sameSpan = {{ .Values.tracing.zipkin.sameSpan }}
+        {{- end }}
+        {{- if ne (.Values.tracing.zipkin.id128bit | quote) "" }}
+        id128bit = {{ .Values.tracing.zipkin.id128bit }}
+        {{- end }}
+      {{- end }}
+      {{- if eq .Values.tracing.backend "datadog" }}
+      [tracing.datadog]
+        {{- if .Values.tracing.datadog.localAgentHostPort }}
+        localAgentHostPort = {{ .Values.tracing.datadog.localAgentHostPort | quote }}
+        {{- end }}
+        {{- if ne (.Values.tracing.datadog.debug | quote) "" }}
+        debug = {{ .Values.tracing.datadog.debug }}
+        {{- end }}
+        {{- if ne (.Values.tracing.datadog.globalTag | quote) "" }}
+        globalTag = {{ .Values.tracing.datadog.globalTag | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.timeouts }}
+    {{- if .Values.timeouts.responding }}
+    [respondingTimeouts]
+      {{- if .Values.timeouts.responding.readTimeout }}
+      readTimeout = {{ .Values.timeouts.responding.readTimeout | quote }}
+      {{- end }}
+      {{- if .Values.timeouts.responding.writeTimeout }}
+      writeTimeout = {{ .Values.timeouts.responding.writeTimeout | quote }}
+      {{- end }}
+      {{- if .Values.timeouts.responding.idleTimeout }}
+      idleTimeout = {{ .Values.timeouts.responding.idleTimeout | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.timeouts.forwarding }}
+    [forwardingTimeouts]
+      {{- if .Values.timeouts.forwarding.dialTimeout }}
+      dialTimeout = {{ .Values.timeouts.forwarding.dialTimeout | quote }}
+      {{- end }}
+      {{- if .Values.timeouts.forwarding.responseHeaderTimeout }}
+      responseHeaderTimeout = {{ .Values.timeouts.forwarding.responseHeaderTimeout | quote }}
+      {{- end }}
+    {{- end }}
+    {{- end }}

--- a/staging/traefik/templates/configmap.yaml
+++ b/staging/traefik/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
         [entryPoints.http.auth.forward]
         address = {{ .Values.forwardAuth.address | quote }}
         trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
-        authResponseHeaders = {{ .Values.forwardAuth.authResponseHeaders }}
+        {{ template "traefik.authResponseHeaders" . }}
       {{- end }}
       {{- end }}
       {{- if .Values.whiteListSourceRange }}
@@ -72,7 +72,7 @@ data:
         [entryPoints.https.auth.forward]
         address = {{ .Values.forwardAuth.address | quote }}
         trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
-        authResponseHeaders = {{ .Values.forwardAuth.authResponseHeaders }}
+        {{ template "traefik.authResponseHeaders" . }}
       {{- end }}
       {{- end }}
       {{- if .Values.proxyProtocol.enabled }}
@@ -120,7 +120,7 @@ data:
         [entryPoints.httpn.auth.forward]
         address = {{ .Values.forwardAuth.address | quote }}
         trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
-        authResponseHeaders = {{ .Values.forwardAuth.authResponseHeaders }}
+        {{ template "traefik.authResponseHeaders" . }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/staging/traefik/templates/dashboard-ingress.yaml
+++ b/staging/traefik/templates/dashboard-ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "traefik.fullname" . }}-dashboard
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  {{- if .Values.dashboard.ingress }}
+  {{- range $key, $value := .Values.dashboard.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  annotations:
+  {{- if .Values.dashboard.ingress }}
+  {{- range $key, $value := .Values.dashboard.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  rules:
+  - host: {{ .Values.dashboard.domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "traefik.fullname" . }}-dashboard
+          servicePort: dashboard-http
+  {{- if .Values.dashboard.ingress.tls }}
+  tls:
+{{ toYaml .Values.dashboard.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end }}

--- a/staging/traefik/templates/dashboard-service.yaml
+++ b/staging/traefik/templates/dashboard-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "traefik.fullname" . }}-dashboard
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+  {{- if .Values.dashboard.service }}
+  {{- range $key, $value := .Values.dashboard.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.dashboard.serviceType | default ("ClusterIP") }}
+  selector:
+    app: {{ template "traefik.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+  - name: dashboard-http
+    port: 80
+    targetPort: 8080
+{{- end }}

--- a/staging/traefik/templates/default-cert-secret.yaml
+++ b/staging/traefik/templates/default-cert-secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ssl.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "traefik.fullname" . }}-default-cert
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+data:
+{{- if .Values.ssl.generateTLS }}
+  {{- $ca := genCA "default-ca" 365 }}
+  {{- $cn := default "example.com" .Values.ssl.defaultCN }}
+  {{- $server := genSignedCert $cn ( default nil .Values.ssl.defaultIPList ) ( default nil .Values.ssl.defaultSANList ) 365 $ca }}
+  tls.crt: {{ $server.Cert | b64enc }}
+  tls.key: {{ $server.Key | b64enc }}
+{{- else }}
+  tls.crt: {{ .Values.ssl.defaultCert }}
+  tls.key: {{ .Values.ssl.defaultKey }}
+{{- end }}
+{{- end }}

--- a/staging/traefik/templates/deployment.yaml
+++ b/staging/traefik/templates/deployment.yaml
@@ -1,0 +1,201 @@
+{{- if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: apps/v1
+{{- else }}
+apiVersion: apps/v1beta1
+{{- end }}
+kind: Deployment
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  replicas: {{ default 1 .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "traefik.name" . }}
+      release: {{ .Release.Name }}
+  {{- if .Values.deploymentStrategy }}
+  strategy:
+{{ toYaml .Values.deploymentStrategy | indent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if and (.Values.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
+        scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
+      {{- end }}
+      {{- range $key, $value := .Values.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      labels:
+        app: {{ template "traefik.name" . }}
+        chart: {{ template "traefik.chart" . }}
+        release: {{ .Release.Name | quote }}
+        heritage: {{ .Release.Service | quote }}
+        {{- if .Values.deployment.podLabels }}
+{{ toYaml .Values.deployment.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ template "traefik.fullname" . }}
+      {{- else }}
+      serviceAccountName: default
+      {{- end }}
+      terminationGracePeriodSeconds: 60
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+      - image: {{ .Values.image }}:{{ .Values.imageTag }}
+        name: {{ template "traefik.fullname" . }}
+        resources:
+        {{- if or .Values.cpuRequest .Values.memoryRequest .Values.cpuLimit .Values.memoryLimit }}
+          requests:
+            cpu: {{ .Values.cpuRequest | quote }}
+            memory: {{ .Values.memoryRequest | quote }}
+          limits:
+            cpu: {{ .Values.cpuLimit | quote }}
+            memory: {{ .Values.memoryLimit | quote }}
+        {{- else }}
+{{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 80
+          failureThreshold: 1
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 80
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        {{- if or (and .Values.acme.enabled (eq .Values.acme.challengeType "dns-01") .Values.acme.dnsProvider.name) .Values.env }}
+        env:
+        {{- range $k, $v := (index .Values.acme.dnsProvider .Values.acme.dnsProvider.name) }}
+          {{- if or $v $.Values.acme.dnsProvider.existingSecretName }}
+          - name: {{ $k }}
+            valueFrom:
+              secretKeyRef:
+              {{- if $.Values.acme.dnsProvider.existingSecretName }}
+                name: {{ $.Values.acme.dnsProvider.existingSecretName }}
+              {{- else }}
+                name: {{ template "traefik.fullname" $ }}-dnsprovider-config
+              {{- end }}
+                key: {{ $k }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.env }}
+{{ toYaml .Values.env | indent 10 }}
+        {{- end }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        {{- if and .Values.ssl.enabled (not .Values.ssl.upstream) }}
+        - mountPath: /ssl
+          name: ssl
+        {{- end }}
+        {{- if .Values.acme.enabled }}
+        - mountPath: /acme
+          name: acme
+        {{- end }}
+        {{- if .Values.configFiles }}
+        - mountPath: /configs
+          name: {{ template "traefik.fullname" $ }}-configs
+        {{ end }}
+        {{- if .Values.secretFiles }}
+        - mountPath: /secrets
+          name: {{ template "traefik.fullname" $ }}-secrets
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: 80
+          {{- if .Values.deployment.hostPort.httpEnabled }}
+          hostPort: {{ default 80 .Values.deployment.hostPort.httpPort }}
+          {{- end }}
+          protocol: TCP
+        - name: httpn
+          containerPort: 8880
+          protocol: TCP
+        - name: https
+          containerPort: 443
+          {{- if .Values.deployment.hostPort.httpsEnabled }}
+          hostPort: {{ default 443 .Values.deployment.hostPort.httpsPort }}
+          {{- end }}
+          protocol: TCP
+        {{- if .Values.dashboard.enabled }}
+        - name: dash
+          containerPort: 8080
+          {{- if .Values.deployment.hostPort.dashboardEnabled }}
+          hostPort: {{ default 8080 .Values.deployment.hostPort.dashboardPort }}
+          {{- end }}
+          protocol: TCP
+        {{- end }}
+        args:
+        - --configfile=/config/traefik.toml
+        {{- range .Values.startupArguments }}
+        - {{ . }}
+        {{- end }}
+
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "traefik.fullname" . }}
+      {{- if and .Values.ssl.enabled (not .Values.ssl.upstream) }}
+      - name: ssl
+        secret:
+          secretName: {{ template "traefik.fullname" . }}-default-cert
+      {{- end }}
+      {{- if .Values.acme.enabled }}
+      - name: acme
+      {{- if .Values.acme.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.acme.persistence.existingClaim | default (printf "%s-acme" (include "traefik.fullname" .)) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.configFiles }}
+      - name: {{ template "traefik.fullname" $ }}-configs
+        configMap:
+          name: {{ template "traefik.fullname" $ }}-configs
+      {{ end }}
+      {{- if .Values.secretFiles }}
+      - name: {{ template "traefik.fullname" $ }}-secrets
+        secret:
+          secretName: {{ template "traefik.fullname" $ }}-secrets
+      {{- end }}
+      {{- if and (.Values.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- end }}

--- a/staging/traefik/templates/dns-provider-secret.yaml
+++ b/staging/traefik/templates/dns-provider-secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.acme.enabled (eq .Values.acme.challengeType "dns-01") .Values.acme.dnsProvider.name (not .Values.acme.dnsProvider.existingSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "traefik.fullname" . }}-dnsprovider-config
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+data:
+{{- range $k, $v := (index .Values.acme.dnsProvider .Values.acme.dnsProvider.name) }}
+  {{- if $v }}
+    {{ $k }}: {{ $v | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/staging/traefik/templates/hpa.yaml
+++ b/staging/traefik/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.autoscaling }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "traefik.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- end }}

--- a/staging/traefik/templates/poddisruptionbudget.yaml
+++ b/staging/traefik/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "traefik.name" . }}
+      release: {{ .Release.Name }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/staging/traefik/templates/rbac.yaml
+++ b/staging/traefik/templates/rbac.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.rbac.enabled }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "traefik.fullname" . }}
+---
+kind: ClusterRole
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ template "traefik.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+---
+kind: ClusterRoleBinding
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ template "traefik.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "traefik.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "traefik.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/staging/traefik/templates/secret-files.yaml
+++ b/staging/traefik/templates/secret-files.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secretFiles }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "traefik.fullname" . }}-secrets
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+{{- range $filename, $fileContents := .Values.secretFiles }}
+  {{ $filename }}: {{ $fileContents | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/staging/traefik/templates/service.yaml
+++ b/staging/traefik/templates/service.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  {{- if .Values.service }}
+  {{- range $key, $value := .Values.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  annotations:
+  {{- if .Values.service }}
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.serviceType }}
+  {{- if .Values.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.externalIP }}
+  externalIPs:
+    - {{ .Values.externalIP }}
+  {{- end }}
+  {{- if .Values.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $cidr := .Values.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    app: {{ template "traefik.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+  - port: 80
+    name: http
+    {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.service.nodePorts.http)))}}
+    nodePort: {{ .Values.service.nodePorts.http }}
+    {{- end }}
+    targetPort: http
+  - port: 443
+    name: https
+    {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.service.nodePorts.https)))}}
+    nodePort: {{ .Values.service.nodePorts.https }}
+    {{- end }}
+    {{- if not .Values.ssl.enabled }}
+    targetPort: httpn
+    {{- end }}
+  {{- if (and (.Values.metrics.prometheus.enabled) (not (.Values.metrics.prometheus.restrictAccess)))}}
+  - port: 8080
+    name: metrics
+    targetPort: dash
+  {{- end }}

--- a/staging/traefik/templates/storeconfig-job.yaml
+++ b/staging/traefik/templates/storeconfig-job.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.kvprovider.storeAcme }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "storeconfig-job-{{ .Release.Revision }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+  labels:
+    chart: {{ template "traefik.chart" . }}
+    app: {{ template "traefik.name" . }}
+spec:
+  template:
+    metadata:
+      name: "storeconfig-job-{{ .Release.Revision }}"
+      labels:
+        app: {{ template "traefik.name" . }}
+        chart: {{ template "traefik.chart" . }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: storeconfig-job
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          args:
+          - storeconfig
+          - --configfile=/config/traefik.toml
+          volumeMounts:
+          - mountPath: /config
+            name: config
+          - mountPath: /acme
+            name: acme
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "traefik.fullname" . }}
+      - name: acme
+      {{- if .Values.acme.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.acme.persistence.existingClaim | default (printf "%s-acme" (include "traefik.fullname" .)) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+{{- end }}

--- a/staging/traefik/templates/tests/test-configmap.yaml
+++ b/staging/traefik/templates/tests/test-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "traefik.fullname" . }}-test
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+data:
+  run.sh: |-
+    @test "Test Access" {
+      curl -D - http://{{ template "traefik.fullname" . }}/
+    }
+

--- a/staging/traefik/templates/tests/test.yaml
+++ b/staging/traefik/templates/tests/test.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "traefik.fullname" . }}-test
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+    - name: test-framework
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+      - mountPath: /tools
+        name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "traefik.fullname" . }}-test
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -1,0 +1,475 @@
+## Default values for Traefik
+image: traefik
+imageTag: 1.7.12
+
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# imagePullSecrets:
+# - "regsecret"
+
+
+testFramework:
+  image: "dduportal/bats"
+  tag: "0.4.0"
+
+## can switch the service type to NodePort if required
+serviceType: LoadBalancer
+# loadBalancerIP: ""
+# loadBalancerSourceRanges: []
+whiteListSourceRange: []
+externalTrafficPolicy: Cluster
+replicas: 1
+# startupArguments:
+#   - "--ping"
+#   - "--ping.entrypoint=http"
+
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+  # minAvailable: 2
+
+# priorityClassName: ""
+
+# rootCAs: []
+
+resources: {}
+
+debug:
+  enabled: false
+
+# logLevel: error
+
+deploymentStrategy: {}
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+  # type: RollingUpdate
+
+securityContext: {}
+env: {}
+
+nodeSelector: {}
+  # key: value
+affinity: {}
+  # key: value
+tolerations: []
+# - key: "key"
+#   operator: "Equal|Exists"
+#   value: "value"
+#   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+## Kubernetes ingress filters
+# kubernetes:
+  # endpoint:
+  # namespaces:
+  # - default
+  # labelSelector:
+  # ingressClass:
+  # ingressEndpoint:
+  #   hostname: "localhost"
+  #   ip: "127.0.0.1"
+  #   publishedService: "namespace/servicename"
+  #   useDefaultPublishedService: false
+
+fileBackend: ""
+  # as in same traefik.toml
+  #
+  # [backends]
+  #   [backends.backend1]
+  #     # ...
+  #   [backends.backend2]
+  #     # ...
+  # [frontends]
+  #   [frontends.frontend1]
+  #   # ...
+  #   [frontends.frontend2]
+  #
+  # or separated file from configFiles
+  # filename = "/configs/rules.toml"
+
+proxyProtocol:
+  enabled: false
+  # trustedIPs is required when enabled
+  trustedIPs: []
+  # - 10.0.0.0/8
+forwardedHeaders:
+  enabled: false
+  # trustedIPs is required when enabled
+  trustedIPs: []
+  # - 10.0.0.0/8
+
+## Add arbitrary ConfigMaps to deployment
+## Will be mounted to /configs/, i.e. myconfig.json would
+## be mounted to /configs/myconfig.json.
+configFiles: {}
+  # myconfig.json: |
+  #   filecontents...
+
+## Add arbitrary Secrets to deployment
+## Will be mounted to /secrets/, i.e. file.name would
+## be mounted to /secrets/mysecret.txt.
+## The contents will be base64 encoded when added
+secretFiles: {}
+  # mysecret.txt: |
+  #   filecontents...
+
+ssl:
+  enabled: false
+  enforced: false
+  permanentRedirect: false
+  upstream: false
+  insecureSkipVerify: false
+  generateTLS: false
+  # defaultCN: "example.com"
+    # or *.example.com
+  defaultSANList: []
+    # - example.com
+    # - test1.example.com
+  defaultIPList: []
+    # - 1.2.3.4
+  # cipherSuites: []
+  # https://docs.traefik.io/configuration/entrypoints/#specify-minimum-tls-version
+  # tlsMinVersion: VersionTLS12
+  # https://docs.traefik.io/configuration/entrypoints/#strict-sni-checking
+  # sniStrict: false
+  defaultCert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVtekNDQTRPZ0F3SUJBZ0lKQUpBR1FsTW1DMGt5TUEwR0NTcUdTSWIzRFFFQkJRVUFNSUdQTVFzd0NRWUQKVlFRR0V3SlZVekVSTUE4R0ExVUVDQk1JUTI5c2IzSmhaRzh4RURBT0JnTlZCQWNUQjBKdmRXeGtaWEl4RkRBUwpCZ05WQkFvVEMwVjRZVzF3YkdWRGIzSndNUXN3Q1FZRFZRUUxFd0pKVkRFV01CUUdBMVVFQXhRTktpNWxlR0Z0CmNHeGxMbU52YlRFZ01CNEdDU3FHU0liM0RRRUpBUllSWVdSdGFXNUFaWGhoYlhCc1pTNWpiMjB3SGhjTk1UWXgKTURJME1qRXdPVFV5V2hjTk1UY3hNREkwTWpFd09UVXlXakNCanpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVgpCQWdUQ0VOdmJHOXlZV1J2TVJBd0RnWURWUVFIRXdkQ2IzVnNaR1Z5TVJRd0VnWURWUVFLRXd0RmVHRnRjR3hsClEyOXljREVMTUFrR0ExVUVDeE1DU1ZReEZqQVVCZ05WQkFNVURTb3VaWGhoYlhCc1pTNWpiMjB4SURBZUJna3EKaGtpRzl3MEJDUUVXRVdGa2JXbHVRR1Y0WVcxd2JHVXVZMjl0TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQwpBUThBTUlJQkNnS0NBUUVBdHVKOW13dzlCYXA2SDROdUhYTFB6d1NVZFppNGJyYTFkN1ZiRUJaWWZDSStZNjRDCjJ1dThwdTNhVTVzYXVNYkQ5N2pRYW95VzZHOThPUHJlV284b3lmbmRJY3RFcmxueGpxelUyVVRWN3FEVHk0bkEKNU9aZW9SZUxmZXFSeGxsSjE0VmlhNVFkZ3l3R0xoRTlqZy9jN2U0WUp6bmg5S1dZMnFjVnhEdUdEM2llaHNEbgphTnpWNFdGOWNJZm1zOHp3UHZPTk5MZnNBbXc3dUhUKzNiSzEzSUloeDI3ZmV2cXVWcENzNDFQNnBzdStWTG4yCjVIRHk0MXRoQkN3T0wrTithbGJ0ZktTcXM3TEFzM25RTjFsdHpITHZ5MGE1RGhkakpUd2tQclQrVXhwb0tCOUgKNFpZazErRUR0N09QbGh5bzM3NDFRaE4vSkNZK2RKbkFMQnNValFJREFRQUJvNEgzTUlIME1CMEdBMVVkRGdRVwpCQlJwZVc1dFhMdHh3TXJvQXM5d2RNbTUzVVVJTERDQnhBWURWUjBqQklHOE1JRzVnQlJwZVc1dFhMdHh3TXJvCkFzOXdkTW01M1VVSUxLR0JsYVNCa2pDQmp6RUxNQWtHQTFVRUJoTUNWVk14RVRBUEJnTlZCQWdUQ0VOdmJHOXkKWVdSdk1SQXdEZ1lEVlFRSEV3ZENiM1ZzWkdWeU1SUXdFZ1lEVlFRS0V3dEZlR0Z0Y0d4bFEyOXljREVMTUFrRwpBMVVFQ3hNQ1NWUXhGakFVQmdOVkJBTVVEU291WlhoaGJYQnNaUzVqYjIweElEQWVCZ2txaGtpRzl3MEJDUUVXCkVXRmtiV2x1UUdWNFlXMXdiR1V1WTI5dGdna0FrQVpDVXlZTFNUSXdEQVlEVlIwVEJBVXdBd0VCL3pBTkJna3EKaGtpRzl3MEJBUVVGQUFPQ0FRRUFjR1hNZms4TlpzQit0OUtCemwxRmw2eUlqRWtqSE8wUFZVbEVjU0QyQjRiNwpQeG5NT2pkbWdQcmF1SGI5dW5YRWFMN3p5QXFhRDZ0YlhXVTZSeENBbWdMYWpWSk5aSE93NDVOMGhyRGtXZ0I4CkV2WnRRNTZhbW13QzFxSWhBaUE2MzkwRDNDc2V4N2dMNm5KbzdrYnIxWVdVRzN6SXZveGR6OFlEclpOZVdLTEQKcFJ2V2VuMGxNYnBqSVJQNFhac25DNDVDOWdWWGRoM0xSZTErd3lRcTZoOVFQaWxveG1ENk5wRTlpbVRPbjJBNQovYkozVktJekFNdWRlVTZrcHlZbEpCemRHMXVhSFRqUU9Xb3NHaXdlQ0tWVVhGNlV0aXNWZGRyeFF0aDZFTnlXCnZJRnFhWng4NCtEbFNDYzkzeWZrL0dsQnQrU0tHNDZ6RUhNQjlocVBiQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  defaultKey: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdHVKOW13dzlCYXA2SDROdUhYTFB6d1NVZFppNGJyYTFkN1ZiRUJaWWZDSStZNjRDCjJ1dThwdTNhVTVzYXVNYkQ5N2pRYW95VzZHOThPUHJlV284b3lmbmRJY3RFcmxueGpxelUyVVRWN3FEVHk0bkEKNU9aZW9SZUxmZXFSeGxsSjE0VmlhNVFkZ3l3R0xoRTlqZy9jN2U0WUp6bmg5S1dZMnFjVnhEdUdEM2llaHNEbgphTnpWNFdGOWNJZm1zOHp3UHZPTk5MZnNBbXc3dUhUKzNiSzEzSUloeDI3ZmV2cXVWcENzNDFQNnBzdStWTG4yCjVIRHk0MXRoQkN3T0wrTithbGJ0ZktTcXM3TEFzM25RTjFsdHpITHZ5MGE1RGhkakpUd2tQclQrVXhwb0tCOUgKNFpZazErRUR0N09QbGh5bzM3NDFRaE4vSkNZK2RKbkFMQnNValFJREFRQUJBb0lCQUhrTHhka0dxNmtCWWQxVAp6MkU4YWFENnhneGpyY2JSdGFCcTc3L2hHbVhuQUdaWGVWcE81MG1SYW8wbHZ2VUgwaE0zUnZNTzVKOHBrdzNmCnRhWTQxT1dDTk1PMlYxb1MvQmZUK3Zsblh6V1hTemVQa0pXd2lIZVZMdVdEaVVMQVBHaWl4emF2RFMyUnlQRmEKeGVRdVNhdE5pTDBGeWJGMG5Zd3pST3ZoL2VSa2NKVnJRZlZudU1melFkOGgyMzZlb1UxU3B6UnhSNklubCs5UApNc1R2Wm5OQmY5d0FWcFo5c1NMMnB1V1g3SGNSMlVnem5oMDNZWUZJdGtDZndtbitEbEdva09YWHBVM282aWY5ClRIenBleHdubVJWSmFnRG85bTlQd2t4QXowOW80cXExdHJoU1g1U2p1K0xyNFJvOHg5bytXdUF1VnVwb0lHd0wKMWVseERFRUNnWUVBNzVaWGp1enNJR09PMkY5TStyYVFQcXMrRHZ2REpzQ3gyZnRudk1WWVJKcVliaGt6YnpsVQowSHBCVnk3NmE3WmF6Umxhd3RGZ3ljMlpyQThpM0F3K3J6d1pQclNJeWNieC9nUVduRzZlbFF1Y0FFVWdXODRNCkdSbXhKUGlmOGRQNUxsZXdRalFjUFJwZVoxMzlYODJreGRSSEdma1pscHlXQnFLajBTWExRSEVDZ1lFQXcybkEKbUVXdWQzZFJvam5zbnFOYjBlYXdFUFQrbzBjZ2RyaENQOTZQK1pEekNhcURUblZKV21PeWVxRlk1eVdSSEZOLwpzbEhXU2lTRUFjRXRYZys5aGlMc0RXdHVPdzhUZzYyN2VrOEh1UUtMb2tWWEFUWG1NZG9xOWRyQW9INU5hV2lECmRSY3dEU2EvamhIN3RZV1hKZDA4VkpUNlJJdU8vMVZpbDBtbEk5MENnWUVBb2lsNkhnMFNUV0hWWDNJeG9raEwKSFgrK1ExbjRYcFJ5VEg0eldydWY0TjlhYUxxNTY0QThmZGNodnFiWGJHeEN6U3RxR1E2cW1peUU1TVpoNjlxRgoyd21zZEpxeE14RnEzV2xhL0lxSzM0cTZEaHk3cUNld1hKVGRKNDc0Z3kvY0twZkRmeXZTS1RGZDBFejNvQTZLCmhqUUY0L2lNYnpxUStQREFQR0YrVHFFQ2dZQmQ1YnZncjJMMURzV1FJU3M4MHh3MDBSZDdIbTRaQVAxdGJuNk8KK0IvUWVNRC92UXBaTWV4c1hZbU9lV2Noc3FCMnJ2eW1MOEs3WDY1NnRWdGFYay9nVzNsM3ZVNTdYSFF4Q3RNUwpJMVYvcGVSNHRiN24yd0ZncFFlTm1XNkQ4QXk4Z0xiaUZhRkdRSDg5QWhFa0dTd1d5cWJKc2NoTUZZOUJ5OEtUCkZaVWZsUUtCZ0V3VzJkVUpOZEJMeXNycDhOTE1VbGt1ZnJxbllpUTNTQUhoNFZzWkg1TXU0MW55Yi95NUUyMW4KMk55d3ltWGRlb3VJcFZjcUlVTXl0L3FKRmhIcFJNeVEyWktPR0QyWG5YaENNVlRlL0FQNDJod294Nm02QkZpQgpvemZFa2wwak5uZmREcjZrL1p2MlQ1TnFzaWxaRXJBQlZGOTBKazdtUFBIa0Q2R1ZMUUJ4Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+  # Basic auth to protect all the routes. Can use htpasswd to generate passwords
+  # > htpasswd -n -b testuser testpass
+  # > testuser:$apr1$JXRA7j2s$LpVns9vsme8FHN0r.aSt11
+  auth: {}
+    # basic:
+    #   testuser: $apr1$JXRA7j2s$LpVns9vsme8FHN0r.aSt11
+
+kvprovider:
+  ## If you want to run Traefik in HA mode, you will need to setup a KV Provider. Therefore you can choose one of
+  ## * etcd
+  ## * consul
+  ## * boltdb
+  ## * zookeeper
+  ##
+  ## ref: https://docs.traefik.io/user-guide/cluster/
+
+  ## storeAcme has to be enabled to support HA Support using acme, but at least one kvprovider is needed
+  storeAcme: false
+  importAcme: false
+
+  # etcd:
+    # endpoint: etcd-service:2379
+    # useAPIV3: false
+    # watch: true
+    # prefix: traefik
+
+    ## Override default configuration template.
+    ## For advanced users :)
+    ##
+    ## Optional
+    # filename: consul.tmpl
+    # username: foo
+    # password: bar
+    # tls:
+    #   ca: "/etc/ssl/ca.crt"
+    #   cert: "/etc/ssl/consul.crt"
+    #   key: "/etc/ssl/consul.key"
+    #   insecureSkipVerify: true
+    #
+  # consul:
+    # endpoint: consul-service:8500
+    # watch: true
+    # prefix: traefik
+
+    ## Override default configuration template.
+    ## For advanced users :)
+    ##
+    ## Optional
+    # filename: consul.tmpl
+    # username: foo
+    # password: bar
+    # tls:
+    #   ca: "/etc/ssl/ca.crt"
+    #   cert: "/etc/ssl/consul.crt"
+    #   key: "/etc/ssl/consul.key"
+    #   insecureSkipVerify: true
+
+    ## only relevant for etcd
+
+
+acme:
+  keyType: RSA4096
+  enabled: false
+  email: admin@example.com
+  onHostRule: true
+  staging: true
+  logging: false
+  # Configure a Let's Encrypt certificate to be managed by default.
+  # This is the only way to request wildcard certificates (works only with dns challenge).
+  domains:
+    enabled: false
+    # List of sets of main and (optional) SANs to generate for
+    # for wildcard certificates see https://docs.traefik.io/configuration/acme/#wildcard-domains
+    domainsList:
+      # - main: "*.example.com"
+      # - sans:
+      #   - "example.com"
+      # - main: "*.example2.com"
+      # - sans:
+      #   - "test1.example2.com"
+      #   - "test2.example2.com"
+  ## ACME challenge type: "tls-sni-01", "tls-alpn-01", "http-01" or "dns-01"
+  ## Note the chart's default of tls-sni-01 has been DEPRECATED and (except in
+  ## certain circumstances) DISABLED by Let's Encrypt. It remains as a default
+  ## value in this chart to preserve legacy behavior and avoid a breaking
+  ## change. Users of this chart should strongly consider making the switch to
+  ## the recommended "tls-alpn-01" (avaialbe since v1.7), dns-01 or http-01
+  ## (available since v1.5) challenge.
+  challengeType: tls-sni-01
+  ## Configure dnsProvider to perform domain verification using dns challenge
+  ## Applicable only if using the dns-01 challenge type
+  delayBeforeCheck: 0
+  resolvers: []
+    # - 1.1.1.1:53
+    # - 8.8.8.8:53
+  dnsProvider:
+    name: nil
+    existingSecretName: ""
+    auroradns:
+      AURORA_USER_ID: ""
+      AURORA_KEY: ""
+      AURORA_ENDPOINT: ""
+    azure:
+      AZURE_CLIENT_ID: ""
+      AZURE_CLIENT_SECRET: ""
+      AZURE_SUBSCRIPTION_ID: ""
+      AZURE_TENANT_ID: ""
+      AZURE_RESOURCE_GROUP: ""
+    cloudflare:
+      CLOUDFLARE_EMAIL: ""
+      CLOUDFLARE_API_KEY: ""
+    digitalocean:
+      DO_AUTH_TOKEN: ""
+    dnsimple:
+      DNSIMPLE_OAUTH_TOKEN: ""
+      DNSIMPLE_BASE_URL: ""
+    dnsmadeeasy:
+      DNSMADEEASY_API_KEY: ""
+      DNSMADEEASY_API_SECRET: ""
+      DNSMADEEASY_SANDBOX: ""
+    dnspod:
+      DNSPOD_API_KEY: ""
+    dreamhost:
+      DREAMHOST_API_KEY: ""
+    dyn:
+      DYN_CUSTOMER_NAME: ""
+      DYN_USER_NAME: ""
+      DYN_PASSWORD: ""
+    exoscale:
+      EXOSCALE_API_KEY: ""
+      EXOSCALE_API_SECRET: ""
+      EXOSCALE_ENDPOINT: ""
+    gandi:
+      GANDI_API_KEY: ""
+    godaddy:
+      GODADDY_API_KEY: ""
+      GODADDY_API_SECRET: ""
+    gcloud:
+      GCE_PROJECT: ""
+      GCE_SERVICE_ACCOUNT_FILE: ""
+    linode:
+      LINODE_API_KEY: ""
+    namecheap:
+      NAMECHEAP_API_USER: ""
+      NAMECHEAP_API_KEY: ""
+    ns1:
+      NS1_API_KEY: ""
+    otc:
+      OTC_DOMAIN_NAME: ""
+      OTC_USER_NAME: ""
+      OTC_PASSWORD: ""
+      OTC_PROJECT_NAME: ""
+      OTC_IDENTITY_ENDPOINT: ""
+    ovh:
+      OVH_ENDPOINT: ""
+      OVH_APPLICATION_KEY: ""
+      OVH_APPLICATION_SECRET: ""
+      OVH_CONSUMER_KEY: ""
+    pdns:
+      PDNS_API_URL: ""
+    rackspace:
+      RACKSPACE_USER: ""
+      RACKSPACE_API_KEY: ""
+    rfc2136:
+      RFC2136_NAMESERVER: ""
+      RFC2136_TSIG_ALGORITHM: ""
+      RFC2136_TSIG_KEY: ""
+      RFC2136_TSIG_SECRET: ""
+      RFC2136_TIMEOUT: ""
+    route53:
+      AWS_REGION: ""
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
+    vultr:
+      VULTR_API_KEY: ""
+  ## Save ACME certs to a persistent volume.
+  ## WARNING: If you do not do this and you did not have configured
+  ## a kvprovider, you will re-request certs every time a pod (re-)starts
+  ## and you WILL be rate limited!
+  persistence:
+    enabled: true
+    annotations: {}
+    ## acme data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    ## A manually managed Persistent Volume Claim
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    ##
+    # existingClaim:
+dashboard:
+  enabled: false
+  domain: traefik.example.com
+  # serviceType: ClusterIP
+  service: {}
+    # annotations:
+    #   key: value
+  ingress: {}
+    # annotations:
+    #   key: value
+    # labels:
+    #   key: value
+    # tls:
+      # - hosts:
+      #   - traefik.example.com
+      #   secretName: traefik-default-cert
+  auth: {}
+    # basic:
+    #   username: password
+  statistics: {}
+    ## Number of recent errors to show in the ‘Health’ tab
+    # recentErrors:
+service:
+  # annotations:
+  #   key: value
+  # labels:
+  #   key: value
+  ## Further config for service of type NodePort
+  ## Default config with empty string "" will assign a dynamic
+  ## nodePort to http and https ports
+  nodePorts:
+    http: ""
+    https: ""
+  ## If static nodePort configuration is required it can be enabled as below
+  ## Configure ports in allowable range (eg. 30000 - 32767 on minikube)
+  # nodePorts:
+  #   http: 30080
+  #   https: 30443
+gzip:
+  enabled: true
+traefikLogFormat: json
+accessLogs:
+  enabled: false
+  ## Path to the access logs file. If not provided, Traefik defaults it to stdout.
+  # filePath: ""
+  format: common  # choices are: common, json
+  ## for JSON logging, finer-grained control over what is logged. Fields can be
+  ## retained or dropped, and request headers can be retained, dropped or redacted
+  fields:
+    # choices are keep, drop
+    defaultMode: keep
+    names: {}
+      # ClientUsername: drop
+    headers:
+      # choices are keep, drop, redact
+      defaultMode: keep
+      names: {}
+        # Authorization: redact
+rbac:
+  enabled: false
+## Enable the /metrics endpoint, for now only supports prometheus
+## set to true to enable metric collection by prometheus
+metrics:
+  prometheus:
+    enabled: false
+    ## If true, prevents exposing port 8080 on the main Traefik service, reserving
+    ## it to the dashboard service only
+    restrictAccess: false
+    # buckets: [0.1,0.3,1.2,5]
+  datadog:
+    enabled: false
+    # address: localhost:8125
+    # pushinterval: 10s
+  statsd:
+    enabled: false
+    # address: localhost:8125
+    # pushinterval: 10s
+deployment:
+  # labels to add to the pod container metadata
+  # podLabels:
+  #   key: value
+  # podAnnotations:
+  #   key: value
+  hostPort:
+    httpEnabled: false
+    httpsEnabled: false
+    dashboardEnabled: false
+    # httpPort: 80
+    # httpsPort: 443
+    # dashboardPort: 8080
+sendAnonymousUsage: false
+tracing:
+  enabled: false
+  serviceName: traefik
+  # backend: choices are jaeger, zipkin, datadog
+  # jaeger:
+  #   localAgentHostPort: "127.0.0.1:6831"
+  #   samplingServerURL: http://localhost:5778/sampling
+  #   samplingType: const
+  #   samplingParam: 1.0
+  # zipkin:
+  #   httpEndpoint: http://localhost:9411/api/v1/spans
+  #   debug: false
+  #   sameSpan: false
+  #   id128bit: true
+  # datadog:
+  #   localAgentHostPort: "127.0.0.1:8126"
+  #   debug: false
+  #   globalTag: ""
+
+## Create HorizontalPodAutoscaler object.
+##
+# autoscaling:
+#   minReplicas: 1
+#   maxReplicas: 10
+#   metrics:
+#   - type: Resource
+#     resource:
+#       name: cpu
+#       targetAverageUtilization: 60
+#   - type: Resource
+#     resource:
+#       name: memory
+#       targetAverageUtilization: 60
+
+## Timeouts
+##
+# timeouts:
+#   ## responding are timeouts for incoming requests to the Traefik instance
+#   responding:
+#     readTimeout: 0s
+#     writeTimeout: 0s
+#     idleTimeout: 180s
+#   ## forwarding are timeouts for requests forwarded to the backend servers
+#   forwarding:
+#     dialTimeout: 30s
+#     responseHeaderTimeout: 0s
+
+# forwardAuth:
+#   entryPoints: ["http", "https"]
+#   address: https://authserver.com/auth
+#   trustForwardHeader: true
+#   authResponseHeaders: []


### PR DESCRIPTION
As a backup plan until https://github.com/helm/charts/pull/15511 is merged, we might want to use our own traefik chart which allows us defining auth response headers.