### PR TITLE
feat: remove dependency on observableCluster-CRD for konvoy-ui

### DIFF
--- a/stable/kommander/templates/crd.yaml
+++ b/stable/kommander/templates/crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.createObservableClusterCRD }}
 {{- if not (.Capabilities.APIVersions.Has "stable.mesosphere.com/v1") }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -63,5 +62,4 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
-{{- end }}
 {{- end }}

--- a/stable/konvoy-ui/Chart.yaml
+++ b/stable/konvoy-ui/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: konvoy-ui
+home: https://github.com/mesosphere/kommander
+appVersion: "1.65.30"
+description: UI-Dashboard for Konvoy
+version: 0.1.0
+maintainers:
+  - name: pierrebeitz

--- a/stable/konvoy-ui/templates/_helpers.tpl
+++ b/stable/konvoy-ui/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "konvoy-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "konvoy-ui.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "konvoy-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/konvoy-ui/templates/deployment.yaml
+++ b/stable/konvoy-ui/templates/deployment.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "konvoy-ui.fullname" . }}
+  labels:
+    app: {{ template "konvoy-ui.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "konvoy-ui.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "konvoy-ui.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+    spec:
+      serviceAccountName: {{ template "konvoy-ui.fullname" . }}
+      imagePullSecrets:
+        - name: dockerhub
+      initContainers:
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: {{ template "konvoy-ui.fullname" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          ports:
+            - name: http
+              containerPort: 4000
+          resources:
+            {{ with .Values.resources }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LOGOUT_REDIRECT_PATH
+              value: {{ .Values.logoutRedirectPath | quote }}
+            - name: MODE
+              value: {{ .Values.mode | quote }}
+            - name: CLUSTER_POLLING_INTERVAL
+              value: {{ .Values.clusterPollingInterval | quote }}
+            - name: CLIENT_POLLING_INTERVAL
+              value: {{ .Values.clientPollingInterval | quote }}

--- a/stable/konvoy-ui/templates/hooks-roles.yaml
+++ b/stable/konvoy-ui/templates/hooks-roles.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "konvoy-ui.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "konvoy-ui.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: "before-hook-creation"

--- a/stable/konvoy-ui/templates/ingress.yaml
+++ b/stable/konvoy-ui/templates/ingress.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "konvoy-ui.fullname" . }}
+  labels:
+    app: {{ template "konvoy-ui.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.frontend.rule.type: {{ .Values.ingress.traefikFrontendRuleType }}
+    {{- with .Values.ingress.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: {{ .Values.service.name }}
+              servicePort: 80
+            path: {{ .Values.ingress.path }}

--- a/stable/konvoy-ui/templates/roles.yaml
+++ b/stable/konvoy-ui/templates/roles.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "konvoy-ui.fullname" . }}
+  labels:
+    app: {{ template "konvoy-ui.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "konvoy-ui.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/stable/konvoy-ui/templates/service.yaml
+++ b/stable/konvoy-ui/templates/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  labels:
+    app: {{ template "konvoy-ui.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.name }}"
+    heritage: "{{ .Release.Service }}"
+    servicemonitor.kubeaddons.mesosphere.io/path: metrics
+spec:
+  ports:
+    - name: metrics
+      port: 80
+      protocol: TCP
+      targetPort: 4000
+  selector:
+    app: {{ template "konvoy-ui.fullname" . }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/stable/konvoy-ui/values.yaml
+++ b/stable/konvoy-ui/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: mesosphere/kommander
-  tag: 1.60.0
+  repository: mesosphere/konvoy-ui
+  tag: 1.65.30
   pullPolicy: IfNotPresent
 replicas: 1
 logoutRedirectPath: /ops/landing
@@ -28,10 +28,10 @@ livenessProbe:
 
 ### This must match the serviceName set in the ingress backend below
 service:
-  name: kommander
+  name: konvoy-ui
 
 ingress:
   traefikFrontendRuleType: PathPrefixStrip
   # extraAnnotations:
   #   ingress.kubernetes.io/foo: bar
-  path: /ops/portal/kommander
+  path: /ops/portal/konvoy-ui

--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0.0"
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: hectorj2f

--- a/stable/opsportal/requirements.yaml
+++ b/stable/opsportal/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
-- name: kommander
-  version: 0.1.22
+- name: konvoy-ui
+  version: 0.1.0
   repository: https://mesosphere.github.io/charts/stable

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -70,20 +70,15 @@ opsportal:
 ###############################################################################
 kommander:
   image:
-    repository: mesosphere/kommander
-    tag: 1.60.0
+    repository: mesosphere/konvoy-ui
+    tag: 1.65.30
     pullPolicy: IfNotPresent
   replicas: 1
   logoutRedirectPath: /ops/landing
   clusterPollingInterval: 3000
   clientPollingInterval: 3000
 
-  # Mode must be either production|konvoy
-  mode: konvoy
-
   displayName: Konvoy Cluster
-
-  createObservableClusterCRD: true
 
   extraInitContainers:
 


### PR DESCRIPTION
Now that Konvoy-UI can be built separately from Kommander, let's make use of that by giving it an own chart. There's no need for the ObservableClusters-CRD anymore in the context of Konvoy-UI. 🎉

@shaneutt, @hectorj2f please have a thorough look, as this is the first time i wrote a chart. There's definitely the need to update the `requirements.lock` of `opsportal`.

How to make sure this gets deployed? Is there anything the frontend-folks can do to test/debug this further?