### PR TITLE
should not deploy ops-portal-secret

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.1.3
+version: 0.1.4
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/configmap.yaml
+++ b/staging/traefik-forward-auth/templates/configmap.yaml
@@ -4,6 +4,6 @@ metadata:
   name: {{ .Release.Name }}-configmap
 data:
   config: |
-    client-id = {{ required "traefikForwardAuth.clientId is required" .Values.traefikForwardAuth.clientId }}
+    client-id = {{ required "A valid clientId is required" .Values.traefikForwardAuth.clientId }}
     user-cookie-name = {{ required "traefikForwardAuth.userCookieName is required" .Values.traefikForwardAuth.userCookieName }}
     {{ .Values.traefikForwardAuth.extraConfig | nindent 4 }}

--- a/staging/traefik-forward-auth/templates/secret.yaml
+++ b/staging/traefik-forward-auth/templates/secret.yaml
@@ -6,17 +6,3 @@ type: Opaque
 data:
   clientSecret: {{ required "traefikForwardAuth.clientSecret is required" .Values.traefikForwardAuth.clientSecret.value | b64enc | quote }}
   secret: {{ required "traefikForwardAuth.secret is required" .Values.traefikForwardAuth.secret | b64enc | quote }}
-
-{{- if .Values.traefikForwardAuth.opsPortalSecret.enable }}
----
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: ops-portal-credentials
-data:
-  # cGxhY2Vob2xkZXIK is "placeholder" and will be regenerated before container deployment
-  # TODO: this should be reworked to not require the placeholder (see: DCOS-56555)
-  username: cGxhY2Vob2xkZXIK
-  password: cGxhY2Vob2xkZXIK
-{{- end}}

--- a/staging/traefik-forward-auth/templates/secret.yaml
+++ b/staging/traefik-forward-auth/templates/secret.yaml
@@ -6,6 +6,8 @@ type: Opaque
 data:
   clientSecret: {{ required "traefikForwardAuth.clientSecret is required" .Values.traefikForwardAuth.clientSecret.value | b64enc | quote }}
   secret: {{ required "traefikForwardAuth.secret is required" .Values.traefikForwardAuth.secret | b64enc | quote }}
+
+{{- if .Values.traefikForwardAuth.opsPortalSecret.enable }}
 ---
 apiVersion: v1
 kind: Secret
@@ -17,3 +19,4 @@ data:
   # TODO: this should be reworked to not require the placeholder (see: DCOS-56555)
   username: cGxhY2Vob2xkZXIK
   password: cGxhY2Vob2xkZXIK
+{{- end}}

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -25,8 +25,6 @@ traefikForwardAuth:
         name: secretName
         key: secretKey
   secret: "do-not-use"
-  opsPortalSecret:
-    enable: false
   # https only?
   cookieSecure: false
   domain:

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -25,6 +25,8 @@ traefikForwardAuth:
         name: secretName
         key: secretKey
   secret: "do-not-use"
+  opsPortalSecret:
+    enable: false
   # https only?
   cookieSecure: false
   domain:


### PR DESCRIPTION
I may be mistaken, but other tools will create this secret, we probably should not create it in production as it will break and fail to deploy. 