### PR TITLE
add optional configuration parameters for AWS EBS volumes.

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -5,7 +5,7 @@ name: awsebscsiprovisioner
 maintainers:
   - name: alejandroEsc
   - name: gpaul
-version: 0.2.6
+version: 0.2.7
 kubeVersion: ">=1.13.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/templates/storageclass.yaml
+++ b/stable/awsebscsiprovisioner/templates/storageclass.yaml
@@ -10,3 +10,14 @@ metadata:
 provisioner: ebs.csi.aws.com
 volumeBindingMode: {{ .Values.storageclass.volumeBindingMode | quote }}
 reclaimPolicy: {{ .Values.storageclass.reclaimPolicy | quote }}
+parameters:
+  type: {{ .Values.storageclass.type | quote }}
+  {{- if .Values.storageclass.fsType }}
+  fsType: {{ .Values.storageclass.fsType | quote }}
+  {{- end }}
+  {{- if .Values.storageclass.iopsPerGB }}
+  iopsPerGB: {{ .Values.storageclass.iopsPerGB | quote }}
+  {{- end }}
+  {{- if .Values.storageclass.encrypted }}
+  encrypted: {{ .Values.storageclass.encrypted | quote }}
+  {{- end }}

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -65,3 +65,4 @@ storageclass:
   isDefault: false
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
+  type: gp2

--- a/stable/awsebsprovisioner/Chart.yaml
+++ b/stable/awsebsprovisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: awsebsprovisioner
 home: https://kubernetes.io/docs/concepts/storage/storage-classes/
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.0"
 description: AWS EBS storage provisioner for konvoy
 maintainers:

--- a/stable/awsebsprovisioner/templates/storageclass.yaml
+++ b/stable/awsebsprovisioner/templates/storageclass.yaml
@@ -12,3 +12,12 @@ volumeBindingMode: {{ .Values.storageclass.volumeBindingMode | quote }}
 reclaimPolicy: {{ .Values.storageclass.reclaimPolicy | quote }}
 parameters:
   type: {{ .Values.storageclass.type | quote }}
+  {{- if .Values.storageclass.fsType }}
+  fsType: {{ .Values.storageclass.fsType | quote }}
+  {{- end }}
+  {{- if .Values.storageclass.iopsPerGB }}
+  iopsPerGB: {{ .Values.storageclass.iopsPerGB | quote }}
+  {{- end }}
+  {{- if .Values.storageclass.encrypted }}
+  encrypted: {{ .Values.storageclass.encrypted | quote }}
+  {{- end }}


### PR DESCRIPTION
These parameters are supported by both, 'awsebsprovisioner' as well as
'awsebscsiprovisioner'.