### PR TITLE
Add config for service labels to velero for service monitor discovery

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -16,4 +16,4 @@ name: velero
 sources:
 - https://github.com/heptio/velero
 tillerVersion: '>=2.10.0'
-version: 2.2.1
+version: 2.2.2

--- a/staging/velero/templates/service.yaml
+++ b/staging/velero/templates/service.yaml
@@ -8,6 +8,11 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+  {{- if .Values.metrics.service }}
+  {{- range $key, $value := .Values.metrics.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/staging/velero/templates/servicemonitor.yaml
+++ b/staging/velero/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -43,6 +43,8 @@ metrics:
     #   key: value
 
   # Pod annotations for Prometheus
+  # Commented out since the Prometheus Operator discourages annotation-based service discovery.
+  # See https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheusioscrape
   # podAnnotations:
   #   prometheus.io/scrape: "true"
   #   prometheus.io/port: "8085"

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -38,11 +38,15 @@ metrics:
   enabled: false
   scrapeInterval: 30s
 
+  service:
+    # labels:
+    #   key: value
+
   # Pod annotations for Prometheus
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8085"
-    prometheus.io/path: "/metrics"
+  # podAnnotations:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "8085"
+  #   prometheus.io/path: "/metrics"
 
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
- Commented out pod annotations because it looks like [prometheus-operator does not encourage annotation-based discovery of services anymore](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheusioscrape) (in other charts, these annotations are commented out so following the pattern here).
- Added a `(.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")` check in servicemonitor.yaml to avoid the case where velero's service monitor is enabled but the prometheus-operator isn't or has not yet deployed the `ServiceMonitor` CRD.
- Added config option to add service labels to enable discovery by service monitors already defined in prometheus ([our prom service monitor defs here](https://github.com/mesosphere/kubeaddons-configs/blob/master/templates/prometheus.yaml#L46)) instead to reuse those monitors instead of defining a separate service monitor here. This is already a common pattern I've noticed in other charts, including some that we use e.g. [fluent-bit](https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml#L21) - we use label matching on the service for prom discovery/scraping instead of enabling its own service monitor def

![image](https://user-images.githubusercontent.com/5897740/62579887-c4828900-b859-11e9-8dd6-8ba9edd2cdcd.png)

[these changes should be upstreamed]