### PR TITLE
stable/storage charts: set tolerations and critical priority

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -5,7 +5,7 @@ name: awsebscsiprovisioner
 maintainers:
   - name: alejandroEsc
   - name: gpaul
-version: 0.2.4
+version: 0.2.5
 kubeVersion: ">=1.13.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/templates/daemonset.yaml
+++ b/stable/awsebscsiprovisioner/templates/daemonset.yaml
@@ -20,6 +20,12 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
+        # Make sure csi-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
       containers:

--- a/stable/awsebscsiprovisioner/templates/daemonset.yaml
+++ b/stable/awsebscsiprovisioner/templates/daemonset.yaml
@@ -19,15 +19,10 @@ spec:
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
+{{- if .Values.tolerations }}
       tolerations:
-        # Make sure csi-node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
       containers:
         - name: ebs-plugin
           securityContext:

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -10,6 +10,14 @@ liveness:
     repository: "quay.io/k8scsi/livenessprobe"
     tag: "v1.1.0"
 
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+
 registrar:
   node:
     image:

--- a/stable/localvolumeprovisioner/Chart.yaml
+++ b/stable/localvolumeprovisioner/Chart.yaml
@@ -3,6 +3,6 @@ name: localvolumeprovisioner
 home: https://github.com/mesosphere/charts
 appVersion: "1.0"
 description: Local persistent volume provisioner for konvoy
-version: 0.2.1
+version: 0.2.2
 maintainers:
   - name: s12chung

--- a/stable/localvolumeprovisioner/templates/daemonset.yaml
+++ b/stable/localvolumeprovisioner/templates/daemonset.yaml
@@ -12,16 +12,11 @@ spec:
       labels:
         app: local-volume-provisioner
     spec:
+{{- if .Values.tolerations }}
       tolerations:
-        # Make sure csi-node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-      priorityClassName: system-node-critical
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+      priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: local-volume-provisioner-service-account
       containers:
         - name: local-volume-provisioner

--- a/stable/localvolumeprovisioner/templates/daemonset.yaml
+++ b/stable/localvolumeprovisioner/templates/daemonset.yaml
@@ -12,6 +12,16 @@ spec:
       labels:
         app: local-volume-provisioner
     spec:
+      tolerations:
+        # Make sure csi-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+      priorityClassName: system-node-critical
       serviceAccountName: local-volume-provisioner-service-account
       containers:
         - name: local-volume-provisioner

--- a/stable/localvolumeprovisioner/values.yaml
+++ b/stable/localvolumeprovisioner/values.yaml
@@ -7,3 +7,13 @@ storageclass:
   isDefault: true
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
+
+priorityClassName: system-node-critical
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists


### PR DESCRIPTION
During our mwt tests, we found that the pods were not deployed in all the nodes. Besides I found that the priority class of the localvolumeprovisioner pod is not set as a priority class.