### PR TITLE
dex-k8s-authenticator: stop using subPath in general for dex-k8s-auth

### DIFF
--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.1.0"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.1.4
+version: 1.1.5
 home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mintel/dex-k8s-authenticator

--- a/staging/dex-k8s-authenticator/README.md
+++ b/staging/dex-k8s-authenticator/README.md
@@ -1,7 +1,10 @@
 # Helm chart for dex-k8s-authenticator
 
-This chart installs [`dex-k8s-authenticator`](https://github.com/mintel/dex-k8s-authenticator) in a Kubernetes cluster. 
-`dex-k8s-authenticator` is a helper application for [`dex`](https://github.com/coreos/dex). `dex` lets you use external 
+**IMPORTANT**: We have changed the original chart template to avoid using subPaths due to the
+issues while mounting and unmounting this type of volumes in certain OS.
+
+This chart installs [`dex-k8s-authenticator`](https://github.com/mintel/dex-k8s-authenticator) in a Kubernetes cluster.
+`dex-k8s-authenticator` is a helper application for [`dex`](https://github.com/coreos/dex). `dex` lets you use external
 Identify Providers (like Google, Microsoft, GitHUb, LDAP) to authenticate access to Kubernetes cluster
 (e.g. for `kubectl`). This helper makes it easy to provide a web UI for one or more clusters.
 It give uses the information and commands to configure `kubectl` to work with the credentials `dex` provides.
@@ -70,14 +73,14 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
-caCerts: 
+caCerts:
   enabled: false
   secrets: {}
   # Array of Self Signed Certificates
   # cat CA.crt | base64 -w 0
   #
-  #     name: The internal k8s name of the secret we create. It's also used in 
-  #     the volumeMount name. It must respect the k8s naming convension (avoid 
+  #     name: The internal k8s name of the secret we create. It's also used in
+  #     the volumeMount name. It must respect the k8s naming convension (avoid
   #     upper-case and '.' to be safe).
   #
   #     filename: The filename of the CA to be mounted. It must end in .crt for

--- a/staging/dex-k8s-authenticator/templates/deployment.yaml
+++ b/staging/dex-k8s-authenticator/templates/deployment.yaml
@@ -53,13 +53,9 @@ spec:
             port: http
         volumeMounts:
         - name: config
-          subPath: config.yaml
           mountPath: /app/config.yaml
-{{- range $path, $bytes :=  .Files.Glob "html-templates/*" }}
         - name: html-templates
-          subPath: {{ base $path }}
-          mountPath: /app/templates/{{ base $path }}
-{{- end }}
+          mountPath: /app/templates/
 {{- if .Values.caCerts.enabled }}
 {{- range .Values.caCerts.secrets }}
         - name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
@@ -84,9 +80,17 @@ spec:
       - name: config
         configMap:
           name: {{ template "dex-k8s-authenticator.fullname" . }}
+          items:
+          - key: config.yaml
+            path: config.yaml
       - name: html-templates
         configMap:
           name: {{ template "dex-k8s-authenticator.fullname" . }}-html-templates
+          items:
+{{- range $path, $bytes :=  .Files.Glob "html-templates/*" }}
+          - key: {{ base $path }}
+            path: {{ base $path }}
+{{- end }}
 {{- if .Values.caCerts.enabled }}
 {{- range .Values.caCerts.secrets }}
       - name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}

--- a/staging/dex-k8s-authenticator/templates/deployment.yaml
+++ b/staging/dex-k8s-authenticator/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: [ "--config", "config.yaml" ]
+        args: [ "--config", "/app/configuration/config.yaml" ]
         ports:
         - name: http
           containerPort: {{ default "5555" .Values.dexK8sAuthenticator.port }}
@@ -53,7 +53,7 @@ spec:
             port: http
         volumeMounts:
         - name: config
-          mountPath: /app/config.yaml
+          mountPath: /app/configuration/
         - name: html-templates
           mountPath: /app/templates/
 {{- if .Values.caCerts.enabled }}


### PR DESCRIPTION
I proposed to stay away of subPath volumes in general to avoid issues when mounting/unmounting vols on multiple OS and environments.
related issues: 
https://github.com/kubernetes/kubernetes/issues/50345 
https://github.com/kubernetes/kubernetes/issues/72991#issuecomment-508132380
also this one #60 