### PR TITLE
[fixe] changed how crd deployment works for kommander

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.50.0"
 description: Kommander
-version: 0.1.17
+version: 0.1.18
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/templates/crd.yaml
+++ b/stable/kommander/templates/crd.yaml
@@ -1,4 +1,5 @@
-{{- if (.Values.createObservableClusterCRD) }}
+{{- if .Values.createObservableClusterCRD }}
+{{- if not (.Capabilities.APIVersions.Has "stable.mesosphere.com/v1") }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -11,7 +12,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: stable.mesosphere.com
   versions:
@@ -63,4 +63,5 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
-{{ end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
When multiple deployments of Kommander would occur, here is the lifecycle of what would happen:

- First instance is deployed, CRD hook runs and installs CRD with hook-delete-policy: before-hook-creation
- CRD is running all is good in the world
-  Second instance is deployed. BY CRD hook-delete-policy, the previous hook has to be deleted.
  - First hook deletes first instance of CRD, or tries to immediately
  - If resources already exist, it may not delete immediately
  - If the delete failed in timely manner Second instance CRD attempts to run anyway
  - Error message that CRD already exists and something about deletion failing also
- We are in a sad place

To mitigate the above story, we should instead
- Remove that policy, try not to delete anything if possible for CRDS
- use the default policy to delete only if we fail
- On subsequent deployments, DO NOT RUN another hook. This can be accomplished by checking that the api group exists. If so, do nothing. This will preserve our hook and will keep the CRDS.

Conclusion: These changes should allow us to continue with no additional extra steps.