### PR TITLE
Fix awsebscsiprovisioner chart values

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -5,7 +5,7 @@ name: awsebscsiprovisioner
 maintainers:
   - name: alejandroEsc
   - name: gpaul
-version: 0.2.5
+version: 0.2.6
 kubeVersion: ">=1.13.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/templates/statefulset.yaml
+++ b/stable/awsebscsiprovisioner/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
         {{- end }}
         {{- if .Values.resizer.enabled }}
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          image: "{{ .Values.resizer.image.repository }}:{{ .Values.resizer.image.tag }}"
           imagePullPolicy: Always
           args:
             - --csi-address=$(ADDRESS)

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -33,12 +33,12 @@ provisioner:
   enableVolumeScheduling: false
   image:
     repository: "quay.io/k8scsi/csi-provisioner"
-    tag: "v1.1.0"
+    tag: "v1.2.0"
 
 attacher:
   image:
     repository: "quay.io/k8scsi/csi-attacher"
-    tag: "v1.1.0"
+    tag: "v1.1.1"
 
 snapshotter:
   # True if enable volume snapshot


### PR DESCRIPTION
The chart refactoring in https://github.com/mesosphere/charts/pull/26 got the image tag version wrong in a few places. I've gone through that PR and checked that the values in values.yaml all match the pre-refactoring values.

Fixes https://jira.mesosphere.com/browse/DCOS-56901 - further PRs required to update all the various upstream repositories.