### PR TITLE
Use D2iQ repo names in traefik-forward-auth chart

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.2.3
+version: 0.2.4
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - traefik-forward-auth
   - traefik
   - oauth
-home: https://github.com/jongiddy/traefik-forward-auth
+home: https://github.com/mesosphere/traefik-forward-auth
 maintainers:
   - name: jongiddy
     email: jgiddy@mesosphere.com

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: jongiddy/traefik-forward-auth
-  tag: latest
+  repository: mesosphere/traefik-forward-auth
+  tag: 1.0.4
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
Update names in the traefik-forward-auth chart