### PR TITLE
stable/dex: add dex chart with initContainers support

### DIFF
--- a/stable/dex/.helmignore
+++ b/stable/dex/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+name: dex
+version: 1.5.2
+appVersion: 2.17.0
+description: CoreOS Dex
+keywords:
+- dex
+- oidc
+icon: https://github.com/dexidp/dex/raw/master/Documentation/logos/dex-glyph-color.png
+home: https://github.com/dexidp/dex/
+source:
+- https://github.com/dexidp/dex/
+maintainers:
+- name: kfox1111
+  email: Kevin.Fox@pnnl.gov
+- name: sstarcher
+  email: shane.starcher@gmail.com
+- name: rendhalver
+  email: pete.brown@powerhrg.com

--- a/stable/dex/OWNERS
+++ b/stable/dex/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- desaintmartin
+reviewers:
+- desaintmartin

--- a/stable/dex/config/openssl.conf
+++ b/stable/dex/config/openssl.conf
@@ -1,0 +1,82 @@
+# OpenSSL configuration file.
+# Adapted from https://github.com/coreos/matchbox/blob/master/examples/etc/matchbox/openssl.conf
+
+# default environment variable values
+SAN =
+
+[ ca ]
+# `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = .
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+# certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/intermediate-ca.crl
+crl_extensions    = crl_ext
+default_crl_days  = 30
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_loose
+
+[ policy_loose ]
+# Allow the CA to sign a range of certificates.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# `man req`
+default_bits        = 4096
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+default_md          = sha256
+
+[ req_distinguished_name ]
+countryName                    = Country Name (2 letter code)
+stateOrProvinceName            = State or Province Name
+localityName                   = Locality Name
+0.organizationName             = Organization Name
+organizationalUnitName         = Organizational Unit Name
+commonName                     = Common Name
+
+# Certificate extensions (`man x509v3_config`)
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+basicConstraints = CA:FALSE
+nsCertType = client
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+
+[ server_cert ]
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = $ENV::SAN

--- a/stable/dex/templates/NOTES.txt
+++ b/stable/dex/templates/NOTES.txt
@@ -1,0 +1,20 @@
+1. Get the application URL by running these commands:
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "dex.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo https://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "dex.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dex.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo https://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "dex.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit https://127.0.0.1:8080/.well-known/openid-configuration to use your application"
+  kubectl port-forward $POD_NAME 8080:5556
+{{- end }}

--- a/stable/dex/templates/_helpers.tpl
+++ b/stable/dex/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dex.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dex.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dex.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dex.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "dex.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/dex/templates/clusterrole.yaml
+++ b/stable/dex/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}
+rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
+{{- end -}}

