### PR TITLE
Do not set WHITELIST in traefik-forward-auth if whitelist is empty.

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.2.0
+version: 0.2.1
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/deployment.yaml
+++ b/staging/traefik-forward-auth/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
                 secretKeyRef:
                   name: {{ required "traefikForwardAuth.allowedUser.valueFrom.secretKeyRef.name is required" .Values.traefikForwardAuth.allowedUser.valueFrom.secretKeyRef.name }}
                   key: {{ required "traefikForwardAuth.allowedUser.valueFrom.secretKeyRef.key is required" .Values.traefikForwardAuth.allowedUser.valueFrom.secretKeyRef.key }}
-            {{- else }}
+            {{- else if gt (len .Values.traefikForwardAuth.whitelist) 0 }}
             - name: WHITELIST
               value: {{ join "," .Values.traefikForwardAuth.whitelist | quote }}
             {{- end }}


### PR DESCRIPTION
WHITELIST is currently alwyas set on the traefik-forward-auth deployment even if it is not needed.

If it is set, then domain-based authentication will not work.

This allows users to use oauth with the following configuration in Konvoy:

```
    - name: traefik-forward-auth
      enabled: true
      values: |
        traefikForwardAuth:
          extraConfig: |
            domain = "d2iq.com"
          whitelist: []
          allowedUser:
            valueFrom:
              secretKeyRef:
```