### PR TITLE
remove ssh cruft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ stablerepo: $(STABLE_TARGETS) | docs/stable/index.yaml
 .PHONY: publish
 publish:
 	@git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1 || true
-	@ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
-	@chmod 0644 /etc/ssh/ssh_known_hosts
 	@git branch -d master >/dev/null 2>&1 || true
 	@git checkout -B master
 	@git pull --rebase publish master -s recursive -X theirs


### PR DESCRIPTION
Since we're now using the https uri for publishing, we no longer need these ssh commands.