### PR TITLE
dex-k8s-authenticator: avoid using subPath for the secret

### DIFF
--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -7,9 +7,5 @@ home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mintel/dex-k8s-authenticator
 maintainers:
-- name: Martin Hrabovcin
-# Original maintainers from `mintel/dex-k8s-authenticator` repository
-- name: Aaron Roydhouse
-  email: aaron@roydhouse.com
-- name: Nick Badger
-  email: nbadger@mintel.com
+- name: mhrabovcin
+  email: mhrabovcin.c@mesosphere.com

--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 appVersion: "v1.1.0"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.1.3
+version: 1.1.4
+home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mintel/dex-k8s-authenticator
 maintainers:
 - name: Martin Hrabovcin
-  email: mhrabovcin.c@mesosphere.com
 # Original maintainers from `mintel/dex-k8s-authenticator` repository
 - name: Aaron Roydhouse
   email: aaron@roydhouse.com

--- a/staging/dex-k8s-authenticator/templates/deployment.yaml
+++ b/staging/dex-k8s-authenticator/templates/deployment.yaml
@@ -63,8 +63,7 @@ spec:
 {{- if .Values.caCerts.enabled }}
 {{- range .Values.caCerts.secrets }}
         - name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
-          subPath: {{ .name }}
-          mountPath: /certs/{{ .filename }}
+          mountPath: /certs/
 {{- end }}
 {{- end }}
         resources:
@@ -93,5 +92,8 @@ spec:
       - name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
         secret:
           secretName: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
+          items:
+          - key: {{ .name }}
+            path: {{ .filename }}
 {{- end }}
 {{- end }}

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -21,9 +21,9 @@ dexK8sAuthenticator:
     periodSeconds: 10
     initialDelaySeconds: 10
   web_path_prefix: /
-  #logoUrl: http://<path-to-your-logo.png>
-  #tlsCert: /path/to/dex-client.crt
-  #tlsKey: /path/to/dex-client.key
+  # logoUrl: http://<path-to-your-logo.png>
+  # tlsCert: /path/to/dex-client.crt
+  # tlsKey: /path/to/dex-client.key
   clusters:
   - name: my-cluster
     short_description: "My Cluster"
@@ -84,13 +84,13 @@ caCerts:
   #
   #     value: The base64 encoded value of the CA
   #
-  #secrets:
-  #- name: ca-cert1
-  #  filename: ca1.crt
-  #  value: LS0tLS1......X2F
-  #- name: ca-cert2
-  #  filename: ca2.crt
-  #  value: DS1tFA1......X2F
+  # secrets:
+  # - name: ca-cert1
+  #   filename: ca1.crt
+  #   value: LS0tLS1......X2F
+  # - name: ca-cert2
+  #   filename: ca2.crt
+  #   value: DS1tFA1......X2F
 
 
 nodeSelector: {}


### PR DESCRIPTION
The cleanup of the subpath for this secret resulted in a problem when terminating the pod. This change should work the same without using `subPath`.

```
Jul 22 12:01:19 out-darwin-9d9b-worker-pool0-1 kubelet[686]: E0722 12:01:19.110863     686 nestedpendingoperations.go:270] Operation for "\"kubernetes.io/secret/5729f513-0433-4c56-a8b6-aafa9cbd4289-dex-k8s-authenticator-kubeaddons-dex-root-ca\" (\"5729f513-0433-4c56-a8b6-aafa9cbd4289\")" failed. No retries permitted until 2019-07-22 12:02:23.1108117 +0000 UTC m=+4373.047820401 (durationBeforeRetry 1m4s). Error: "error cleaning subPath mounts for volume \"dex-k8s-authenticator-kubeaddons-dex-root-ca\" (UniqueName: \"kubernetes.io/secret/5729f513-0433-4c56-a8b6-aafa9cbd4289-dex-k8s-authenticator-kubeaddons-dex-root-ca\") pod \"5729f513-0433-4c56-a8b6-aafa9cbd4289\" (UID: \"5729f513-0433-4c56-a8b6-aafa9cbd4289\") : error processing /var/lib/kubelet/pods/5729f513-0433-4c56-a8b6-aafa9cbd4289/volume-subpaths/dex-k8s-authenticator-kubeaddons-dex-root-ca/dex-k8s-authenticator: error cleaning subpath mount /var/lib/kubelet/pods/5729f513-0433-4c56-a8b6-aafa9cbd4289/volume-subpaths/dex-k8s-authenticator-kubeaddons-dex-root-ca/dex-k8s-authenticator/7: Unmount failed: exit status 32\nUnmounting arguments: /var/lib/kubelet/pods/5729f513-0433-4c56-a8b6-aafa9cbd4289/volume-subpaths/dex-k8s-authenticator-kubeaddons-dex-root-ca/dex-k8s-authenticator/7\nOutput: umount: /var/lib/kubelet/pods/5729f513-0433-4c56-a8b6-aafa9cbd4289/volume-subpaths/dex-k8s-authenticator-kubeaddons-dex-root-ca/dex-k8s-authenticator/7: not mounted\n\n"
```