### PR TITLE
dashboard: rename konvoy-ui to opsportal

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0.0"
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: hectorj2f

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -104,7 +104,7 @@ kommander:
 
   ### This must match the serviceName set in the ingress backend below
   service:
-    name: konvoy-ui
+    name: opsportal
 
   ingress:
     traefikFrontendRuleType: PathPrefixStrip

--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -15,4 +15,4 @@ name: prometheus-operator
 sources:
 - https://github.com/coreos/prometheus-operator
 - https://coreos.com/operators/prometheus
-version: 5.10.4
+version: 5.10.5

--- a/staging/prometheus-operator/templates/grafana/dashboards/mesosphere-dashboards/opsportaldashboard.yaml
+++ b/staging/prometheus-operator/templates/grafana/dashboards/mesosphere-dashboards/opsportaldashboard.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.mesosphereResources.create .Values.mesosphereResources.dashboards.konvoyui }}
+{{- if and .Values.mesosphereResources.create .Values.mesosphereResources.dashboards.opsportal }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) "konvoyui-dashboard" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) "opsportal-dashboard" | trunc 63 | trimSuffix "-" }}
   labels:
     {{- if $.Values.grafana.sidecar.dashboards.label }}
     {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
@@ -10,7 +10,7 @@ metadata:
     app: {{ template "prometheus-operator.name" $ }}-grafana
 {{ include "prometheus-operator.labels" $ | indent 4 }}
 data:
-  konvoyuidashboard.json: |-
+  opsportaldashboard.json: |-
     {
       "__inputs": [],
       "__requires": [
@@ -121,7 +121,7 @@ data:
           "tableColumn": "Value",
           "targets": [
             {
-              "expr": "up{job=~\"konvoy-ui\"}",
+              "expr": "up{job=~\"opsportal\"}",
               "format": "table",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -210,7 +210,7 @@ data:
           "tableColumn": "Value",
           "targets": [
             {
-              "expr": "avg((avg_over_time(up{job=~\"konvoy-ui\"}[$interval]) * 100))",
+              "expr": "avg((avg_over_time(up{job=~\"opsportal\"}[$interval]) * 100))",
               "format": "table",
               "hide": false,
               "intervalFactor": 2,
@@ -289,7 +289,7 @@ data:
           "tableColumn": "Value",
           "targets": [
             {
-              "expr": "(time() - process_start_time_seconds{job=~\"konvoy-ui\"})",
+              "expr": "(time() - process_start_time_seconds{job=~\"opsportal\"})",
               "format": "table",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -341,7 +341,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (status_code) (irate(http_requests_total{job=~\"konvoy-ui\"}[5m]))",
+              "expr": "sum by (status_code) (irate(http_requests_total{job=~\"opsportal\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{`{{status_code}}`}}",
@@ -425,7 +425,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "process_resident_memory_bytes{service=\"konvoy-ui\"}",
+              "expr": "process_resident_memory_bytes{service=\"opsportal\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "RSS",
@@ -509,14 +509,14 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "nodejs_heap_size_used_bytes{job=~\"konvoy-ui\"}/1024/1024",
+              "expr": "nodejs_heap_size_used_bytes{job=~\"opsportal\"}/1024/1024",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Used",
               "refId": "A"
             },
             {
-              "expr": "nodejs_heap_size_total_bytes{job=~\"konvoy-ui\"}/1024/1024",
+              "expr": "nodejs_heap_size_total_bytes{job=~\"opsportal\"}/1024/1024",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Total",
@@ -601,7 +601,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (release) (rate(nodejs_eventloop_lag_seconds{job=~\"konvoy-ui\"}[5m]))",
+              "expr": "sum by (release) (rate(nodejs_eventloop_lag_seconds{job=~\"opsportal\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Lag",
@@ -685,7 +685,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum((rate(nodejs_gc_runs_total{job=\"konvoy-ui\"}[5m])))",
+              "expr": "sum((rate(nodejs_gc_runs_total{job=\"opsportal\"}[5m])))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Rate",
@@ -769,7 +769,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum((rate(nodejs_gc_pause_seconds_total{job=\"konvoy-ui\"}[5m])))",
+              "expr": "sum((rate(nodejs_gc_pause_seconds_total{job=\"opsportal\"}[5m])))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pause Time",
@@ -821,7 +821,7 @@ data:
       "schemaVersion": 18,
       "style": "dark",
       "tags": [
-        "konvoy-ui"
+        "opsportal"
       ],
       "templating": {
         "list": [
@@ -943,7 +943,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Konvoy UI",
+      "title": "Ops Portal",
       "uid": "Jw7Mw-HWz",
       "version": 1
     }

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -53,7 +53,7 @@ mesosphereResources:
     elasticsearch: true
     fluentbit: true
     grafana: true
-    konvoyui: true
+    opsportal: true
     kubelet: true
     localvolumeprovisioner: true
     localvolumeusage: true


### PR DESCRIPTION
We need to rename konvoy-ui  dashboard to be consistent with the current name for it `ops portal`