### PR TITLE
adding kudo as a chart

### DIFF
--- a/staging/kudo/.helmignore
+++ b/staging/kudo/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/staging/kudo/Chart.yaml
+++ b/staging/kudo/Chart.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "0.7.4"
 description: "Kubernetes Universal Declarative Operator"
 name: kudo
-version: 0.7.4
+version: 0.1.0
 home: https://kudo.dev
 sources:
 - https://github.com/kudobuilder/kudo
+icon: https://raw.githubusercontent.com/kudobuilder/www/master/content/.vuepress/public/favicon.ico
 maintainers:
 - name: kensipe
   email: kensipe@gmail.com

--- a/staging/kudo/Chart.yaml
+++ b/staging/kudo/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: "1.0"
+description: "Kubernetes Universal Declarative Operator"
+name: kudo
+version: 0.7.4
+home: https://kudo.dev
+sources:
+- https://github.com/kudobuilder/kudo
+maintainers:
+- name: kensipe
+  email: kensipe@gmail.com
+- name: Alena Varkockova
+  email: avarkockova@mesosphere.com
+- name: Gerred Dillon
+  email: gdillon@d2iq.com
+- name: Aleksey Dukhovniy
+  email: adukhovniy@d2iq.com

--- a/staging/kudo/Chart.yaml
+++ b/staging/kudo/Chart.yaml
@@ -10,9 +10,9 @@ icon: https://raw.githubusercontent.com/kudobuilder/www/master/content/.vuepress
 maintainers:
 - name: kensipe
   email: kensipe@gmail.com
-- name: Alena Varkockova
+- name: alenkacz
   email: avarkockova@mesosphere.com
-- name: Gerred Dillon
+- name: gerred
   email: gdillon@d2iq.com
-- name: Aleksey Dukhovniy
+- name: zen-dog
   email: adukhovniy@d2iq.com

