### PR TITLE
use curl to get docs archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,10 @@ stablerepo: $(STABLE_TARGETS) | docs/stable/index.yaml
 
 .PHONY: publish
 publish:
-	@git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1 || true
-	@git fetch publish master
-	@git checkout master
-	@mv docs docs~
-	@git reset --hard $(GIT_REF)
-	@rm -rf docs
-	@mv docs~ docs
+	-git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1
+	-@git branch -D master
+	@git checkout -b master
+	@curl -Ls https://github.com/mesosphere/charts/archive/master.tar.gz | tar -xz --strip-components=1 charts-master/docs
 	@make all
 	@git add .
 	@git commit -m "$(LAST_COMMIT_MESSAGE)"


### PR DESCRIPTION
Rather than working around git to try to grab the archived history of
the docs directory, use curl to get it directly.