### PR TITLE
[extrasteps] opsportal updated with hooks for secrets generation

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0.0"
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.0.7
+version: 0.0.8
 maintainers:
   - name: hectorj2f

--- a/stable/opsportal/templates/hooks-roles.yaml
+++ b/stable/opsportal/templates/hooks-roles.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.secrets.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "opsportal.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "opsportal.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "pre-install,post-delete"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "opsportal.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "opsportal.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "pre-install,post-delete"
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "opsportal.fullname" . }}-secrets
+{{- end }}

--- a/stable/opsportal/templates/hooks-secrets.yaml
+++ b/stable/opsportal/templates/hooks-secrets.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.secrets.create }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}-secret-pre-install"
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+        app.kubernetes.io/instance: {{.Release.Name | quote }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: "{{.Release.Name}}-pre-install"
+          image: "{{.Values.secrets.image.repository}}:{{.Values.secrets.image.tag}}"
+          args:
+            - opsportal-secret
+            - create
+            - --name={{ .Values.secrets.name }}
+            - --namespace={{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}-secret-post-delete"
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+        app.kubernetes.io/instance: {{.Release.Name | quote }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: "{{.Release.Name}}-post-delete"
+        image: "{{.Values.secrets.image.repository}}:{{.Values.secrets.image.tag}}"
+        args:
+        - opsportal-secret
+        - delete
+        - --name={{ .Values.secrets.name }}
+        - --namespace={{ .Release.Namespace }}
+{{- end }}

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -8,6 +8,14 @@ bearerproxy:
 landing:
   enabled: true
 
+# these secrets are created via hooks
+secrets:
+  create: true
+  name: ops-portal-credentials
+  image:
+    repository: "kubeaddons/addon-initializer"
+    tag: "opsportal-2"
+
 opsportal:
   ingress:
     paths:


### PR DESCRIPTION
made changes to automatically generate secrets for the credentials required by multiple tools. Should unblock CI when we delete extra steps. 

Blocked on: https://github.com/mesosphere/kubeaddons-extrasteps/pull/6