### PR TITLE
Add pre-upgrade on all new hooks

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.6.0
+version: 1.6.1
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/certificate.yaml
+++ b/stable/dex/templates/certificate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dex
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
 spec:
   secretName: dex
   issuerRef:

--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.10.0
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/templates/issuers.yaml
+++ b/staging/cert-manager-setup/templates/issuers.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kubernetes-root-issuer
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-4"
 spec:
   ca:
@@ -16,7 +16,7 @@ kind: Certificate
 metadata:
   name: kubernetes-intermediate-ca
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-3"
 spec:
   isCA: true
@@ -35,7 +35,7 @@ kind: ClusterIssuer
 metadata:
   name: {{ required "clusterissuer must have a name" .Values.clusterissuer.name }}
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-2"
 spec:
 {{ required "clusterissuer must have a spec" .Values.clusterissuer.spec | toYaml | indent 4 }}

--- a/staging/cert-manager-setup/templates/post-install-hook-job.yaml
+++ b/staging/cert-manager-setup/templates/post-install-hook-job.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "cert-manager-setup.labels" . | indent 4 }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-6"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
@@ -27,7 +27,7 @@ metadata:
   labels:
 {{ include "cert-manager-setup.labels" . | indent 4 }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:

--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.0
+version: 1.72.1
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/certificate.yaml
+++ b/staging/traefik/templates/certificate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik
   namespace: kubeaddons
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
 spec:
   secretName: traefik-certificate
   issuerRef:


### PR DESCRIPTION
Add `pre-upgrade/post-upgrade` to all `pre-install/post-install` hooks in the `dex`, `traefik` and `cert-manager`.