### PR TITLE
kommander: add conditional to install the CRD

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.47.2"
 description: Kommander
-version: 0.1.10
+version: 0.1.11
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/templates/crd.yaml
+++ b/stable/kommander/templates/crd.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.createObservableClusterCRD) }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -62,3 +63,4 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
+{{ end }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -8,6 +8,9 @@ logoutRedirectPath: /
 # Mode must be either production|konvoy
 mode: production
 
+# Konvoy ui should NOT create the CRD if Kommander already did it
+createObservableClusterCRD: true
+
 extraInitContainers:
 
 resources:


### PR DESCRIPTION
We are seeing this error when installing konvoy-ui and kommander, we should install one time the CRD:
```
konvoy-ui                                                              [ERROR]

konvoy-ui: konvoy-ui failed: exit status 1 [stderr: Error: object is being deleted: customresourcedefinitions.apiextensions.k8s.io "observableclusters.stable.mesosphere.com" already exists
]
```