### PR TITLE
cert-manager: fix upgrade issue with hooks

### DIFF
--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.10.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/templates/issuers.yaml
+++ b/staging/cert-manager-setup/templates/issuers.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   ca:
     secretName: kubernetes-root-ca
@@ -18,6 +19,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   isCA: true
   commonName: cert-manager
@@ -38,6 +40,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
 {{ required "clusterissuer must have a spec" .Values.clusterissuer.spec | toYaml | indent 4 }}
 {{ end }}

--- a/staging/cert-manager-setup/templates/post-install-hook-job.yaml
+++ b/staging/cert-manager-setup/templates/post-install-hook-job.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-6"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:
@@ -29,7 +29,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:


### PR DESCRIPTION
Currently, upgrade will fail with "already exists" because the hook
resources are not managed by helm.

To be backwards compatible, we'll have to add the following:
"helm.sh/hook-delete-policy": before-hook-creation

The side effect of this is that the certificates will be re-newed
everything we do upgrade. This is fine because all services including
API server are using root CA for TLS verficiation. Re-newing the
intermediate certs shouldn't affect running services.