### PR TITLE
ensure env values are strings

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.50.0"
 description: Kommander
-version: 0.1.16
+version: 0.1.17
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/templates/deployment.yaml
+++ b/stable/kommander/templates/deployment.yaml
@@ -55,10 +55,10 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: LOGOUT_REDIRECT_PATH
-              value: {{ .Values.logoutRedirectPath }}
+              value: {{ .Values.logoutRedirectPath | quote }}
             - name: MODE
-              value: {{ .Values.mode }}
+              value: {{ .Values.mode | quote }}
             - name: CLUSTER_POLLING_INTERVAL
-              value: {{ .Values.clusterPollingInterval }}
+              value: {{ .Values.clusterPollingInterval | quote }}
             - name: CLIENT_POLLING_INTERVAL
-              value: {{ .Values.clientPollingInterval }}
+              value: {{ .Values.clientPollingInterval | quote }}


### PR DESCRIPTION
The env map in a deployment requires both name and value to be strings.
Always `quote` filter Values variables that are used for setting
env.value fields.