### PR TITLE
kommander: increase timeout for liveness, env maintenance

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: kommander
 home: https://github.com/mesosphere/kommander
-appVersion: "1.141.4"
+appVersion: "1.145.6"
 description: Kommander
-version: 0.1.42
+version: 0.1.43
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/kommander/templates/deployment.yaml
+++ b/stable/kommander/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
               port: 4000
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           env:
             - name: FED_NAMESPACE
               valueFrom:
@@ -64,8 +65,8 @@ spec:
               value: {{ .Values.mode | quote }}
             - name: CLUSTER_POLLING_INTERVAL
               value: {{ .Values.clusterPollingInterval | quote }}
-            - name: CLIENT_POLLING_INTERVAL
-              value: {{ .Values.clientPollingInterval | quote }}
+            - name: CLUSTER_POLLING_THROTTLE_FACTOR
+              value: {{ .Values.clusterPollingThrottleFactor | quote }}
             - name: HOST_POLLING_INTERVAL
               value: {{ .Values.hostPollingInterval | quote }}
             - name: SUPPORTED_KUBERNETES_VERSIONS

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -1,13 +1,13 @@
 image:
   repository: mesosphere/kommander
-  tag: 1.141.4
+  tag: 1.145.6
   pullPolicy: IfNotPresent
 replicas: 1
 logoutRedirectPath: /ops/landing
 clusterPollingInterval: 3000
-clientPollingInterval: 3000
 hostPollingInterval: 3000
-kubernetesVersionsSelection: '[{"kubernetesVersion":"1.15.4","konvoyVersion":"v1.3.0-kommander-beta2","kubeaddonsVersion":"kommander-beta2"},{"kubernetesVersion":"1.15.3","konvoyVersion":"v1.1.5","kubeaddonsVersion":"stable-1.15.3-4"}]'
+clusterPollingThrottleFactor: 1
+kubernetesVersionsSelection: '[{"kubernetesVersion":"1.15.4","konvoyVersion":"v1.3.0-kommander-beta3","kubeaddonsVersion":"kommander-beta3"},{"kubernetesVersion":"1.15.3","konvoyVersion":"v1.1.5","kubeaddonsVersion":"stable-1.15.3-4"}]'
 
 # Mode must be either production|konvoy
 mode: production
@@ -21,7 +21,7 @@ extraInitContainers:
 
 resources:
   requests:
-    memory: "128Mi"
+    memory: "256Mi"
     cpu: "100m"
   limits:
     memory: "512Mi"
@@ -29,10 +29,11 @@ resources:
 
 readinessProbe:
   initialDelaySeconds: 15
-  periodSeconds: 3
+  periodSeconds: 10
 livenessProbe:
   initialDelaySeconds: 15
-  periodSeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 3
 
 ### This must match the serviceName set in the ingress backend below
 service:

--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0.0"
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -64,7 +64,6 @@ opsportal:
           servicePort: 80
         path: /ops/portal/traefik
 
-
 ###############################################################################
 #  Konvoy UI
 ###############################################################################
@@ -72,12 +71,11 @@ kommander:
   enabled: true
   image:
     repository: mesosphere/kommander
-    tag: 1.114.5
+    tag: 1.145.6
     pullPolicy: IfNotPresent
   replicas: 1
   logoutRedirectPath: /ops/landing
   clusterPollingInterval: 3000
-  clientPollingInterval: 3000
 
   # Mode must be either production|konvoy
   mode: konvoy
@@ -98,10 +96,11 @@ kommander:
 
   readinessProbe:
     initialDelaySeconds: 15
-    periodSeconds: 3
+    periodSeconds: 10
   livenessProbe:
     initialDelaySeconds: 15
-    periodSeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 3
 
   ### This must match the serviceName set in the ingress backend below
   service:


### PR DESCRIPTION
I noticed during MWT that when Kommander was very busy polling large numbers of clusters the default liveness timeout of 1 second was sometimes not enough time for kommander to respond and this would send the pod into a termination loop.

I also added and removed some env variables to reflect the actual env config.