### PR TITLE
dex: bump cert duration to 10 years

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.6.1
+version: 1.6.2
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/certificate.yaml
+++ b/stable/dex/templates/certificate.yaml
@@ -11,6 +11,7 @@ spec:
     name: kubernetes-ca
     kind: ClusterIssuer
   commonName: dex
+  duration: 87600h
   organization:
     - D2iQ
   dnsNames:


### PR DESCRIPTION
The default value is 90 days, which is way too short.  Until we figure
out a good cert rotation story, it's better to use a longer duration to
be safe.