### PR TITLE
Modify Ops Portal dashboard uptime text to green when up

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -15,4 +15,4 @@ name: prometheus-operator
 sources:
 - https://github.com/coreos/prometheus-operator
 - https://coreos.com/operators/prometheus
-version: 5.10.5
+version: 5.10.6

--- a/staging/prometheus-operator/templates/grafana/dashboards/mesosphere-dashboards/opsportaldashboard.yaml
+++ b/staging/prometheus-operator/templates/grafana/dashboards/mesosphere-dashboards/opsportaldashboard.yaml
@@ -128,7 +128,7 @@ data:
               "refId": "A"
             }
           ],
-          "thresholds": "1",
+          "thresholds": "1,1",
           "timeFrom": "1s",
           "timeShift": null,
           "title": "Status",


### PR DESCRIPTION
Fix for uptime panel in Ops Portal dashboard to show up green (instead of orange) when value is 1 (up).
![image](https://user-images.githubusercontent.com/5897740/62324978-84896380-b45f-11e9-9034-ab29a443fbe3.png)
vs
![image](https://user-images.githubusercontent.com/5897740/62324958-78050b00-b45f-11e9-8d4e-85f9c7713f05.png)
