### PR TITLE
awsebscsiprovisioner: set allowed topologies values

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -5,7 +5,8 @@ name: awsebscsiprovisioner
 maintainers:
   - name: alejandroEsc
   - name: gpaul
-version: 0.2.8
+  - name: hectorj2f
+version: 0.2.9
 kubeVersion: ">=1.13.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/templates/storageclass.yaml
+++ b/stable/awsebscsiprovisioner/templates/storageclass.yaml
@@ -21,3 +21,7 @@ parameters:
   {{- if .Values.storageclass.encrypted }}
   encrypted: {{ .Values.storageclass.encrypted | quote }}
   {{- end }}
+{{- with .Values.storageclass.allowedTopologies }}
+allowedTopologies:
+{{ toYaml . }}
+{{- end }}

--- a/stable/awsebscsiprovisioner/templates/storageclass.yaml
+++ b/stable/awsebscsiprovisioner/templates/storageclass.yaml
@@ -21,7 +21,9 @@ parameters:
   {{- if .Values.storageclass.encrypted }}
   encrypted: {{ .Values.storageclass.encrypted | quote }}
   {{- end }}
+{{- if .Values.storageclass.allowedTopologies }}
 {{- with .Values.storageclass.allowedTopologies }}
 allowedTopologies:
 {{ toYaml . }}
+{{- end }}
 {{- end }}

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -66,3 +66,10 @@ storageclass:
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
   type: gp2
+  allowedTopologies: []
+  # - matchLabelExpressions:
+  #   - key: topology.ebs.csi.aws.com/zone
+  #     values:
+  #     - us-west-2a
+  #     - us-west-2b
+  #     - us-west-2c


### PR DESCRIPTION
Customers might want to configure the allowed topologies when deploying on a multi AZ cluster:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    kubernetes.io/description: AWS EBS CSI provisioner StorageClass
    storageclass.kubernetes.io/is-default-class: "true"
  creationTimestamp: "2019-07-27T14:12:39Z"
  name: awsebscsiprovisioner
  resourceVersion: "2043"
  selfLink: /apis/storage.k8s.io/v1/storageclasses/awsebscsiprovisioner
  uid: 684d5b49-6704-4ef9-98d3-01e9c137bb45
parameters:
  type: gp2
provisioner: ebs.csi.aws.com
allowedTopologies:
- matchLabelExpressions:
  - key: topology.ebs.csi.aws.com/zone
    values:
    - us-west-2a
    - us-west-2b
    - us-west-2c
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```