### PR TITLE
Add support for custom annotations

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.6.9
+version: 1.6.10
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -15,6 +15,10 @@ metadata:
     chart: {{ template "dex.chart" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -13,6 +13,8 @@ nodeSelector: {}
 
 podAnnotations: {}
 
+deploymentAnnotations: {}
+
 initContainers: []
 
 tolerations: []

--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.1.1"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.1.11
+version: 1.1.12
 home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mintel/dex-k8s-authenticator

--- a/staging/dex-k8s-authenticator/templates/deployment.yaml
+++ b/staging/dex-k8s-authenticator/templates/deployment.yaml
@@ -14,6 +14,10 @@ metadata:
     chart: {{ template "dex-k8s-authenticator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -100,6 +100,8 @@ tolerations: []
 
 affinity: {}
 
+deploymentAnnotations: {}
+
 # Init containers to add to the Dex K8s Authenticator deployment's pod spec. Optional.
 initContainers: []
 # - name:

--- a/staging/kube-oidc-proxy/Chart.yaml
+++ b/staging/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.1.1"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/mesosphere/charts
 name: kube-oidc-proxy
-version: 0.1.6
+version: 0.1.7
 sources:
 - https://github.com/jetstack/kube-oidc-proxy
 maintainers:

--- a/staging/kube-oidc-proxy/templates/deployment.yaml
+++ b/staging/kube-oidc-proxy/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "kube-oidc-proxy.fullname" . }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/staging/kube-oidc-proxy/values.yaml
+++ b/staging/kube-oidc-proxy/values.yaml
@@ -84,6 +84,8 @@ env: {}
 
 initContainers: []
 
+deploymentAnnotations: {}
+
 nodeSelector: {}
 
 tolerations: []

--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.2.6
+version: 0.2.7
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/deployment.yaml
+++ b/staging/traefik-forward-auth/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "traefik-forward-auth.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -78,3 +78,5 @@ tolerations: []
 affinity: {}
 
 initContainers: []
+
+deploymentAnnotations: {}

--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.6
+version: 1.72.7
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/deployment.yaml
+++ b/staging/traefik/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ default 1 .Values.replicas }}
   selector:

--- a/staging/traefik/templates/init-cert-job.yaml
+++ b/staging/traefik/templates/init-cert-job.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
   labels:
     chart: {{ template "traefik.chart" . }}
-    app: {{ template "traefik.name" . }}  
+    app: {{ template "traefik.name" . }}
 spec:
   template:
     metadata:
@@ -36,6 +36,6 @@ spec:
         - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
           value: "traefik-kubeaddons-certificate"
         - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
-          value: "konvoyaddons-kubeaddons"
+          value: "konvoyconfig-kubeaddons"
         - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
           value: "clusterHostname"

--- a/staging/traefik/templates/init-cert-rbac.yaml
+++ b/staging/traefik/templates/init-cert-rbac.yaml
@@ -31,3 +31,16 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "traefik.fullname" . }}-cert-init
   namespace: {{ .Release.Namespace }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "traefik.fullname" . }}-default-cert-init
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: update-traefik-cert
+subjects:
+- kind: ServiceAccount
+  name: {{ template "traefik.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -50,6 +50,8 @@ env: {}
 
 initContainers: []
 
+deploymentAnnotations: {}
+
 nodeSelector: {}
   # key: value
 affinity: {}


### PR DESCRIPTION
* Add support for injecting custom annotations to multiple charts
* Fix wrong `TRAEFIK_KONVOY_ADDONS_CONFIG_MAP` value
* Allow traefik init container to update its end-entity certificate

This PR prepares for introducing new component - Reloader https://github.com/stakater/Reloader