### PR TITLE
Grant Prometheus access to namespaces and configmaps

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.19.1
+version: 5.19.2
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/staging/prometheus-operator/templates/prometheus/clusterrole.yaml
+++ b/staging/prometheus-operator/templates/prometheus/clusterrole.yaml
@@ -25,6 +25,14 @@ rules:
   - endpoints
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get", "create"]
 - apiGroups:
   - extensions
   resources:

--- a/staging/prometheus-operator/templates/prometheus/clusterrole.yaml
+++ b/staging/prometheus-operator/templates/prometheus/clusterrole.yaml
@@ -25,6 +25,17 @@ rules:
   - endpoints
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+# The following namespaces and configmaps permissions are needed to
+# grab the kube-system namespace uid and write it out to a configmap.
+# This is run in a container in the Prometheus pod,
+# see: https://github.com/mesosphere/kubeaddons-extrasteps/tree/master/pkg/prometheus/prometheus.go
 - apiGroups: [""]
   resources:
   - namespaces
@@ -33,11 +44,4 @@ rules:
   resources:
   - configmaps
   verbs: ["get", "create"]
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs: ["get", "list", "watch"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
 {{- end }}


### PR DESCRIPTION
This grants the Prometheus pod access to "get" namespaces and "get"/"create" configmaps. This is needed so that a container running in the pod can get the kube-system namespace's UID and then create a configmap containing that UID (`cluster_id: <uid>`) -- [see pr here](https://github.com/mesosphere/kubeaddons-extrasteps/pull/22). That configmap is then used in the `prometheus-config-reloader` container to set env variables, which is used to populate prometheus config `externalLabels`'s `cluster` label.