### PR TITLE
prometheus-operator: typo in the mesosphere resources

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -15,4 +15,4 @@ name: prometheus-operator
 sources:
 - https://github.com/coreos/prometheus-operator
 - https://coreos.com/operators/prometheus
-version: 5.10.2
+version: 5.10.3

--- a/staging/prometheus-operator/templates/grafana/dashboards/mesosphere-dashboards/traefikdashboard.yaml
+++ b/staging/prometheus-operator/templates/grafana/dashboards/mesosphere-dashboards/traefikdashboard.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mesosphereResources.create .Values.mesosphereResources.dashboards.trafik }}
+{{- if and .Values.mesosphereResources.create .Values.mesosphereResources.dashboards.traefik }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -59,7 +59,7 @@ mesosphereResources:
     localvolumeusage: true
     prometheusoverview: true
     scheduler: true
-    trafik: true
+    traefik: true
   hooks:
     grafana:
       jobName: grafana-default-dashboard


### PR DESCRIPTION
`traefik` not `trafik` 