### PR TITLE
Add the ability to view services to dex sa

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.5.3
+version: 1.5.4
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/role.yaml
+++ b/stable/dex/templates/role.yaml
@@ -27,4 +27,7 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch"]
 {{- end -}}


### PR DESCRIPTION
This enables Dex extrasteps logic to view the service for traefik to determine metadata needed to bootstrap our Dex implementation.