### PR TITLE
Add initContainers to traefik-forward-auth chart

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.1.1
+version: 0.1.2
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/deployment.yaml
+++ b/staging/traefik-forward-auth/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         app.kubernetes.io/name: {{ include "traefik-forward-auth.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+{{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+{{- end }}
       volumes:
       {{- if .Values.traefikForwardAuth.clientSecret.valueFrom.secretKeyRef }}
       - name: etc-traefik-forward-auth-ca

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -75,3 +75,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+initContainers: []


### PR DESCRIPTION
This PR adds `initContainer` support to the `treafik-forward-auth` chart.