### PR TITLE
kommander: update version + increase polling interval

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: kommander
 home: https://github.com/mesosphere/kommander
-appVersion: "1.116.17"
+appVersion: "1.141.4"
 description: Kommander
-version: 0.1.38
+version: 0.1.39
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/kommander/templates/deployment.yaml
+++ b/stable/kommander/templates/deployment.yaml
@@ -66,3 +66,7 @@ spec:
               value: {{ .Values.clusterPollingInterval | quote }}
             - name: CLIENT_POLLING_INTERVAL
               value: {{ .Values.clientPollingInterval | quote }}
+            - name: HOST_POLLING_INTERVAL
+              value: {{ .Values.hostPollingInterval | quote }}
+            - name: SUPPORTED_KUBERNETES_VERSIONS
+              value: {{ .Values.kubernetesVersionsSelection | toJson  }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -1,12 +1,13 @@
 image:
   repository: mesosphere/kommander
-  tag: 1.116.17
+  tag: 1.141.4
   pullPolicy: IfNotPresent
 replicas: 1
 logoutRedirectPath: /ops/landing
 clusterPollingInterval: 3000
 clientPollingInterval: 3000
-
+hostPollingInterval: 3000
+kubernetesVersionsSelection: '[{"kubernetesVersion":"1.15.4","konvoyVersion":"v1.3.0-kommander-beta2","kubeaddonsVersion":"kommander-beta2"},{"kubernetesVersion":"1.15.3","konvoyVersion":"v1.1.5","kubeaddonsVersion":"stable-1.15.3-4"}]'
 
 # Mode must be either production|konvoy
 mode: production


### PR DESCRIPTION
Not the beta2 version by any means just wanted to go ahead and fix the polling value and add the temporary hardcoding to support konvoy 1.3 clusters.