### PR TITLE
kommander: enable federation of kubeaddons controller

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,7 +3,7 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.145.6"
 description: Kommander
-version: 0.1.44
+version: 0.1.45
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/kommander/templates/federated-kubeaddons.yaml
+++ b/stable/kommander/templates/federated-kubeaddons.yaml
@@ -1,12 +1,4 @@
 {{- if and .Values.federate.customresourcedefinitions .Values.kubefed.enabled }}
-
-{{- if .Values.federate.createKubeaddonsNamespace }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kubeaddons
-{{- end}}
 ---
 apiVersion: types.kubefed.io/v1beta1
 kind: FederatedNamespace

--- a/stable/kommander/templates/federated-kubeaddons.yaml
+++ b/stable/kommander/templates/federated-kubeaddons.yaml
@@ -1,0 +1,503 @@
+{{- if and .Values.federate.customresourcedefinitions .Values.kubefed.enabled }}
+
+{{- if .Values.federate.createKubeaddonsNamespace }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeaddons
+{{- end}}
+---
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedNamespace
+metadata:
+  name: kubeaddons
+  namespace: kubeaddons
+spec:
+  placement:
+    clusterSelector:
+      matchLabels: {}
+  template:
+    spec: {}
+---
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedCustomResourceDefinition
+metadata:
+  name: addons.kubeaddons.mesosphere.io
+spec:
+  placement:
+    clusterSelector:
+      matchLabels: {}
+  template:
+    spec:
+      additionalPrinterColumns:
+        - JSONPath: .status.ready
+          name: ready
+          type: string
+        - JSONPath: .status.stage
+          name: stage
+          type: string
+      conversion:
+        strategy: None
+      group: kubeaddons.mesosphere.io
+      names:
+        kind: Addon
+        listKind: AddonList
+        plural: addons
+        singular: addon
+      preserveUnknownFields: true
+      scope: Namespaced
+      subresources:
+        status: {}
+      validation:
+        openAPIV3Schema:
+          description: Addon is the Schema for the addons API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AddonSpec defines the desired state of Addon
+              properties:
+                chartReference:
+                  description: ChartReference defines the Helm Chart configuration
+                    of this addon (if applicable)
+                  properties:
+                    chart:
+                      description: Chart is the name of the desired chart to use
+                      type: string
+                    release:
+                      description: Release is the helm release by which to reference
+                        this addon
+                      type: string
+                    repo:
+                      description: Repo is the chart repository to use (if not the
+                        default)
+                      type: string
+                    values:
+                      description: Values is the value configurations defined to configure
+                        the chart
+                      type: string
+                    version:
+                      description: Version is the version of the chart to use
+                      type: string
+                  required:
+                    - chart
+                    - version
+                  type: object
+                cloudProvider:
+                  description: 'CloudProvider defines the cloud providers for which
+                    this addon should be included in the default configuration. If
+                    CloudProvider is omitted, all cloud providers will be included
+                    and the default for each will be set to "enabled". If CloudProvider
+                    is an empty list, this addon will not be part of a generated list
+                    of available addons for implementers of this library to consume.
+                    They may still add this addon to their list and enable it. If
+                    CloudProvider has any entries, only those cloud providers will
+                    receive this addons as an available addon in the generated list.
+                    Any cloud providers absent from the list will not receive this
+                    addon as "available". TODO: come back and replace "generated list"
+                    with the function name that generates this list.'
+                  items:
+                    description: ProviderSpec is configuration specific to a cloud
+                      provider
+                    properties:
+                      enabled:
+                        description: Enabled is a field that can be used by the library
+                          implementer to populate a list of available addons. This
+                          field will allow them to set a default enable or disable
+                          setting.
+                        type: boolean
+                      name:
+                        description: Name is the cloud provider name, ie "aws" or
+                          "none"
+                        type: string
+                      values:
+                        description: Values provides provider specific values which
+                          should be merged into the general values before deployment
+                        type: string
+                    required:
+                      - enabled
+                      - name
+                    type: object
+                  type: array
+                kubernetes:
+                  description: Kubernetes defines configuration options relevant to
+                    the Kubernetes cluster where the addon will be deployed
+                  properties:
+                    maxSupportedVersion:
+                      description: MaxSupportedVersion is the maximum version of Kubernetes
+                        that this addon can be used with
+                      type: string
+                    minSupportedVersion:
+                      description: MinSupportedVersion is the minimum version of Kubernetes
+                        that this addon can be used with
+                      type: string
+                  type: object
+                requires:
+                  description: 'Requires (dependencies) based on LabelSelectors. This
+                    allows for depending on a specific addon, or a label that defines
+                    the capability, ie: test that metadata.labels.cni exists.'
+                  items:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: AddonStatus defines the observed state of Addon
+              properties:
+                ready:
+                  type: boolean
+                stage:
+                  description: Status represents the operational status of an addon
+                  type: string
+              required:
+                - ready
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      version: v1beta1
+      versions:
+        - name: v1beta1
+          served: true
+          storage: true
+---
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedCustomResourceDefinition
+metadata:
+  name: clusteraddons.kubeaddons.mesosphere.io
+spec:
+  placement:
+    clusterSelector:
+      matchLabels: {}
+  template:
+    spec:
+      additionalPrinterColumns:
+        - JSONPath: .status.ready
+          name: ready
+          type: string
+        - JSONPath: .status.stage
+          name: stage
+          type: string
+      conversion:
+        strategy: None
+      group: kubeaddons.mesosphere.io
+      names:
+        kind: ClusterAddon
+        listKind: ClusterAddonList
+        plural: clusteraddons
+        singular: clusteraddon
+      preserveUnknownFields: true
+      scope: Cluster
+      subresources:
+        status: {}
+      validation:
+        openAPIV3Schema:
+          description: ClusterAddon is the Schema for the cluster-scoped addons API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterAddonSpec defines the desired state of Addon
+              properties:
+                chartReference:
+                  description: ChartReference defines the Helm Chart configuration
+                    of this addon (if applicable)
+                  properties:
+                    chart:
+                      description: Chart is the name of the desired chart to use
+                      type: string
+                    release:
+                      description: Release is the helm release by which to reference
+                        this addon
+                      type: string
+                    repo:
+                      description: Repo is the chart repository to use (if not the
+                        default)
+                      type: string
+                    values:
+                      description: Values is the value configurations defined to configure
+                        the chart
+                      type: string
+                    version:
+                      description: Version is the version of the chart to use
+                      type: string
+                  required:
+                    - chart
+                    - version
+                  type: object
+                cloudProvider:
+                  description: 'CloudProvider defines the cloud providers for which
+                    this addon should be included in the default configuration. If
+                    CloudProvider is omitted, all cloud providers will be included
+                    and the default for each will be set to "enabled". If CloudProvider
+                    is an empty list, this addon will not be part of a generated list
+                    of available addons for implementers of this library to consume.
+                    They may still add this addon to their list and enable it. If
+                    CloudProvider has any entries, only those cloud providers will
+                    receive this addons as an available addon in the generated list.
+                    Any cloud providers absent from the list will not receive this
+                    addon as "available". TODO: come back and replace "generated list"
+                    with the function name that generates this list.'
+                  items:
+                    description: ProviderSpec is configuration specific to a cloud
+                      provider
+                    properties:
+                      enabled:
+                        description: Enabled is a field that can be used by the library
+                          implementer to populate a list of available addons. This
+                          field will allow them to set a default enable or disable
+                          setting.
+                        type: boolean
+                      name:
+                        description: Name is the cloud provider name, ie "aws" or
+                          "none"
+                        type: string
+                      values:
+                        description: Values provides provider specific values which
+                          should be merged into the general values before deployment
+                        type: string
+                    required:
+                      - enabled
+                      - name
+                    type: object
+                  type: array
+                kubernetes:
+                  description: Kubernetes defines configuration options relevant to
+                    the Kubernetes cluster where the addon will be deployed
+                  properties:
+                    maxSupportedVersion:
+                      description: MaxSupportedVersion is the maximum version of Kubernetes
+                        that this addon can be used with
+                      type: string
+                    minSupportedVersion:
+                      description: MinSupportedVersion is the minimum version of Kubernetes
+                        that this addon can be used with
+                      type: string
+                  type: object
+                namespace:
+                  description: Namespace defines the namespace for which to deploy
+                    cluster-scoped addon components to (defaults to the same namespace
+                    where the cluster-scoped addon is installed)
+                  type: string
+                requires:
+                  description: 'Requires (dependencies) based on LabelSelectors. This
+                    allows for depending on a specific addon, or a label that defines
+                    the capability, ie: test that metadata.labels.cni exists.'
+                  items:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: AddonStatus defines the observed state of Addon
+              properties:
+                ready:
+                  type: boolean
+                stage:
+                  description: Status represents the operational status of an addon
+                  type: string
+              required:
+                - ready
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      version: v1beta1
+      versions:
+        - name: v1beta1
+          served: true
+          storage: true
+---
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedServiceAccount
+metadata:
+  name: kubeaddons-controller-manager
+  namespace: kubeaddons
+spec:
+  placement:
+    clusterSelector:
+      matchLabels: {}
+  template: {}
+---
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedClusterRoleBinding
+metadata:
+  name: kubeaddons-controller-manager-cluster-admin-binding
+spec:
+  placement:
+    clusterSelector:
+      matchLabels: {}
+  template:
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-admin
+    subjects:
+      - kind: ServiceAccount
+        name: kubeaddons-controller-manager
+        namespace: kubeaddons
+---
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedDeployment
+metadata:
+  name: kubeaddons-controller-manager
+  namespace: kubeaddons
+spec:
+  placement:
+    clusterSelector:
+      matchLabels: {}
+  template:
+    metadata:
+      labels:
+        control-plane: kubeaddons-controller-manager
+    spec:
+      progressDeadlineSeconds: 600
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        matchLabels:
+          control-plane: kubeaddons-controller-manager
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            control-plane: kubeaddons-controller-manager
+        spec:
+          containers:
+            - command:
+                - /manager
+              image: mesosphere/kubeaddons:v0.4.5
+              imagePullPolicy: Always
+              name: manager
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 20Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          serviceAccount: kubeaddons-controller-manager
+          serviceAccountName: kubeaddons-controller-manager
+          terminationGracePeriodSeconds: 10
+{{- end }}

--- a/stable/kommander/templates/federated-kubeaddons.yaml
+++ b/stable/kommander/templates/federated-kubeaddons.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.federate.customresourcedefinitions .Values.kubefed.enabled }}
+{{- if and .Values.federate.kubeaddons .Values.kubefed.enabled }}
 ---
 apiVersion: types.kubefed.io/v1beta1
 kind: FederatedNamespace

