### PR TITLE
localvolumeprovisioner: allow configuration of multiple storage classes

### DIFF
--- a/stable/localvolumeprovisioner/Chart.yaml
+++ b/stable/localvolumeprovisioner/Chart.yaml
@@ -3,6 +3,6 @@ name: localvolumeprovisioner
 home: https://github.com/mesosphere/charts
 appVersion: "1.0"
 description: Local persistent volume provisioner for konvoy
-version: 0.4.0
+version: 0.5.0
 maintainers:
   - name: s12chung

--- a/stable/localvolumeprovisioner/templates/NOTES.txt
+++ b/stable/localvolumeprovisioner/templates/NOTES.txt
@@ -1,6 +1,8 @@
 The following directory has been created on worker nodes:
 
-/mnt/disks/
+{{- range .Values.storageclasses }}
+/mnt/{{ .name }}/
+{{- end }}
 
 Volumes that are mounted into this directory show up as persistent volumes. Their
-`storageClassName` is set to `"localvolumeprovisioner"`.
+`storageClassName` is set to `"localvolumeprovisioner-*"`.

--- a/stable/localvolumeprovisioner/templates/configmap.yaml
+++ b/stable/localvolumeprovisioner/templates/configmap.yaml
@@ -6,11 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   storageClassMap: |
-    localvolumeprovisioner:
-       hostDir: /mnt/disks
-       mountDir: /mnt/disks
-       blockCleanerCommand:
-         - "/scripts/shred.sh"
-         - "2"
-       volumeMode: Filesystem
-       fsType: ext4
+    {{- range .Values.storageclasses }}
+    localvolumeprovisioner-{{ .name }}:
+      hostDir: /mnt/{{ .name }}
+      mountDir: /mnt/{{ .name }}
+      blockCleanerCommand:
+       - "/scripts/shred.sh"
+       - "2"
+      volumeMode: Filesystem
+      fsType: ext4
+    {{- end }}

--- a/stable/localvolumeprovisioner/templates/daemonset.yaml
+++ b/stable/localvolumeprovisioner/templates/daemonset.yaml
@@ -49,9 +49,11 @@ spec:
               readOnly: true
             - name: local-volume-provisioner-dev
               mountPath: /dev
-            - name: disks
-              mountPath: /mnt/disks
+            {{- range .Values.storageclasses }}
+            - name: {{ .name }}
+              mountPath: /mnt/{{ .name }}
               mountPropagation: "HostToContainer"
+            {{- end }}
       volumes:
         - name: provisioner-config
           configMap:
@@ -59,6 +61,8 @@ spec:
         - name: local-volume-provisioner-dev
           hostPath:
             path: /dev
-        - name: disks
+        {{- range .Values.storageclasses }}
+        - name: {{ .name }}
           hostPath:
-            path: /mnt/disks
+            path: /mnt/{{ .name }}
+        {{- end }}

--- a/stable/localvolumeprovisioner/templates/storageclass.yaml
+++ b/stable/localvolumeprovisioner/templates/storageclass.yaml
@@ -1,13 +1,15 @@
+{{- range .Values.storageclasses }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: localvolumeprovisioner
+  name: localvolumeprovisioner-{{ .name }}
   annotations:
-{{- if .Values.storageclass.isDefault }}
+{{- if .isDefault }}
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
-    kubernetes.io/description: Local volume provisioner StorageClass
+    kubernetes.io/description: Local volume provisioner StorageClass ({{ .name }})
 provisioner: kubernetes.io/no-provisioner
-volumeBindingMode: {{ .Values.storageclass.volumeBindingMode | quote }}
-reclaimPolicy: {{ .Values.storageclass.reclaimPolicy | quote }}
+volumeBindingMode: {{ .volumeBindingMode | quote }}
+reclaimPolicy: {{ .reclaimPolicy | quote }}
+{{- end }}

--- a/stable/localvolumeprovisioner/values.yaml
+++ b/stable/localvolumeprovisioner/values.yaml
@@ -3,10 +3,11 @@ image:
   tag: "v2.3.2"
   pullPolicy: "IfNotPresent"
 
-storageclass:
-  isDefault: true
-  reclaimPolicy: Delete
-  volumeBindingMode: WaitForFirstConsumer
+storageclasses:
+  - name: disks
+    isDefault: true
+    reclaimPolicy: Delete
+    volumeBindingMode: WaitForFirstConsumer
 
 priorityClassName: system-node-critical
 

--- a/stable/localvolumeprovisioner/values.yaml
+++ b/stable/localvolumeprovisioner/values.yaml
@@ -3,6 +3,11 @@ image:
   tag: "v2.3.2"
   pullPolicy: "IfNotPresent"
 
+# Multiple storage classes can be defined here. This allows to, e.g.,
+# distinguish between different disk types.
+# For each entry a storage class 'localvolumeprovisioner-$name' and
+# a host folder '/mnt/$name' will be created. Volumes mounted to this
+# folder are made available in the storage class.
 storageclasses:
   - name: disks
     isDefault: true


### PR DESCRIPTION
Multiple storage classes allow defining a volume topology. For each item
in the configuration a 'localvolumeprovisioner-%name%' storage class
will get created. Volumes mounted at '/mnt/%name%' on each host will be
detected and added as persistent volumes under this storage class.