### PR TITLE
Add temporary placeholder for traefik-forward-auth

### DIFF
--- a/staging/traefik-forward-auth/templates/secret.yaml
+++ b/staging/traefik-forward-auth/templates/secret.yaml
@@ -9,6 +9,7 @@ data:
 ---
 apiVersion: v1
 kind: Secret
+type: Opaque
 metadata:
   name: ops-portal-credentials
 data:

--- a/staging/traefik-forward-auth/templates/secret.yaml
+++ b/staging/traefik-forward-auth/templates/secret.yaml
@@ -6,3 +6,13 @@ type: Opaque
 data:
   clientSecret: {{ required "traefikForwardAuth.clientSecret is required" .Values.traefikForwardAuth.clientSecret.value | b64enc | quote }}
   secret: {{ required "traefikForwardAuth.secret is required" .Values.traefikForwardAuth.secret | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ops-portal-credentials
+data:
+  # cGxhY2Vob2xkZXIK is "placeholder" and will be regenerated before container deployment
+  # TODO: this should be reworked to not require the placeholder (see: DCOS-56555)
+  username: cGxhY2Vob2xkZXIK
+  password: cGxhY2Vob2xkZXIK


### PR DESCRIPTION
This is a temporary workaround for a problem with how we currently deploy the traefik-forward-auth addon. Follow up is [DCOS-56555](https://jira.mesosphere.com/browse/DCOS-56555).