### PR TITLE
stable/awsebscsi: fix role not being created and add env to values

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - name: alejandroEsc
   - name: gpaul
   - name: hectorj2f
-version: 0.3.0
+version: 0.3.1
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/templates/roles.yaml
+++ b/stable/awsebscsiprovisioner/templates/roles.yaml
@@ -170,6 +170,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- end}}
 
+---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:

--- a/stable/awsebscsiprovisioner/templates/statefulset.yaml
+++ b/stable/awsebscsiprovisioner/templates/statefulset.yaml
@@ -32,6 +32,10 @@ spec:
             - --logtostderr
             - --v=5
           env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ tpl $value $ | quote }}
+            {{- end }}
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: AWS_ACCESS_KEY_ID

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -18,6 +18,8 @@ tolerations:
   - key: CriticalAddonsOnly
     operator: Exists
 
+env: {}
+
 registrar:
   node:
     image:


### PR DESCRIPTION
Adding `env: {}` to awsebscsi driver to be able to pass HTTP_PROXY settings.

Also fixed in roles since it was not creating `ebs-csi-snapshotter-binding` correctly. 

**Merging into `master` because it looks like thats the main branch now**