### PR TITLE
fix: change logout redirect to '/landing' in kommander

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.50.0"
 description: Kommander
-version: 0.1.13
+version: 0.1.14
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -3,7 +3,7 @@ image:
   tag: 1.50.0
   pullPolicy: IfNotPresent
 replicas: 1
-logoutRedirectPath: /
+logoutRedirectPath: /ops/landing
 
 # Mode must be either production|konvoy
 mode: production


### PR DESCRIPTION
Redirect to on logout `/` leads to 404. Redirect to `/landing` instead.