### PR TITLE
traefik: adapt self-signed cert generation for MacOS Catalina

### DIFF
--- a/staging/traefik/templates/certificate.yaml
+++ b/staging/traefik/templates/certificate.yaml
@@ -19,7 +19,11 @@ spec:
   issuerRef:
     name: kubernetes-ca
     kind: ClusterIssuer
-  duration: 87600h
+  duration: 800d
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
   organization:
   - D2iQ
   # The commonName will get replaced by kubeaddons-config


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-60297
https://support.apple.com/en-us/HT210176

Upstream cert-manager issue: jetstack/cert-manager#2168

All TLS server certificates issued after July 1, 2019 (as indicated in the NotBefore field of the certificate) must follow these guidelines:

TLS server certificates must contain an ExtendedKeyUsage (EKU) extension containing the id-kp-serverAuth OID.
TLS server certificates must have a validity period of 825 days or fewer (as expressed in the NotBefore and NotAfter fields of the certificate)

For issue 1, confirmed upstream that setting `KeyUsage` to `server auth` is sufficient for now. Updated cert-manager in this PR. We already have Key Usage set to server auth (https://github.com/mesosphere/kubeaddons-extrasteps/blob/master/pkg/traefik/traefik.go#L235) in kubeaddons-extrasteps.

For issue 2, reduced the validity duration in this PR to comply with the new regulations