### PR TITLE
dex-controller: bump to 0.2.1

### DIFF
--- a/stable/dex-controller/Chart.yaml
+++ b/stable/dex-controller/Chart.yaml
@@ -3,6 +3,6 @@ name: dex-controller
 home: https://github.com/mesosphere/dex-controller
 appVersion: "v0.2.0"
 description: Dex controller
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: jieyu

--- a/stable/dex-controller/templates/deployments.yaml
+++ b/stable/dex-controller/templates/deployments.yaml
@@ -40,7 +40,6 @@ spec:
           {{- end }}
       - args:
         - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
         command:
         - /manager
         image: {{ .Values.controller.manager.image }}

--- a/stable/dex-controller/values.yaml
+++ b/stable/dex-controller/values.yaml
@@ -9,7 +9,7 @@ controller:
     resources:
       limits:
         cpu: 100m
-        memory: 30Mi
+        memory: 100Mi
       requests:
         cpu: 100m
         memory: 20Mi


### PR DESCRIPTION
This removes the leader election flag to workaround a potential bug in
controller runtime that might cause leader election to stuck.