### PR TITLE
chore: fix ops portal and kommander charts

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.47.2"
 description: Kommander
-version: 0.1.11
+version: 0.1.12
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/templates/ingress.yaml
+++ b/stable/kommander/templates/ingress.yaml
@@ -10,18 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     kubernetes.io/ingress.class: traefik
-{{- if (eq "konvoy" .Values.mode) }}
-    traefik.ingress.kubernetes.io/priority: "1"
-    traefik.ingress.kubernetes.io/redirect-permanent: "true"
-    traefik.ingress.kubernetes.io/redirect-regex: ^https://([^/]*)/ops/portal$
-    traefik.ingress.kubernetes.io/redirect-replacement: https://$1/ops/portal/
-    traefik.ingress.kubernetes.io/request-modifier: 'ReplacePathRegex: ^/ops/portal/(.*) /$1'
-{{- else }}
     traefik.frontend.rule.type: {{ .Values.ingress.traefikFrontendRuleType }}
     {{- with .Values.ingress.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- end }}
 spec:
   rules:
     - http:

--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0.0"
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.0.4
+version: 0.0.5
 maintainers:
   - name: hectorj2f

--- a/stable/opsportal/templates/ingress-opsportal.yaml
+++ b/stable/opsportal/templates/ingress-opsportal.yaml
@@ -6,6 +6,9 @@ metadata:
     kubernetes.io/ingress.class: traefik
     traefik.frontend.rule.type: PathPrefixStrip
     traefik.ingress.kubernetes.io/priority: "2"
+    traefik.ingress.kubernetes.io/auth-type: forward
+    traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+    traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
   name: {{ template "opsportal.fullname" . }}-addons
   namespace: {{ .Release.Namespace }}
 spec:

--- a/stable/opsportal/templates/landing.yaml
+++ b/stable/opsportal/templates/landing.yaml
@@ -31,7 +31,7 @@ spec:
           - backend:
               serviceName: opsportal-landing
               servicePort: 80
-            path: /landing
+            path: /ops/landing
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fix the traefik related annotations. Some traefik forward auth related
configurations should be moved to kubeaddons-configs.