### PR TITLE
Add service monitor label to kommander

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.50.0"
 description: Kommander
-version: 0.1.14
+version: 0.1.15
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/templates/service.yaml
+++ b/stable/kommander/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.name }}"
     heritage: "{{ .Release.Service }}"
+    servicemonitor.kubeaddons.mesosphere.io/path: metrics
 spec:
   ports:
     - name: metrics


### PR DESCRIPTION
Add the service monitor label to get kommander metrics automatically scraped by prometheus