--- a/stable/kommander/templates/hooks-kubeaddons.yaml
+++ b/stable/kommander/templates/hooks-kubeaddons.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.federate.customresourcedefinitions .Values.kubefed.enabled }}
+{{- if and .Values.federate.kubeaddons .Values.kubefed.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/kommander/templates/hooks-kubeaddons.yaml
+++ b/stable/kommander/templates/hooks-kubeaddons.yaml
@@ -1,0 +1,65 @@
+{{- if and .Values.federate.customresourcedefinitions .Values.kubefed.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{.Release.Name}}-kubeaddons-ns
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "kommander.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Release.Name}}-kubeaddons-ns
+  labels:
+{{ include "kommander.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Release.Name}}-kubeaddons-ns
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.Release.Name}}-kubeaddons-ns
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "kommander.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{.Release.Name}}
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+        app.kubernetes.io/instance: {{.Release.Name | quote }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{.Release.Name}}-kubeaddons-ns
+          image: "{{.Values.federate.image.repository}}:{{.Values.federate.image.tag}}"
+          imagePullPolicy: {{.Values.federate.image.pullPolicy}}
+          args:
+            - kommander
+            - create-kubeaddons-ns
+{{ end }}

--- a/stable/kommander/templates/hooks-kubeaddons.yaml
+++ b/stable/kommander/templates/hooks-kubeaddons.yaml
@@ -57,8 +57,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{.Release.Name}}-kubeaddons-ns
-          image: "{{.Values.federate.image.repository}}:{{.Values.federate.image.tag}}"
-          imagePullPolicy: {{.Values.federate.image.pullPolicy}}
+          image: "{{.Values.federate.kubeaddonsInitializer.repository}}:{{.Values.federate.kubeaddonsInitializer.tag}}"
+          imagePullPolicy: {{.Values.federate.kubeaddonsInitializer.pullPolicy}}
           args:
             - kommander
             - create-kubeaddons-ns

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -53,9 +53,12 @@ federate:
   clusteraddons: true
   clusterrolebindings: true
   customresourcedefinitions: true
+  kubeaddons: true
   roles: true
   rolebindings: true
 
+  # set to true if you wish to deploy on a non konvoy cluster
+  createKubeaddonsNamespace: false
 
   systemNamespace:
     enable: true

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -57,7 +57,7 @@ federate:
   roles: true
   rolebindings: true
 
-  image:
+  kubeaddonsInitializer:
     repository: "mesosphere/kubeaddons-addon-initializer"
     tag: "v0.1.1"
     pullPolicy: IfNotPresent

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -57,8 +57,11 @@ federate:
   roles: true
   rolebindings: true
 
-  # set to true if you wish to deploy on a non konvoy cluster
-  createKubeaddonsNamespace: false
+  image:
+    repository: "mesosphere/kubeaddons-addon-initializer"
+    tag: "v0.1.1"
+    pullPolicy: IfNotPresent
+
 
   systemNamespace:
     enable: true


### PR DESCRIPTION
change allow federating kubeaddons controller

Tested locally, we assume by default we are deploying on a konvoy cluster, to avoid deleting the kubeaddons namespace when removing the chart. 