### PR TITLE
traefik: adapt certificate for new macOS catalina

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.7
+version: 1.72.8
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/certificate.yaml
+++ b/staging/traefik/templates/certificate.yaml
@@ -19,7 +19,13 @@ spec:
   issuerRef:
     name: kubernetes-ca
     kind: ClusterIssuer
-  duration: 87600h
+  # DCOS-60297 Update certificate to comply with Apple security requirements
+  # https://support.apple.com/en-us/HT210176
+  duration: 19200h   # 800 days
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
   organization:
   - D2iQ
   # The commonName will get replaced by kubeaddons-config


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-60297
https://support.apple.com/en-us/HT210176

Upstream cert-manager issue: jetstack/cert-manager#2168

All TLS server certificates issued after July 1, 2019 (as indicated in the NotBefore field of the certificate) must follow these guidelines:

TLS server certificates must contain an ExtendedKeyUsage (EKU) extension containing the id-kp-serverAuth OID.
TLS server certificates must have a validity period of 825 days or fewer (as expressed in the NotBefore and NotAfter fields of the certificate)

For issue 1, confirmed upstream that adding "server auth" to KeyUsage (in addition to default `digital signature` and `key encipherment`) is sufficient for now. 

For issue 2, reduced the validity duration in this PR to comply with the new regulations