### PR TITLE
Add Kubeaddons Catalog Chart

### DIFF
--- a/staging/kubeaddons-catalog/Chart.yaml
+++ b/staging/kubeaddons-catalog/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "v0.0.1-alpha1"
+description: "A Catalog service for Kubeaddons"
+name: kubeaddons-catalog
+version: 0.0.1
+home: https://github.com/mesosphere/kubeaddons
+sources:
+- https://github.com/mesosphere/kubeaddons/tools/catalog
+maintainers:
+- name: shaneutt
+  email: shaneutt@linux.com

--- a/staging/kubeaddons-catalog/templates/_helpers.tpl
+++ b/staging/kubeaddons-catalog/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubeaddons-catalog.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubeaddons-catalog.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubeaddons-catalog.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubeaddons-catalog.labels" -}}
+app.kubernetes.io/name: {{ include "kubeaddons-catalog.name" . }}
+helm.sh/chart: {{ include "kubeaddons-catalog.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/staging/kubeaddons-catalog/templates/deployment.yaml
+++ b/staging/kubeaddons-catalog/templates/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubeaddons-catalog.fullname" . }}
+  labels:
+{{ include "kubeaddons-catalog.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kubeaddons-catalog.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kubeaddons-catalog.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /v1alpha1/repositories
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /v1alpha1/repositories
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/staging/kubeaddons-catalog/templates/service.yaml
+++ b/staging/kubeaddons-catalog/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubeaddons-catalog.fullname" . }}
+  labels:
+{{ include "kubeaddons-catalog.labels" . | indent 4 }}
+spec:
+  ports:
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: {{ include "kubeaddons-catalog.fullname" . }}
+    app.kubernetes.io/name: {{ include "kubeaddons-catalog.fullname" . }}
+  sessionAffinity: None
+  type: {{ .Values.service.type }}

--- a/staging/kubeaddons-catalog/values.yaml
+++ b/staging/kubeaddons-catalog/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: mesosphere/kubeaddons-catalog
+  tag: stable
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
This adds the Kubeaddons Catalog as a staging chart for testing use while the app itself is in alpha.

This chart was tested locally via port-forward (no ingress is wanted at this point, will be added in later iterations).

Resolves [DCOS-59097](https://jira.mesosphere.com/browse/DCOS-59097)