### PR TITLE
Add staging/velero with Minio backend support

### DIFF
--- a/staging/velero/.helmignore
+++ b/staging/velero/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: 1.0.0
+description: A Helm chart for velero
+home: https://github.com/heptio/velero
+icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
+maintainers:
+- email: d-caruso@hotmail.it
+  name: domcar
+- email: hfernandez@mesosphere.com
+  name: hectorj2f
+- email: brubakern@vmware.com
+  name: nrb
+- email: aadnan@vmware.com
+  name: prydonius
+name: velero
+sources:
+- https://github.com/heptio/velero
+tillerVersion: '>=2.10.0'
+version: 2.1.1

--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -16,4 +16,4 @@ name: velero
 sources:
 - https://github.com/heptio/velero
 tillerVersion: '>=2.10.0'
-version: 2.1.1
+version: 2.1.2

--- a/staging/velero/OWNERS
+++ b/staging/velero/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- hectorj2f
+- nrb
+- prydonius
+reviewers:
+- hectorj2f
+- nrb
+- prydonius

--- a/staging/velero/README.md
+++ b/staging/velero/README.md
@@ -1,0 +1,106 @@
+# Velero-server
+
+This helm chart installs Velero version v1.0.0
+https://github.com/heptio/velero/tree/v1.0.0
+
+
+## Upgrading to v1.0.0
+
+As of v1.0.0, Heptio Velero is no longer backwards-compatible with Heptio Ark.
+
+The [instructions found here](https://velero.io/docs/v1.0.0/upgrade-to-1.0/) will assist you in upgrading from version v0.11.0 to v1.0.0
+
+## Upgrading to v0.11.0
+
+As of v0.11.0, Heptio Ark has become Velero.
+
+The [instructions found here](https://velero.io/docs/v0.11.0/migrating-to-velero/) will assist you in upgrading from Ark to Velero
+
+## Prerequisites
+
+### Secret for cloud provider credentials
+Velero server needs an IAM service account in order to run, if you don't have it you must create it.
+Please follow the official documentation: https://velero.io/docs/v1.0.0/install-overview/
+
+Don't forget the step to create the secret
+```
+kubectl create secret generic cloud-credentials --namespace <VELERO_NAMESPACE> --from-file cloud=credentials-velero
+```
+
+### Configuration
+Please change the values.yaml according to your setup
+See here for the official documentation https://velero.io/docs/v1.0.0/install-overview/
+
+#### Required Parameters
+Parameter | Description | Default | Required
+--- | --- | --- | ---
+`configuration.provider` | The name of the cloud provider where you are deploying velero to (`aws`, `azure`, `gcp`) | none | yes
+`configuration.backupStorageLocation.name` | The name of the cloud provider that will be used to actually store the backups (`aws`, `azure`, `gcp`) | none | yes
+`configuration.backupStorageLocation.bucket` | The storage bucket where backups are to be uploaded | none | yes
+`configuration.backupStorageLocation.config.region` | The cloud provider region (AWS only) | none | yes, if using AWS
+`configuration.backupStorageLocation.config.resourceGroup` | The resource group containing the storage account (Azure only) | none | yes, if using Azure
+`configuration.backupStorageLocation.config.storageAccount` | The storage account containing the blob container (Azure only) | none | yes, if using Azure
+`configuration.volumeSnapshotLocation.name` | The name of the cloud provider the cluster is using for persistent volumes, if any | none | yes, if using PV snapshots
+`configuration.volumeSnapshotLocation.config.region` | The cloud provider region (AWS only) | none | yes, if using AWS
+`configuration.volumeSnapshotLocation.config.apitimeout` | The API timeout (Azure only) | none | yes, if using Azure
+`credentials.useSecret` | Whether a secret should be used for IAM credentials. Set this to `false` when using `kube2iam` | `true` | yes
+`credentials.existingSecret` | If specified and `useSecret` is `true`, uses an existing secret with this name instead of creating one | none | yes, if `useSecret` is `true` and `secretContents` is empty
+`credentials.secretContents` | If specified and `useSecret` is `true`, contents for the credentials secret | none | yes, if `useSecret` is `true` and `existingSecret` is empty
+
+#### All Parameters
+Parameter | Description | Default
+--- | --- | ---
+`image.repository` | Image repository | `gcr.io/heptio-images/velero`
+`image.tag` | Image tag | `v1.0.0`
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`podAnnotations` | Annotations for the Velero server pod | `{}`
+`rbac.create` | If true, create and use RBAC resources | `true`
+`rbac.server.serviceAccount.create` | Whether a new service account name that the server will use should be created | `true`
+`rbac.server.serviceAccount.name` | Service account to be used for the server. If not set and `rbac.server.serviceAccount.create` is `true` a name is generated using the fullname template | ``
+`resources` | Resource requests and limits | `{}`
+`initContainers` | InitContainers and their specs to start with the deployment pod | `[]`
+`tolerations` | List of node taints to tolerate | `[]`
+`nodeSelector` | Node labels for pod assignment | `{}`
+`configuration.backupStorageLocation.name` | The name of the cloud provider that will be used to actually store the backups (`aws`, `azure`, `gcp`) | ``
+`configuration.backupStorageLocation.bucket` | The storage bucket where backups are to be uploaded | ``
+`configuration.backupStorageLocation.config.region` | The cloud provider region (AWS only) | ``
+`configuration.backupStorageLocation.config.s3ForcePathStyle` | Set to `true` for a local storage service like Minio | ``
+`configuration.backupStorageLocation.config.s3Url` | S3 url (primarily used for local storage services like Minio) | ``
+`configuration.backupStorageLocation.config.kmsKeyId` | KMS key for encryption (AWS only) | ``
+`configuration.backupStorageLocation.config.resourceGroup` | The resource group containing the storage account (Azure only) | ``
+`configuration.backupStorageLocation.config.storageAccount` | The storage account containing the blob container (Azure only) | ``
+`configuration.backupStorageLocation.prefix` | The directory inside a storage bucket where backups are to be uploaded | ``
+`configuration.backupSyncPeriod` | How frequently Velero queries the object storage to make sure that the appropriate Backup resources have been created for existing backup files | (uses `velero server` default)
+`configuration.extraEnvVars` | Key/values for extra environment variables such as AWS_CLUSTER_NAME, etc | `{}`
+`configuration.provider` | The name of the cloud provider where you are deploying velero to (`aws`, `azure`, `gcp`) |
+`configuration.restoreResourcePriorities` | An ordered list that describes the order in which Kubernetes resource objects should be restored | (uses `velero server` default)
+`configuration.resticTimeout` | How long backups/restores of pod volumes should be allowed to run before timing out. | (uses `velero server` default)
+`configuration.restoreOnlyMode` | When RestoreOnly mode is on, functionality for backups, schedules, and expired backup deletion is turned off. Restores are made from existing backup files in object storage | (uses `velero server` default)
+`configuration.volumeSnapshotLocation.name` | The name of the cloud provider the cluster is using for persistent volumes, if any | `{}`
+`configuration.volumeSnapshotLocation.config.region` | The cloud provider region (AWS only) | ``
+`configuration.volumeSnapshotLocation.config.apitimeout` | The API timeout (`azure` only) |
+`configuration.volumeSnapshotLocation.config.resourceGroup` | The name of the resource group where volume snapshots should be stored, if different from the cluster’s resource group. (Azure only) |
+`configuration.volumeSnapshotLocation.config.project` | The project ID where snapshots should be stored, if different than the project that your IAM account is in. (GCP only) |
+`configuration.volumeSnapshotLocation.config.snapshotLocation` | The location where the snapshots will be stored. (GCP only) |
+`credentials.existingSecret` | If specified and `useSecret` is `true`, uses an existing secret with this name instead of creating one | ``
+`credentials.useSecret` | Whether a secret should be used. Set this to `false` when using `kube2iam` | `true`
+`credentials.secretContents` | Contents for the credentials secret | `{}`
+`snapshotsEnabled` | If `true`, create volumesnapshotlocation crd. Set this to `false` to disable snapshot feature | `true`
+`deployRestic` | If `true`, enable restic deployment | `false`
+`metrics.enabled` | Set this to `true` to enable exporting Prometheus monitoring metrics | `false`
+`metrics.scrapeInterval` | Scrape interval for the Prometheus ServiceMonitor | `30s`
+`metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
+`metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
+`schedules` | A dict of schedules | `{}`
+`restic.podVolumePath` | Location of pod volumes on the host | `/var/lib/kubelet/pods`
+`restic.privileged` | Whether restic should run as a privileged pod. Only necessary in special cases (SELinux) | `false`
+`restic.resources` | Restic DaemonSet resource requests and limits | `{}`
+`configMaps` | Velero ConfigMaps | `[]`
+
+## How to
+```
+helm install --name velero --namespace velero ./velero
+```
+
+## Remove heptio/velero
+Remember that when you remove Velero all backups remain untouched

--- a/staging/velero/README.md
+++ b/staging/velero/README.md
@@ -96,6 +96,7 @@ Parameter | Description | Default
 `restic.privileged` | Whether restic should run as a privileged pod. Only necessary in special cases (SELinux) | `false`
 `restic.resources` | Restic DaemonSet resource requests and limits | `{}`
 `configMaps` | Velero ConfigMaps | `[]`
+`minioBackend` | Enable Minio Backend | `false`
 
 ## How to
 ```

--- a/staging/velero/ci/test-values.yaml
+++ b/staging/velero/ci/test-values.yaml
@@ -1,0 +1,10 @@
+# Set a service account so that the CRD clean up job has proper permissions to delete CRDs
+serviceAccount:
+  server:
+    name: velero
+
+# Whether or not to clean up CustomResourceDefintions when deleting a release.
+# Cleaning up CRDs will delete the BackupStorageLocation and VolumeSnapshotLocation instances, which would have to be reconfigured.
+# Backup data in object storage will _not_ be deleted, however Backup instances in the Kubernetes API will.
+# Always clean up CRDs in CI.
+cleanUpCRDs: true

--- a/staging/velero/templates/NOTES.txt
+++ b/staging/velero/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Check that the velero is up and running:
+
+    kubectl get deployment/{{ include "velero.fullname" . }} -n {{ .Release.Namespace }}
+
+Check that the secret has been created:
+
+    kubectl get secret/{{ include "velero.fullname" . }} -n {{ .Release.Namespace }}
+
+Once velero server is up and running you need the client before you can use it
+1. wget https://github.com/heptio/velero/releases/download/{{ .Values.image.tag }}/velero-{{ .Values.image.tag }}-darwin-amd64.tar.gz
+2. tar -xvf velero-{{ .Values.image.tag }}-darwin-amd64.tar.gz -C velero-client
+
+More info on the official site: https://github.com/heptio/velero#install-client

--- a/staging/velero/templates/_helpers.tpl
+++ b/staging/velero/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "velero.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "velero.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "velero.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for creating or deleting the velero server
+*/}}
+{{- define "velero.serverServiceAccount" -}}
+{{- if .Values.serviceAccount.server.create -}}
+    {{ default (printf "%s-%s" (include "velero.fullname" .) "server") .Values.serviceAccount.server.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.server.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the credentials secret.
+*/}}
+{{- define "velero.secretName" -}}
+{{- if .Values.credentials.existingSecret -}}
+  {{- .Values.credentials.existingSecret -}}
+{{- else -}}
+  {{- include "velero.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/staging/velero/templates/backups.yaml
+++ b/staging/velero/templates/backups.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backups
+    kind: Backup

--- a/staging/velero/templates/backupstoragelocation.yaml
+++ b/staging/velero/templates/backupstoragelocation.yaml
@@ -1,0 +1,46 @@
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+{{- with .Values.configuration }}
+{{- with .backupStorageLocation }}
+  provider: {{ .name  }}
+  objectStorage:
+    bucket: {{ .bucket  }}
+    {{- with .prefix }}
+    prefix: {{ . }}
+    {{- end }}
+{{- with .config }}
+  config:
+  {{- with .region }}
+    region: {{ . }}
+  {{- end }}
+  {{- with .s3ForcePathStyle }}
+    s3ForcePathStyle: {{ . | quote }}
+  {{- end }}
+  {{- with .s3Url }}
+    s3Url: {{ . }}
+  {{- end }}
+  {{- with .kmsKeyId }}
+    kmsKeyId: {{ . }}
+  {{- end }}
+  {{- with .resourceGroup }}
+    resourceGroup: {{ . }}
+  {{- end }}
+  {{- with .storageAccount }}
+    storageAccount: {{ . }}
+  {{- end }}
+  {{- if .publicUrl }}
+  {{- with .publicUrl }}
+    publicUrl: {{ . }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/staging/velero/templates/backupstoragelocations.yaml
+++ b/staging/velero/templates/backupstoragelocations.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backupstoragelocations.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backupstoragelocations
+    kind: BackupStorageLocation

--- a/staging/velero/templates/cleanup-crds.yaml
+++ b/staging/velero/templates/cleanup-crds.yaml
@@ -1,0 +1,38 @@
+# This job is meant primarily for cleaning up on CI systems.
+# Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
+{{- if .Values.cleanUpCRDs }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "velero.fullname" . }}-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  template:
+    metadata:
+      name: velero-cleanup
+    spec:
+      serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      containers:
+        - name: kubectl
+          image: docker.io/bitnami/kubectl:1.14.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - >
+              kubectl delete restore --all;
+              kubectl delete backup --all;
+              kubectl delete backupstoragelocation --all;
+              kubectl delete volumesnapshotlocation --all;
+              kubectl delete crd -l helm.sh/chart={{ include "velero.chart" . }}
+      restartPolicy: OnFailure
+{{- end }}

--- a/staging/velero/templates/configmaps.yaml
+++ b/staging/velero/templates/configmaps.yaml
@@ -1,0 +1,17 @@
+{{- range $configMapName, $configMap := .Values.configMaps }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "velero.fullname" $ }}-{{ $configMapName }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" $ }}
+  {{- with $configMap.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{- toYaml $configMap.data | nindent 2 }}
+---
+{{- end }}

--- a/staging/velero/templates/deletebackuprequests.yaml
+++ b/staging/velero/templates/deletebackuprequests.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: deletebackuprequests.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: deletebackuprequests
+    kind: DeleteBackupRequest

--- a/staging/velero/templates/deployment.yaml
+++ b/staging/velero/templates/deployment.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.configuration.provider -}}
+{{- $provider := .Values.configuration.provider -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "velero.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "velero.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "velero.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ include "velero.chart" . }}
+    {{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    spec:
+      restartPolicy: Always
+      serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      containers:
+        - name: velero
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.metrics.enabled }}
+          ports:
+            - name: monitoring
+              containerPort: 8085
+          {{- end }}
+          command:
+            - /velero
+          args:
+            - server
+          {{- with .Values.configuration }}
+            {{- with .backupSyncPeriod }}
+            - --backup-sync-period={{ . }}
+            {{- end }}
+            {{- with .resticTimeout }}
+            - --restic-timeout={{ . }}
+            {{- end }}
+            {{- if .restoreOnlyMode }}
+            - --restore-only
+            {{- end }}
+            {{- with .restoreResourcePriorities }}
+            - --restore-resource-priorities={{ . }}
+            {{- end }}
+          {{- end }}
+          {{- if eq $provider "azure" }}
+          envFrom:
+            - secretRef:
+                name: {{ include "velero.secretName" . }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: plugins
+              mountPath: /plugins
+        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+            - name: cloud-credentials
+              mountPath: /credentials
+            - name: scratch
+              mountPath: /scratch
+        {{- end }}
+          {{- if (or (and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp"))) .Values.configuration.extraEnvVars) }}
+          env:
+          {{- end }}
+          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+            {{- if eq $provider "aws" }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+            {{- else }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+            {{- end }}
+              value: /credentials/cloud
+            - name: VELERO_SCRATCH_DIR
+              value: /scratch
+          {{- end }}
+          {{- with .Values.configuration.extraEnvVars }}
+          {{- range $key, $value := . }}
+            - name: {{ default "none" $key }}
+              value: {{ default "none" $value }}
+          {{- end }}
+          {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+{{- end }}
+      volumes:
+        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+        - name: cloud-credentials
+          secret:
+            secretName: {{ include "velero.secretName" . }}
+        {{- end }}
+        - name: plugins
+          emptyDir: {}
+        - name: scratch
+          emptyDir: {}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end -}}

--- a/staging/velero/templates/deployment.yaml
+++ b/staging/velero/templates/deployment.yaml
@@ -98,10 +98,6 @@ spec:
               value: {{ default "none" $value }}
           {{- end }}
           {{- end }}
-{{- if .Values.initContainers }}
-      initContainers:
-        {{- toYaml .Values.initContainers | nindent 8 }}
-{{- end }}
       volumes:
         {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
         - name: cloud-credentials
@@ -120,4 +116,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- if or .Values.initContainers .Values.minioBackend }}
+      initContainers:
+        {{- with .Values.minioBackend }}
+        - name: initialize-velero
+          image: kubeaddons/addon-initializer:v0.0.3-alpha
+          args: ["velero"]
+          env:
+          - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"
+            value: "velero-kubeaddons"
+        {{- end }}
+        {{- with .Values.initContainers }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- end }}
+{{- end }}
 {{- end -}}

--- a/staging/velero/templates/downloadrequests.yaml
+++ b/staging/velero/templates/downloadrequests.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: downloadrequests.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: downloadrequests
+    kind: DownloadRequest

--- a/staging/velero/templates/miniobackend.yaml
+++ b/staging/velero/templates/miniobackend.yaml
@@ -1,0 +1,167 @@
+{{- if .Values.minioBackend -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero-minio-operator
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: minioinstances.miniocontroller.min.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  group: miniocontroller.min.io
+  version: v1beta1
+  names:
+    kind: MinIOInstance
+    plural: minioinstances
+  scope: Namespaced
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: minio-operator-role
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  - pods
+  - services
+  - events
+  verbs:
+  - get
+  - watch
+  - create
+  - list
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - create
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - miniocontroller.min.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - min.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-operator-sa
+  namespace: velero-minio-operator
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: minio-operator-binding
+  namespace: velero-minio-operator
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-operator-role
+subjects:
+- kind: ServiceAccount
+  name: minio-operator-sa
+  namespace: velero-minio-operator
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: minio-operator
+  namespace: velero-minio-operator
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: minio-operator
+    spec:
+      serviceAccountName: minio-operator-sa
+      containers:
+      - name: minio-operator
+        image: kubeaddons/minio-operator:v0.0.1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-minio-instance-management
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["miniocontroller.min.io"]
+  resources: ["minioinstances"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["velero.io"]
+  resources: ["backupstoragelocations"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: velero-minio-instance-management
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: velero-minio-instance-management
+{{- end -}}

--- a/staging/velero/templates/podvolumebackups.yaml
+++ b/staging/velero/templates/podvolumebackups.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumebackups.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: podvolumebackups
+    kind: PodVolumeBackup

--- a/staging/velero/templates/podvolumerestores.yaml
+++ b/staging/velero/templates/podvolumerestores.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumerestores.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: podvolumerestores
+    kind: PodVolumeRestore

--- a/staging/velero/templates/rbac.yaml
+++ b/staging/velero/templates/rbac.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "velero.fullname" . }}-server
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "velero.serverServiceAccount" . }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/staging/velero/templates/restic-daemonset.yaml
+++ b/staging/velero/templates/restic-daemonset.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.deployRestic }}
+{{- $provider := .Values.configuration.provider -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: restic
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      name: restic
+  template:
+    metadata:
+      labels:
+        name: restic
+        app.kubernetes.io/name: {{ include "velero.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ include "velero.chart" . }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.serviceAccount.server.create }}
+      serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      {{- end }}
+      securityContext:
+        runAsUser: 0
+      volumes:
+        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+        - name: cloud-credentials
+          secret:
+            secretName: {{ include "velero.secretName" . }}
+        {{- end }}
+        - name: host-pods
+          hostPath:
+            path: {{ .Values.restic.podVolumePath }}
+        - name: scratch
+          emptyDir: {}
+      containers:
+        - name: velero
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /velero
+          args:
+            - restic
+            - server
+          volumeMounts:
+            {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+            - name: cloud-credentials
+              mountPath: /credentials
+            {{- end }}
+            - name: host-pods
+              mountPath: /host_pods
+              mountPropagation: HostToContainer
+            - name: scratch
+              mountPath: /scratch
+          {{- if and .Values.credentials.useSecret (eq $provider "azure") }}
+          envFrom:
+            - secretRef:
+                name: {{ include "velero.secretName" . }}
+          {{- end }}
+          env:
+            - name: VELERO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: VELERO_SCRATCH_DIR
+              value: /scratch
+            {{- if eq $provider "aws" }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+            {{- end }}
+            {{- if eq $provider "gcp" }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /credentials/cloud
+            {{- end }}
+            {{- if eq $provider "minio" }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+            {{- end }}
+          securityContext:
+            privileged: {{ .Values.restic.privileged }}
+          {{- with .Values.restic.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/staging/velero/templates/resticrepositories.yaml
+++ b/staging/velero/templates/resticrepositories.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resticrepositories.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: resticrepositories
+    kind: ResticRepository

--- a/staging/velero/templates/restores.yaml
+++ b/staging/velero/templates/restores.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: restores
+    kind: Restore

--- a/staging/velero/templates/schedule.yaml
+++ b/staging/velero/templates/schedule.yaml
@@ -1,0 +1,18 @@
+{{- range $scheduleName, $schedule := .Values.schedules }}
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" $ }}
+spec:
+  schedule: {{ $schedule.schedule | quote }}
+{{- with $schedule.template }}
+  template:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+---
+{{- end }}

--- a/staging/velero/templates/schedules.yaml
+++ b/staging/velero/templates/schedules.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: schedules.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: schedules
+    kind: Schedule

--- a/staging/velero/templates/secret.yaml
+++ b/staging/velero/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.credentials.useSecret (not .Values.credentials.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "velero.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+type: Opaque
+data:
+{{- range $key, $value := .Values.credentials.secretContents }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end -}}

--- a/staging/velero/templates/serverstatusrequests.yaml
+++ b/staging/velero/templates/serverstatusrequests.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverstatusrequests.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: serverstatusrequests
+    kind: ServerStatusRequest

--- a/staging/velero/templates/service.yaml
+++ b/staging/velero/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "velero.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: monitoring
+      port: 8085
+      targetPort: monitoring
+  selector:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/staging/velero/templates/serviceaccount-server.yaml
+++ b/staging/velero/templates/serviceaccount-server.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.server.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "velero.serverServiceAccount" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+{{- end }}

--- a/staging/velero/templates/servicemonitor.yaml
+++ b/staging/velero/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "velero.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "velero.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+  - port: monitoring
+    interval: {{ .Values.metrics.scrapeInterval }}
+{{- end }}

--- a/staging/velero/templates/volumesnapshotlocation.yaml
+++ b/staging/velero/templates/volumesnapshotlocation.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.snapshotsEnabled }}
+apiVersion: velero.io/v1
+kind: VolumeSnapshotLocation
+metadata:
+  name: default
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+spec:
+{{- with .Values.configuration }}
+{{- with .volumeSnapshotLocation }}
+  provider: {{ .name }}
+{{ with .config }}
+  config:
+  {{- with .region }}
+    region: {{ . }}
+  {{- end }}
+  {{- with .apitimeout }}
+    apiTimeout: {{ . }}
+  {{- end }}
+  {{- with .resourceGroup }}
+    resourceGroup: {{ . }}
+  {{- end }}
+  {{- with .snapshotLocation }}
+    snapshotLocation: {{ . }}
+  {{- end}}
+  {{- with .project }}
+    project: {{ . }}
+  {{- end}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/staging/velero/templates/volumesnapshotlocations.yaml
+++ b/staging/velero/templates/volumesnapshotlocations.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotlocations.velero.io
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" . }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: volumesnapshotlocations
+    kind: VolumeSnapshotLocation

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -1,0 +1,188 @@
+##
+## Configuration settings that directly affect the Velero deployment YAML.
+##
+
+# Details of the container image to use in the Velero deployment & daemonset (if
+# enabling restic). Required.
+image:
+  repository: gcr.io/heptio-images/velero
+  tag: v1.0.0
+  pullPolicy: IfNotPresent
+
+# Annotations to add to the Velero deployment's pod template. Optional.
+#
+# If using kube2iam or kiam, use the following annotation with your AWS_ACCOUNT_ID
+# and VELERO_ROLE_NAME filled in:
+#  iam.amazonaws.com/role: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<VELERO_ROLE_NAME>
+podAnnotations: {}
+
+# Resource requests/limits to specify for the Velero deployment. Optional.
+resources: {}
+
+# Init containers to add to the Velero deployment's pod spec. Optional.
+initContainers: []
+  # - name:
+  #   image:
+  #   volumeMounts:
+  #     - name: plugins
+  #       mountPath: /target
+
+# Tolerations to use for the Velero deployment. Optional.
+tolerations: []
+
+# Node selector to use for the Velero deployment. Optional.
+nodeSelector: {}
+
+# Settings for Velero's prometheus metrics. Disabled by default.
+metrics:
+  enabled: false
+  scrapeInterval: 30s
+
+  # Pod annotations for Prometheus
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8085"
+    prometheus.io/path: "/metrics"
+
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+
+##
+## End of deployment-related settings.
+##
+
+
+##
+## Parameters for the `default` BackupStorageLocation and VolumeSnapshotLocation,
+## and additional server settings.
+##
+configuration:
+  # Cloud provider being used (e.g. aws, azure, gcp).
+  provider:
+
+  # Parameters for the `default` BackupStorageLocation. See
+  # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
+  backupStorageLocation:
+    # Cloud provider where backups should be stored. Usually should
+    # match `configuration.provider`. Required.
+    name:
+    # Bucket to store backups in. Required.
+    bucket:
+    # Prefix within bucket under which to store backups. Optional.
+    prefix:
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    config: {}
+    #  region:
+    #  s3ForcePathStyle:
+    #  s3Url:
+    #  kmsKeyId:
+    #  resourceGroup:
+    #  storageAccount:
+    #  publicUrl:
+
+  # Parameters for the `default` VolumeSnapshotLocation. See
+  # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
+  volumeSnapshotLocation:
+    # Cloud provider where volume snapshots are being taken. Usually
+    # should match `configuration.provider`. Required.,
+    name:
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    config: {}
+  #    region:
+  #    apitimeout:
+  #    resourceGroup:
+  #    snapshotLocation:
+  #    project:
+
+  # These are server-level settings passed as CLI flags to the `velero server` command. Velero
+  # uses default values if they're not passed in, so they only need to be explicitly specified
+  # here if using a non-default value. The `velero server` default values are shown in the
+  # comments below.
+  # --------------------
+  # `velero server` default: 1m
+  backupSyncPeriod:
+  # `velero server` default: 1h
+  resticTimeout:
+  # `velero server` default: namespaces,persistentvolumes,persistentvolumeclaims,secrets,configmaps,serviceaccounts,limitranges,pods
+  restoreResourcePriorities:
+  # `velero server` default: false
+  restoreOnlyMode:
+
+  # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
+  extraEnvVars: {}
+
+##
+## End of backup/snapshot location settings.
+##
+
+
+##
+## Settings for additional Velero resources.
+##
+
+# Whether to create the Velero cluster role binding.
+rbac:
+  create: true
+
+# Information about the Kubernetes service account Velero uses.
+serviceAccount:
+  server:
+    create: true
+    name:
+
+# Info about the secret to be used by the Velero deployment, which
+# should contain credentials for the cloud provider IAM account you've
+# set up for Velero.
+credentials:
+  # Whether a secret should be used as the source of IAM account
+  # credentials. Set to false if, for example, using kube2iam or
+  # kiam to provide IAM credentials for the Velero pod.
+  useSecret: true
+  # Name of a pre-existing secret (if any) in the Velero namespace
+  # that should be used to get IAM account credentials. Optional.
+  existingSecret:
+  # Data to be stored in the Velero secret, if `useSecret` is
+  # true and `existingSecret` is empty. This should be the contents
+  # of your IAM credentials file.
+  secretContents: {}
+
+# Wheter to create volumesnapshotlocation crd, if false => disable snapshot feature
+snapshotsEnabled: true
+
+# Whether to deploy the restic daemonset.
+deployRestic: false
+
+restic:
+  podVolumePath: /var/lib/kubelet/pods
+  privileged: false
+  # Resource requests/limits to specify for the Restic daemonset deployment. Optional.
+  resources: {}
+
+# Backup schedules to create.
+# Eg:
+# schedules:
+#   mybackup:
+#     schedule: "0 0 * * *"
+#     template:
+#       ttl: "240h"
+#       includedNamespaces:
+#        - foo
+schedules: {}
+
+# Velero ConfigMaps.
+# Eg:
+# configMaps:
+#   restic-restore-action-config:
+#     labels:
+#       velero.io/plugin-config: ""
+#       velero.io/restic: RestoreItemAction
+#     data:
+#       image: gcr.io/heptio-images/velero-restic-restore-help
+configMaps: {}
+
+##
+## End of additional Velero resource settings.
+##

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -183,6 +183,9 @@ schedules: {}
 #       image: gcr.io/heptio-images/velero-restic-restore-help
 configMaps: {}
 
+# Deploy a default Minio cluster to use as the backend for Velero.
+minioBackend: false
+
 ##
 ## End of additional Velero resource settings.
 ##


### PR DESCRIPTION
This helps us support an option for Velero to utilize minio as a backend by default when other providers are not configured.

Upstream: [stable/velero](https://github.com/helm/charts/stable/velero)

Blocks https://github.com/mesosphere/kubeaddons-configs/pull/146

Followup: https://jira.mesosphere.com/browse/DCOS-56867