### PR TITLE
Add polling interval env vars for kommander

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.50.0"
 description: Kommander
-version: 0.1.15
+version: 0.1.16
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/templates/deployment.yaml
+++ b/stable/kommander/templates/deployment.yaml
@@ -58,3 +58,7 @@ spec:
               value: {{ .Values.logoutRedirectPath }}
             - name: MODE
               value: {{ .Values.mode }}
+            - name: CLUSTER_POLLING_INTERVAL
+              value: {{ .Values.clusterPollingInterval }}
+            - name: CLIENT_POLLING_INTERVAL
+              value: {{ .Values.clientPollingInterval }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -4,6 +4,9 @@ image:
   pullPolicy: IfNotPresent
 replicas: 1
 logoutRedirectPath: /ops/landing
+clusterPollingInterval: 3000
+clientPollingInterval: 3000
+
 
 # Mode must be either production|konvoy
 mode: production


### PR DESCRIPTION
Add env vars to kommander deployment that represent cluster polling interval (for kommander backend) and client polling interval (for kommander frontend).