--- a/stable/dex/templates/clusterrolebinding.yaml
+++ b/stable/dex/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "dex.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dex.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/dex/templates/config-openssl.yaml
+++ b/stable/dex/templates/config-openssl.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.certs.grpc.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}-openssl-config
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+data:
+  openssl.conf: |
+{{ .Files.Get "config/openssl.conf" | indent 4 }}
+{{- end }}

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -1,0 +1,104 @@
+{{ $fullname := include "dex.fullname" . }}
+{{ $httpsTlsBuiltName := printf "%s-tls" $fullname }}
+{{ $httpsTlsSecretName := default $httpsTlsBuiltName .Values.certs.web.secret.tlsName }}
+{{ $grpcTlsServerBuiltName := printf "%s-server-tls" $fullname }}
+{{ $grpcTlsServerSecretName := default $grpcTlsServerBuiltName .Values.certs.grpc.secret.serverTlsName }}
+{{ $grpcCaBuiltName := printf "%s-ca" $fullname }}
+{{ $grpcCaSecretName := default $grpcCaBuiltName .Values.certs.grpc.secret.caName }}
+
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "dex.fullname" . }}
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  replicas: {{ .Values.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "dex.name" . }}
+      release: "{{ .Release.Name }}"
+  template:
+    metadata:
+      labels:
+        app: {{ template "dex.name" . }}
+        release: "{{ .Release.Name }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+{{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+{{- end }}
+      serviceAccountName: {{ template "dex.serviceAccountName" . }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 10 }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ tpl .Values.affinity | indent 8 }}
+{{- end }}
+      containers:
+      - name: main
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command:
+        - /usr/local/bin/dex
+        - serve
+        - /etc/dex/cfg/config.yaml
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+{{ toYaml .Values.ports | indent 10 }}
+        env:
+{{ toYaml .Values.env | indent 10 }}
+        volumeMounts:
+        - mountPath: /etc/dex/cfg
+          name: config
+        - mountPath: /etc/dex/tls/https/server
+          name: https-tls
+        - mountPath: /etc/dex/tls/grpc/server
+          name: grpc-tls-server
+        - mountPath: /etc/dex/tls/grpc/ca
+          name: grpc-tls-ca
+{{- if ne (len .Values.extraVolumeMounts) 0 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - secret:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          secretName: {{ template "dex.fullname" . }}
+        name: config
+      - name: https-tls
+        secret:
+          defaultMode: 420
+          secretName: {{ $httpsTlsSecretName | quote }}
+      - name: grpc-tls-server
+        secret:
+          defaultMode: 420
+          secretName: {{ $grpcTlsServerSecretName | quote }}
+      - name: grpc-tls-ca
+        secret:
+          defaultMode: 420
+          secretName: {{ $grpcCaSecretName| quote }}
+{{- if ne (len .Values.extraVolumes) 0 }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+

--- a/stable/dex/templates/ingress.yaml
+++ b/stable/dex/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dex.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/stable/dex/templates/job-grpc-certs.yaml
+++ b/stable/dex/templates/job-grpc-certs.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.certs.grpc.create }}
+{{ $fullname := include "dex.fullname" . }}
+{{ $tlsServerBuiltName := printf "%s-server-tls" $fullname }}
+{{ $tlsServerSecretName := default $tlsServerBuiltName .Values.certs.grpc.secret.serverTlsName }}
+{{ $tlsClientBuiltName := printf "%s-client-tls" $fullname }}
+{{ $tlsClientSecretName := default $tlsClientBuiltName .Values.certs.grpc.secret.clientTlsName }}
+{{ $caBuiltName := printf "%s-ca" $fullname }}
+{{ $caName := default $caBuiltName .Values.certs.grpc.secret.caName }}
+{{ $openSslConfigName := printf "%s-openssl-config" $fullname }}
+{{ $local := dict "i" 0 }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: {{ $fullname }}-grpc-certs
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    component: "job"
+spec:
+  activeDeadlineSeconds: {{ .Values.certs.grpc.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "dex.name" . }}
+        release: "{{ .Release.Name }}"
+        component: "job"
+    spec:
+      {{- if .Values.certs.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.certs.securityContext.runAsUser }}
+        fsGroup: {{ .Values.certs.securityContext.fsGroup }}
+      {{- end }}
+      serviceAccountName: {{ template "dex.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+      - name: main
+        image: "{{ .Values.certs.image }}:{{ .Values.certs.imageTag }}"
+        imagePullPolicy: {{ .Values.certs.imagePullPolicy }}
+        env:
+        - name: HOME
+          value: /tmp
+        workingDir: /tmp
+        command:
+        - /bin/bash
+        - -exc
+        - |
+          export CONFIG=/etc/dex/tls/grpc/openssl.conf;
+          cat << EOF > san.cnf
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.grpc.altNames }}
+          DNS.{{ $local.i }}:{{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.grpc.altIPs }}
+          IP.{{ $local.i }}:{{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          EOF
+          export SAN=$(cat san.cnf |  paste -sd "," -)
+
+          # Creating basic files/directories
+          mkdir -p {certs,crl,newcerts}
+          touch index.txt
+          touch index.txt.attr
+          echo 1000 > serial
+          # CA private key (unencrypted)
+          openssl genrsa -out ca.key 4096;
+          # Certificate Authority (self-signed certificate)
+          openssl req -config $CONFIG -new -x509 -days 3650 -sha256 -key ca.key -extensions v3_ca -out ca.crt -subj "/CN=grpc-ca";
+          # Server private key (unencrypted)
+          openssl genrsa -out server.key 2048;
+          # Server certificate signing request (CSR)
+          openssl req -config $CONFIG -new -sha256 -key server.key -out server.csr -subj "/CN=grpc-server";
+          # Certificate Authority signs CSR to grant a certificate
+          openssl ca -batch -config $CONFIG  -extensions server_cert -days 365 -notext -md sha256 -in server.csr -out server.crt -cert ca.crt -keyfile ca.key;
+          # Client private key (unencrypted)
+          openssl genrsa -out client.key 2048;
+          # Signed client certificate signing request (CSR)
+          openssl req -config $CONFIG -new -sha256 -key client.key -out client.csr -subj "/CN=grpc-client";
+          # Certificate Authority signs CSR to grant a certificate
+          openssl ca -batch -config $CONFIG -extensions usr_cert -days 365 -notext -md sha256 -in client.csr -out client.crt -cert ca.crt -keyfile ca.key;
+          # Remove CSR's
+          rm *.csr;
+
+          # Cleanup the existing configmap and secrets
+          kubectl delete configmap {{ $caName }} --namespace {{ .Release.Namespace }} || true
+          kubectl delete secret {{ $caName }} {{ $tlsServerSecretName }} {{ $tlsClientSecretName }} --namespace {{ .Release.Namespace }} || true
+          kubectl create configmap {{ $caName }} --namespace {{ .Release.Namespace }} --from-file=ca.crt;
+          # Store all certficates in secrets
+          kubectl create secret tls {{ $caName }} --namespace {{ .Release.Namespace }} --cert=ca.crt --key=ca.key;
+          kubectl create secret tls {{ $tlsServerSecretName }} --namespace {{ .Release.Namespace }} --cert=server.crt --key=server.key;
+          kubectl create secret tls {{ $tlsClientSecretName }} --namespace {{ .Release.Namespace }} --cert=client.crt --key=client.key;
+        volumeMounts:
+        - name: openssl-config
+          mountPath: /etc/dex/tls/grpc
+      volumes:
+      - name: openssl-config
+        configMap:
+          name: {{ $openSslConfigName }}
+{{- end }}

--- a/stable/dex/templates/job-web-certs.yaml
+++ b/stable/dex/templates/job-web-certs.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.certs.web.create }}
+{{ $fullname := include "dex.fullname" . }}
+{{ $tlsBuiltName := printf "%s-tls" $fullname }}
+{{ $tlsSecretName := default $tlsBuiltName .Values.certs.web.secret.tlsName }}
+{{ $caBuiltName := printf "%s-ca" $fullname }}
+{{ $caName := default $caBuiltName .Values.certs.web.secret.caName }}
+{{ $local := dict "i" 0 }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: {{ $fullname  }}-web-certs
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    component: "job"
+spec:
+  activeDeadlineSeconds: {{ .Values.certs.web.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "dex.name" . }}
+        release: "{{ .Release.Name }}"
+        component: "job"
+    spec:
+      {{- if .Values.certs.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.certs.securityContext.runAsUser }}
+        fsGroup: {{ .Values.certs.securityContext.fsGroup }}
+      {{- end }}
+      serviceAccountName: {{ template "dex.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+      - name: main
+        image: "{{ .Values.certs.image }}:{{ .Values.certs.imageTag }}"
+        imagePullPolicy: {{ .Values.certs.imagePullPolicy }}
+        env:
+        - name: HOME
+          value: /tmp
+        workingDir: /tmp
+        command:
+        - /bin/bash
+        - -exc
+        - |
+          cat << EOF > req.cnf
+          [req]
+          req_extensions = v3_req
+          distinguished_name = req_distinguished_name
+
+          [req_distinguished_name]
+
+          [ v3_req ]
+          basicConstraints = CA:FALSE
+          keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+          subjectAltName = @alt_names
+
+          [alt_names]
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.web.altNames }}
+          DNS.{{ $local.i }} = {{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.web.altIPs }}
+          IP.{{ $local.i }} = {{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          EOF
+
+          openssl genrsa -out ca-key.pem 2048;
+          openssl req -x509 -new -nodes -key ca-key.pem -days {{ .Values.certs.web.caDays }} -out ca.pem -subj "/CN=dex-ca";
+
+          openssl genrsa -out key.pem 2048;
+          openssl req -new -key key.pem -out csr.pem -subj "/CN=dex" -config req.cnf;
+          openssl x509 -req -in csr.pem -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -days {{ .Values.certs.web.certDays }} -extensions v3_req -extfile req.cnf;
+
+          kubectl delete configmap {{ $caName | quote }} --namespace {{ .Release.Namespace }} || true
+          kubectl delete secret {{ $caName | quote }} {{ $tlsSecretName }} --namespace {{ .Release.Namespace }} || true
+
+          kubectl create configmap {{ $caName | quote }} --namespace {{ .Release.Namespace }} --from-file dex-ca.pem=ca.pem;
+          kubectl create secret tls {{ $caName | quote }} --namespace {{ .Release.Namespace }} --cert=ca.pem --key=ca-key.pem;
+          kubectl create secret tls {{ $tlsSecretName }} --namespace {{ .Release.Namespace }} --cert=cert.pem --key=key.pem;
+{{- if .Values.inMiniKube }}
+          cp -a ca.pem /var/lib/localkube/oidc.pem
+        volumeMounts:
+        - mountPath: /var/lib/localkube
+          name: localkube
+      volumes:
+      - name: localkube
+        hostPath:
+          path: /var/lib/localkube
+{{- end }}
+{{- end }}

--- a/stable/dex/templates/poddisruptionbudget.yaml
+++ b/stable/dex/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "dex.fullname" . }}
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "dex.name" . }}
+      release: "{{ .Release.Name }}"
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/stable/dex/templates/role.yaml
+++ b/stable/dex/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+{{- if or .Values.certs.grpc.create .Values.certs.web.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["create", "delete"]
+{{- end -}}
+{{- end -}}

--- a/stable/dex/templates/rolebinding.yaml
+++ b/stable/dex/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.create }}
+{{- if or .Values.certs.grpc.create .Values.certs.web.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "dex.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dex.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/stable/dex/templates/secret.yaml
+++ b/stable/dex/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.fullname" . }}
+data:
+  config.yaml: {{ toYaml .Values.config | b64enc }}

--- a/stable/dex/templates/service.yaml
+++ b/stable/dex/templates/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dex.fullname" . }}
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type}}
+  sessionAffinity: None
+  ports:
+{{- range .Values.ports }}
+  - name: {{ .name }} 
+    port: {{ .containerPort }}
+    targetPort: {{ .containerPort}}
+{{- if and (eq "NodePort" $.Values.service.type) (hasKey . "nodePort") }}
+    nodePort: {{ .nodePort }}
+{{- end}}
+{{- end}}
+{{- if hasKey .Values.service "externalIPs" }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "dex.name" . }}
+    release: {{ .Release.Name | quote }}

