### PR TITLE
cert-manager-setup: bump certs duration to 10years

### DIFF
--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.10.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/templates/issuers.yaml
+++ b/staging/cert-manager-setup/templates/issuers.yaml
@@ -21,6 +21,7 @@ metadata:
 spec:
   isCA: true
   commonName: cert-manager
+  duration: 87600h
   secretName: kubernetes-intermediate-ca
   issuerRef:
     name: kubernetes-root-issuer


### PR DESCRIPTION
Bump the Kubernetes intermediate CA cert duration to 10 years. The
default value is 90 days, which is way too short. Until we figure out a
good cert rotation story, it's better to use a longer duration to be
safe.