### PR TITLE
kommander: reduce default CPU request

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.50.0"
 description: Kommander
-version: 0.1.19
+version: 0.1.20
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -21,7 +21,7 @@ extraInitContainers:
 resources:
   requests:
     memory: "128Mi"
-    cpu: "1000m"
+    cpu: "100m"
   limits:
     memory: "512Mi"
     cpu: "2000m"


### PR DESCRIPTION
As observed in soak, we don't need to reserve 1000m CPU.

Reduce it to 100m, but still allows it to burst to 2000m CPU.