### PR TITLE
velero: add ability to provide service annotations to the minio service

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -16,4 +16,4 @@ name: velero
 sources:
 - https://github.com/heptio/velero
 tillerVersion: '>=2.10.0'
-version: 2.2.4
+version: 2.2.5

--- a/staging/velero/templates/deployment.yaml
+++ b/staging/velero/templates/deployment.yaml
@@ -118,15 +118,24 @@ spec:
     {{- end }}
 {{- if or .Values.initContainers .Values.minioBackend }}
       initContainers:
-        {{- with .Values.minioBackend }}
+        {{- if .Values.minioBackend }}
         - name: initialize-velero
-          image: mesosphere/kubeaddons-addon-initializer:v0.0.5
+          image: mesosphere/kubeaddons-addon-initializer:v0.0.10
           args: ["velero"]
           env:
           - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"
             value: "velero-kubeaddons"
           - name: "MINIO_CREATE_LOADBALANCER"
             value: "true"
+          {{- if and .Values.minioBackendConfiguration.service .Values.minioBackendConfiguration.service.annotations }}
+          {{- if ne (len .Values.minioBackendConfiguration.service.annotations) 0 }}
+          - name: "MINIO_LOADBALANCER_SERVICE_ANNOTATIONS"
+            value: |
+            {{- range $key, $value := .Values.minioBackendConfiguration.service.annotations }}
+              {{ $key }}:{{ $value }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
         {{- end }}
         {{- with .Values.initContainers }}
         {{- toYaml .Values.initContainers | nindent 8 }}

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -192,6 +192,11 @@ configMaps: {}
 # Deploy a default Minio cluster to use as the backend for Velero.
 minioBackend: false
 
+minioBackendConfiguration:
+  service:
+    annotations: {}
+    #   key: value
+
 ##
 ## End of additional Velero resource settings.
 ##


### PR DESCRIPTION
Depends on https://github.com/mesosphere/kubeaddons-extrasteps/pull/19

Waiting on that PR to be merged and retag the image.