### PR TITLE
chore: remove version selection with konvoy < 1.3

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,7 +3,7 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.145.6"
 description: Kommander
-version: 0.1.50
+version: 0.1.51
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -7,7 +7,7 @@ logoutRedirectPath: /ops/landing
 clusterPollingInterval: 3000
 hostPollingInterval: 3000
 clusterPollingThrottleFactor: 1
-kubernetesVersionsSelection: '[{"kubernetesVersion":"1.15.4","konvoyVersion":"v1.3.0-kommander-beta3","kubeaddonsVersion":"kommander-beta3"},{"kubernetesVersion":"1.15.3","konvoyVersion":"v1.1.5","kubeaddonsVersion":"stable-1.15.3-4"}]'
+kubernetesVersionsSelection: '[{"kubernetesVersion":"1.15.4","konvoyVersion":"v1.3.0-kommander-beta3","kubeaddonsVersion":"kommander-beta3"}]'
 
 # Mode must be either production|konvoy
 mode: production


### PR DESCRIPTION
With latest KCL release, konvoy versions < 1.3 are no longer supported.

Note these should be removed or updated to beta4 tags once konvoy/kubeaddons beta4 released.