### PR TITLE
Ae/kommander/required

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,6 +3,6 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.60.0"
 description: Kommander
-version: 0.1.23
+version: 0.1.24
 maintainers:
   - name: hectorj2f

--- a/stable/kommander/requirements.lock
+++ b/stable/kommander/requirements.lock
@@ -2,5 +2,6 @@ dependencies:
 - name: kubefed
   repository: https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
   version: 0.1.0-rc6
+  condition: federate.enabled
 digest: sha256:5fe6d688eec7066fd321adf8126fa026a239ddebf03929e395916e3c7cdbedaa
 generated: "2019-09-09T10:02:06.998354-07:00"

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -51,6 +51,8 @@ federate:
 # This name must match the name of the kubefed dep
 # in order to override values.
 kubefed:
+  # set to false if you wish to run kommander without deploying kubefed (not recommended)
+  enabled: true
   controllermanager:
     # override value is necessary due to a "featureGates":interface {}(nil)... spec.featureGates in body must be of type array: "null"
     # bug found


### PR DESCRIPTION
Allow the option to enable or disable kubefed for future deployments. 

This is more for tidying things up and allow deployment of kommander without necessarily including kubefed as will most likely be required in the future. 