### PR TITLE
[stable/kommander-thanos] Truncate addon name

### DIFF
--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0"
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: branden

--- a/stable/kommander-thanos/templates/_helpers.tpl
+++ b/stable/kommander-thanos/templates/_helpers.tpl
@@ -32,6 +32,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create a truncated name suitable for resources that need shorter names, such as addons.
+*/}}
+{{- define "kommander-thanos.short-name-prefix" -}}
+{{- include "kommander-thanos.fullname" . | trunc 30 -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "kommander-thanos.labels" -}}

--- a/stable/kommander-thanos/templates/federated-addon.yaml
+++ b/stable/kommander-thanos/templates/federated-addon.yaml
@@ -1,7 +1,7 @@
 apiVersion: types.kubefed.io/v1beta1
 kind: FederatedAddon
 metadata:
-  name: {{ template "kommander-thanos.fullname" . }}-proxy
+  name: {{ include "kommander-thanos.short-name-prefix" . }}-proxy
   namespace: {{ .Values.federate.systemNamespace.name }}
   labels:
 {{ include "kommander-thanos.labels" . | indent 4 }}
@@ -13,7 +13,7 @@ spec:
     metadata:
       namespace: kubeaddons
       labels:
-        kubeaddons.mesosphere.io/name: {{ template "kommander-thanos.fullname" . }}-proxy
+        kubeaddons.mesosphere.io/name: {{ include "kommander-thanos.short-name-prefix" . }}-proxy
     spec:
       namespace: {{ .Values.federate.systemNamespace.name }} 
       chartReference:


### PR DESCRIPTION
This PR truncates the name of the `mtls-proxy` `FederatedAddon` in order to make sure that when the addon controller tries to install its Helm chart, it generates a release name within the 53-character limit imposed by Helm.

Without this PR, the generated name for the addon's chart release may be too long, resulting in no deployment and an error like this:

```
ERROR    controller-runtime.controller    Reconciler error    {"controller": "addon", "request": "kommander-system/kommander-kubeaddons-kommander-thanos-proxy", "error": "error running cli command `helm status`. stdout: ``, stderr: `Error: invalid release name, must match regex ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$ and the length must not be longer than 53\n`: could not check whether kommander-kubeaddons-kommander-thanos-proxy-kubeaddons exists: exit status 1"}
```

I tested this by running `helm install stable/kommander-thanos --name kommander-kommander-thanos-kubeaddons-very-long-release-name --set thanosAddress=foo --namespace kommander --debug --dry-run` and observing that the `FederatedAddon` name is truncated to 30 characters.