### PR TITLE
kommander-thanos: Add service label for metrics

### DIFF
--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0"
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: branden

--- a/stable/kommander-thanos/values.yaml
+++ b/stable/kommander-thanos/values.yaml
@@ -38,6 +38,9 @@ thanos:
     - "--grpc-client-server-name=server.thanos.localhost.localdomain"
     certSecretName: kommander-thanos-client-tls
     http:
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Adds a service label so that Prometheus can discover the metrics endpoint for Thanos Querier. I will open up another PR once this is merged to bump the kommander-thanos dependency in kommander.