--- a/stable/dex/templates/serviceaccount.yaml
+++ b/stable/dex/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dex.serviceAccountName" . }}
+{{- end -}}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -1,0 +1,165 @@
+# Default values for dex
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+image: quay.io/dexidp/dex
+imageTag: "v2.17.0"
+imagePullPolicy: "IfNotPresent"
+
+inMiniKube: false
+
+nodeSelector: {}
+
+podAnnotations: {}
+
+initContainers: []
+
+tolerations: []
+  # - key: CriticalAddonsOnly
+  #   operator: Exists
+  # - key: foo
+  #   operator: Equal
+  #   value: bar
+  #   effect: NoSchedule
+
+replicas: 1
+
+# resources:
+  # limits:
+    # cpu: 100m
+    # memory: 50Mi
+  # requests:
+    # cpu: 100m
+    # memory: 50Mi
+
+ports:
+  - name: http
+    containerPort: 8080
+    protocol: TCP
+#   nodePort: 32080
+  - name: grpc
+    containerPort: 5000
+    protocol: TCP
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - dex.example.com
+  tls: []
+  #  - secretName: dex-example-tls
+  #    hosts:
+  #      - dex.example.com
+
+extraVolumes: []
+extraVolumeMounts: []
+
+certs:
+  securityContext:
+    enabled: true
+    runAsUser: 65534
+    fsGroup: 65534
+  image: gcr.io/google_containers/kubernetes-dashboard-init-amd64
+  imageTag: "v1.0.0"
+  imagePullPolicy: "IfNotPresent"
+  web:
+    create: true
+    activeDeadlineSeconds: 300
+    caDays: 10000
+    certDays: 10000
+    altNames:
+      - dex.io
+    altIPs: {}
+    secret:
+      tlsName: dex-web-server-tls
+      caName: dex-web-server-ca
+  grpc:
+    create: true
+    activeDeadlineSeconds: 300
+    altNames:
+      - dex.io
+    altIPs: {}
+    secret:
+      serverTlsName: dex-grpc-server-tls
+      clientTlsName: dex-grpc-client-tls
+      caName: dex-grpc-ca
+
+env: []
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+affinity: {}
+  # podAntiAffinity:
+  #   preferredDuringSchedulingIgnoredDuringExecution:
+  #   - weight: 5
+  #     podAffinityTerm:
+  #       topologyKey: "kubernetes.io/hostname"
+  #       labelSelector:
+  #         matchLabels:
+  #           app: {{ template "dex.name" . }}
+  #           release: "{{ .Release.Name }}"
+
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+
+config:
+  issuer: http://dex.io:8080
+  storage:
+    type: kubernetes
+    config:
+      inCluster: true
+  logger:
+    level: debug
+  web:
+    http: 0.0.0.0:8080
+#   tlsCert: /etc/dex/tls/https/server/tls.crt
+#   tlsKey: /etc/dex/tls/https/server/tls.key
+  grpc:
+    addr: 0.0.0.0:5000
+    tlsCert: /etc/dex/tls/grpc/server/tls.crt
+    tlsKey: /etc/dex/tls/grpc/server/tls.key
+    tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
+  connectors:
+#  - type: github
+#    id: github
+#    name: GitHub
+#    config:
+#      clientID: xxxxxxxxxxxxxxx
+#      clientSecret: yyyyyyyyyyyyyyyyyyyyy
+#      redirectURI: https://dex.minikube.local:5556/callback
+#      org: kubernetes
+  oauth2:
+    skipApprovalScreen: true
+
+#  staticClients:
+#  - id: example-app
+#    redirectURIs:
+#    - 'http://192.168.42.219:31850/oauth2/callback'
+#    name: 'Example App'
+#    secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+#
+  enablePasswordDB: true
+# staticPasswords:
+#  - email: "admin@example.com"
+#    # bcrypt hash of the string "password"
+#    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+#    username: "admin"
+#    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/COPS-4881

Adds support for `initContainers` to official `stable/dex` helm chart. This is necessary in order to migrate `extrasteps` from `kubeadsons` repository.

The chart version has been bumped to `1.5.2` from `1.5.1`.