### PR TITLE
[fix] removing deps from ops-portal

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -15,4 +15,4 @@ name: prometheus-operator
 sources:
 - https://github.com/coreos/prometheus-operator
 - https://coreos.com/operators/prometheus
-version: 5.10.1
+version: 5.10.2

--- a/staging/prometheus-operator/templates/mesosphere-hooks/post-install-hooks.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/post-install-hooks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mesosphereResources.create }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -19,10 +20,7 @@ spec:
           command: ["/bin/sh", "-c", "/job/run.sh"]
           env:
             - name: X_FORWARDED_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.mesosphereResources.hooks.grafana.secretKeyRef }}
-                  key: username
+              value: {{ .Values.mesosphereResources.hooks.grafana.user | quote }}
           volumeMounts:
             - mountPath: /job
               name: job
@@ -43,4 +41,4 @@ data:
     DASHBOARD_ID=$(curl --fail -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/search/?query=Kubernetes+%2F+Compute+Resources+%2F+Cluster | jq '.[0].id')
     echo $DASHBOARD_ID
     curl -X PUT -v --fail  -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"theme":"","homeDashboardId":'"$DASHBOARD_ID"',"timezone":""}' {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/org/preferences
-
+{{- end }}

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -63,7 +63,7 @@ mesosphereResources:
     grafana:
       jobName: grafana-default-dashboard
       image: dwdraju/alpine-curl-jq
-      secretKeyRef: ops-portal-credentials
+      user: admin
       serviceURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
 
 


### PR DESCRIPTION
Goal is to remove last piece of dep on ops-portal-secret and allow CI to continue when removing this part. 

- Need to gather more information about how ops-portal, kommander, dex and konvoy-ui interact
- Should find a way to pass current username, generated either by ops-portal or konvoy-ui
