### PR TITLE
feat: Allow configurable object selector for webhook

### DIFF
--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0.4-beta.1"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.1.0
+version: 0.2.0
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:

--- a/staging/gatekeeper/README.md
+++ b/staging/gatekeeper/README.md
@@ -1,0 +1,58 @@
+# Gatekeeper
+
+[Gatekeeper](https://github.com/open-policy-agent/gatekeeper/), the Policy Controller for
+Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.15 (or newer) for validating and mutating webhook admission
+  controller support.
+
+## Overview
+
+This helm chart installs Gatekeeper as a [Kubernetes admission
+controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/).
+Gatekeeper is a validating (mutating TBA) webhook that enforces CRD-based policies executed by [Open
+Policy Agent](https://github.com/open-policy-agent/opa), a policy engine for Cloud Native
+environments hosted by [CNCF](https://www.cncf.io) as an incubation-level project.
+
+## Kick the tires
+
+If you just want to see something run, install the chart without any
+configuration.
+
+```bash
+helm install stable/gatekeeper
+```
+
+You can then follow the instructions
+[here](https://github.com/open-policy-agent/gatekeeper/#how-to-use-gatekeeper) to learn how to use
+Gatekeeper.
+
+## Configuration
+
+All configuration settings are contained and described in
+[values.yaml](values.yaml).
+
+| Parameter                                             | Description                                                                  | Default             |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------- |
+| port                                                  | Port for gateekeper pod to listen on                                         | 8443                |
+| securityContext.runAsUser                             | Run as user for gatekeeper pod                                               |                     |
+| securityContext.fsGroup                               | FS group for gatekeeper pod                                                  |                     |
+| service.annotations                                   | Service annotations                                                          |                     |
+| service.type                                          | Service type                                                                 | "ClusterIP"         |
+| service.port                                          | Service port                                                                 | 443                 |
+| rbac.create                                           | Create RBAC resources                                                        | true                |
+| serviceAccount.create                                 | Create service account                                                       | true                |
+| serviceAccount.name                                   | Service account name (if not specified, will be generated from release name) |                     |
+| priorityClassName                                     | Pod priority class name                                                      |                     |
+| resources                                             | Pod resources                                                                |                     |
+| admissionControllerFailurePolicy                      | Admission controller failure policy                                          | "Ignore"            |
+| admissionControllerNamespaceSelector.matchExpressions | Admission controller namespace selector expressions                          | []                  |
+| admissionControllerObjectSelector.matchExpressions    | Admission controller object selector expressions                             | []                  |
+| admissionControllerObjectSelector.matchLabels         | Admission controller object label selector                                   | []                  |
+| webhook.apiGroups                                     | Webhook rules API groups                                                     | [""]                |
+| webhook.apiVersions                                   | Webhook rules API versions                                                   | ["*"]               |
+| webhook.operations                                    | Webhook rules operations                                                     | ["CREATE","UPDATE"] |
+| webhook.resources                                     | Webhook rules resources                                                      | ["pods"]            |
+| webhook.scope                                         | Webhook rules scope                                                          | "Namespaced"        |

--- a/staging/gatekeeper/templates/NOTES.txt
+++ b/staging/gatekeeper/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}
+
+You can read more about Gatekeeper at:
+
+https://github.com/open-policy-agent/gatekeeper
+https://kubernetes.io/blog/2019/08/06/opa-gatekeeper-policy-and-governance-for-kubernetes/

--- a/staging/gatekeeper/templates/_helpers.tpl
+++ b/staging/gatekeeper/templates/_helpers.tpl
@@ -56,9 +56,9 @@ Create the name of the service account to use
 */}}
 {{- define "gatekeeper.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "gatekeeper.fullname" .) .Values.serviceAccount.name }}
+{{ default (include "gatekeeper.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -67,8 +67,8 @@ Create the image tag to use
 */}}
 {{- define "gatekeeper.imageTag" -}}
 {{- if .Values.image.tag -}}
-    {{ .Values.image.tag }}
+{{ .Values.image.tag }}
 {{- else -}}
-    v{{ .Chart.AppVersion }}
+v{{ .Chart.AppVersion }}
 {{- end -}}
 {{- end -}}

--- a/staging/gatekeeper/templates/validatingwebhook.yaml
+++ b/staging/gatekeeper/templates/validatingwebhook.yaml
@@ -40,15 +40,14 @@ webhooks:
     {{ end }}
   rules:
   - apiGroups:
-    - '*'
+    {{ toYaml .Values.webhook.apiGroups | nindent 4 }}
     apiVersions:
-    - '*'
+    {{ toYaml .Values.webhook.apiVersions | nindent 4 }}
     operations:
-    - CREATE
-    - UPDATE
+    {{ toYaml .Values.webhook.operations | nindent 4 }}
     resources:
-    - '*'
-    scope: '*'
+    {{ toYaml .Values.webhook.resources | nindent 4 }}
+    scope: {{ .Values.webhook.scope }}
   sideEffects: None
 ---
 apiVersion: v1

--- a/staging/gatekeeper/templates/validatingwebhook.yaml
+++ b/staging/gatekeeper/templates/validatingwebhook.yaml
@@ -27,6 +27,17 @@ webhooks:
   namespaceSelector:
     {{ toYaml . | nindent 4 }}
   {{ end }}
+  objectSelector:
+    matchExpressions:
+    - {key: app.kubernetes.io/name, operator: NotIn, values: ["{{ include "gatekeeper.name" . }}"]}
+    - {key: app.kubernetes.io/instance, operator: NotIn, values: ["{{ .Release.Name }}"]}
+    {{- with .Values.admissionControllerObjectSelector.matchExpressions }}
+    {{ toYaml . | nindent 4 }}
+    {{ end }}
+    {{- with .Values.admissionControllerObjectSelector.matchLabels }}
+    matchLabels:
+    {{ toYaml . | nindent 4 }}
+    {{ end }}
   rules:
   - apiGroups:
     - '*'

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -74,3 +74,10 @@ admissionControllerFailurePolicy: Ignore
 admissionControllerNamespaceSelector:
   matchExpressions:
   - {key: validation.gatekeeper.sh/disable-validation, operator: NotIn, values: ["true"]}
+
+# Adds an object selector to the admission controller webhook
+admissionControllerObjectSelector:
+  matchExpressions: []
+  # - {key: foo, operator: NotIn, values: ["bar"]}
+  matchLabels: []
+  # - foo: bar

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -81,3 +81,15 @@ admissionControllerObjectSelector:
   # - {key: foo, operator: NotIn, values: ["bar"]}
   matchLabels: []
   # - foo: bar
+
+webhook:
+  apiGroups:
+  - ""
+  apiVersions:
+  - "*"
+  operations:
+  - CREATE
+  - UPDATE
+  resources:
+  - pods
+  scope: Namespaced


### PR DESCRIPTION
This defaults to skipping validation of gatekeeper components,
required for a Fail validation webhook policy.