### PR TITLE
fixing selector matchlabels and template name lable to match

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.24.2"
 description: Kommander
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/templates/deployment.yaml
+++ b/stable/kommander/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: kommander
+      app: {{ template "kommander.fullname" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
should fix:
`kommander: kommander failed: exit status 1 [stderr: Error: release kommander-kubeaddons failed: Deployment.apps "kommander-kubeaddons" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"kommander-kubeaddons"}: `selector` does not match template `labels``