--- a/staging/kudo/README.md
+++ b/staging/kudo/README.md
@@ -1,0 +1,38 @@
+# KUDO
+
+[KUDO](https://kudo.dev/) is a Kubernetes Universal Declarative Operator.
+
+## Introduction
+
+KUDO is currently under heavy development and requires a `kudo-system` namespace which is created when KUDO is installed with helm.
+
+## Prerequisites
+
+- Kubernetes 1.16+ based on CRD v1 release
+
+
+## Installing the Chart
+
+```bash
+$ helm install --name kudo  ./kudo
+```
+
+Installing with a new controller version:
+
+```bash
+$ helm install --name kudo  ./kudo --set image.tag=v0.7.3
+```
+
+Installing in a cluster which already has the CRDs.
+
+```bash
+$ helm install --name kudo  ./kudo --set installCRD=false
+```
+
+
+## Uninstalling the Chart
+
+```bash
+$ helm delete kudo
+$ helm del --purge kudo
+```

--- a/staging/kudo/templates/_helpers.tpl
+++ b/staging/kudo/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kudo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kudo.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kudo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kudo.labels" -}}
+app.kubernetes.io/name: {{ include "kudo.name" . }}
+helm.sh/chart: {{ include "kudo.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/staging/kudo/templates/clusterrolebinding.yaml
+++ b/staging/kudo/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kudo-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kudo-manager
+  namespace: kudo-system

--- a/staging/kudo/templates/crds.yaml
+++ b/staging/kudo/templates/crds.yaml
@@ -1,0 +1,232 @@
+{{- if .Values.installCRD }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    controller-tools.k8s.io: "1.0"
+  name: operators.kudo.dev
+spec:
+  group: kudo.dev
+  names:
+    kind: Operator
+    plural: operators
+    singular: operator
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        meta:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            kubernetesVersion:
+              type: string
+            kudoVersion:
+              type: string
+            maintainers:
+              items:
+                properties:
+                  email:
+                    type: string
+                  name:
+                    type: string
+                type: object
+              type: object
+            url:
+              type: string
+          type: object
+        status:
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    controller-tools.k8s.io: "1.0"
+  name: operatorversions.kudo.dev
+spec:
+  group: kudo.dev
+  names:
+    kind: OperatorVersion
+    plural: operatorversions
+    singular: operatorversion
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        meta:
+          type: object
+        spec:
+          properties:
+            connectionString:
+              description: ConnectionString defines a mustached string that can be
+                used to connect to an instance of the Operator
+              type: string
+            crdVersion:
+              type: string
+            dependencies:
+              items:
+                properties:
+                  crdVersion:
+                    description: 'Version captures the requirements for what versions
+                      of the above object are allowed Example: ^3.1.4'
+                    type: string
+                  referenceName:
+                    description: Name specifies the name of the dependency.  Referenced
+                      via this in defaults.config
+                    type: string
+                required:
+                - referenceName
+                - crdVersion
+                type: object
+              type: array
+            operator:
+              type: object
+            parameters:
+              items:
+                properties:
+                  default:
+                    description: Default is a default value if no paramter is provided
+                      by the instance
+                    type: string
+                  description:
+                    description: Description captures a longer description of how
+                      the variable will be used
+                    type: string
+                  displayName:
+                    description: Human friendly crdVersion of the parameter name
+                    type: string
+                  name:
+                    description: 'Name is the string that should be used in the template
+                      file for example, if `name: COUNT` then using the variable `.Params.COUNT`'
+                    type: string
+                  required:
+                    description: Required specifies if the parameter is required to
+                      be provided by all instances, or whether a default can suffice
+                    type: boolean
+                  trigger:
+                    description: Trigger identifies the plan that gets executed when
+                      this parameter changes in the Instance object. Default is `update`
+                      if present, or `deploy` if not present
+                    type: string
+                type: object
+              type: array
+            plans:
+              description: Plans specify a map a plans that specify how to
+              type: object
+            tasks:
+              type: object
+            templates:
+              description: List of go templates YAML files that define the application
+                operator instance
+              type: object
+            upgradableFrom:
+              description: UpgradableFrom lists all OperatorVersions that can upgrade
+                to this OperatorVersion
+              items:
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    controller-tools.k8s.io: "1.0"
+  name: instances.kudo.dev
+spec:
+  group: kudo.dev
+  names:
+    kind: Instance
+    plural: instances
+    singular: instance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        meta:
+          type: object
+        spec:
+          properties:
+            OperatorVersion:
+              description: Operator specifies a reference to a specific Operator object
+              type: object
+            dependencies:
+              description: Dependency references specific
+              items:
+                properties:
+                  crdVersion:
+                    description: 'Version captures the requirements for what versions
+                      of the above object are allowed Example: ^3.1.4'
+                    type: string
+                  referenceName:
+                    description: Name specifies the name of the dependency.  Referenced
+                      via this in defaults.config
+                    type: string
+                required:
+                - referenceName
+                - crdVersion
+                type: object
+              type: array
+            parameters:
+              type: object
+          type: object
+        status:
+          properties:
+            aggregatedStatus:
+              type: object
+            planStatus:
+              type: object
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+{{- end }}

--- a/staging/kudo/templates/deployment.yaml
+++ b/staging/kudo/templates/deployment.yaml
@@ -1,0 +1,59 @@
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kudo-controller-manager
+  namespace: kudo-system
+spec:
+  selector:
+    matchLabels:
+      app: kudo-manager
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  serviceName: kudo-controller-manager-service
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kudo-manager
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - command:
+        - /root/manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SECRET_NAME
+          value: kudo-webhook-server-secret
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: manager
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
+      serviceAccountName: kudo-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kudo-webhook-server-secret
+  updateStrategy: {}

--- a/staging/kudo/templates/deployment.yaml
+++ b/staging/kudo/templates/deployment.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -42,9 +41,9 @@ spec:
           name: webhook-server
           protocol: TCP
         resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
+          {{ with .Values.resources }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         volumeMounts:
         - mountPath: /tmp/cert
           name: cert

--- a/staging/kudo/templates/namespace.yaml
+++ b/staging/kudo/templates/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: kudo-manager
+    controller-tools.k8s.io: "1.0"
+  name: kudo-system

--- a/staging/kudo/templates/secret.yaml
+++ b/staging/kudo/templates/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: kudo-webhook-server-secret
+  namespace: kudo-system

--- a/staging/kudo/templates/service.yaml
+++ b/staging/kudo/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kudo-manager
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kudo-controller-manager-service
+  namespace: kudo-system
+spec:
+  ports:
+  - name: kudo
+    port: 443
+    targetPort: webhook-server
+  selector:
+    app: kudo-manager
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"

--- a/staging/kudo/templates/serviceaccount.yaml
+++ b/staging/kudo/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+  name: kudo-manager
+  namespace: kudo-system

--- a/staging/kudo/values.yaml
+++ b/staging/kudo/values.yaml
@@ -1,0 +1,34 @@
+replicaCount: 1
+
+image:
+  repository: kudobuilder/controller
+  tag: v0.7.4
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+crds:
+  forceDeploy: false
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 50Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# When installing addons on a cluster that already has kudo crds
+# installed this value should be set to false. This is necessary because
+# CRDs and Webhook (APIService) objects are cluster wide global scoped
+# without a namespace. That prevents to install 2 webhook configurations
+# for 2 instances of cert-manager.
+#
+installCRD: true

--- a/staging/kudo/values.yaml
+++ b/staging/kudo/values.yaml
@@ -5,13 +5,6 @@ image:
   tag: v0.7.4
   pullPolicy: IfNotPresent
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
-
-service:
-  type: ClusterIP
-  port: 80
 
 crds:
   forceDeploy: false
@@ -20,10 +13,6 @@ resources:
   requests:
     cpu: 100m
     memory: 50Mi
-
-nodeSelector: {}
-tolerations: []
-affinity: {}
 
 # When installing addons on a cluster that already has kudo crds
 # installed this value should be set to false. This is necessary because

--- a/staging/kudo/values.yaml
+++ b/staging/kudo/values.yaml
@@ -5,14 +5,13 @@ image:
   tag: v0.7.4
   pullPolicy: IfNotPresent
 
-
-crds:
-  forceDeploy: false
-
 resources:
   requests:
     cpu: 100m
     memory: 50Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
 
 # When installing addons on a cluster that already has kudo crds
 # installed this value should be set to false. This is necessary because


### PR DESCRIPTION
This is a tested version of a kudo chart for v0.7.4.   

**Notes:**
1. install `helm install --name kudo  ./kudo`
2. kudo currently does NOT support being in a namespace other than `kudo-system`.  This chart creates that ns and all manifests directly use that ns (until some future time)
3. it is possible to use a different version... to do so pass a different image tag `helm install --name kudo  ./kudo --set image.tag=v0.7.3`
4. it is possible to install without CRDs... pass `--set installCRD=false`

Fixes: https://github.com/kudobuilder/kudo/issues/920