### PR TITLE
kommander: enable federated ingress

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,7 +3,7 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.149.0"
 description: Kommander
-version: 0.1.56
+version: 0.1.57
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -77,7 +77,7 @@ kubefed:
     # bug found
     featureGates:
       CrossClusterServiceDiscovery: "Disabled"
-      FederatedIngress: "Disabled"
+      FederatedIngress: "Enabled"
       PushReconciler: "Enabled"
       SchedulerPreferences: "Disabled"
 


### PR DESCRIPTION

> 2) The FederatedIngress type is currently disable for kommander: https://github.com/mesosphere/charts/blob/dev/stable/kommander/values.yaml#L80 ,  I've asked in the k8s-security channel if we can enable it. If not, then we'll need to come up with another way to federate ingress records to member clusters. A federated addon is an obvious solution, but that means the overrides would live in the wrong namespace so we'd have to clean that up explicitly when a cluster is removed.

Source: https://mesosphere.slack.com/archives/CMPPXKGKX/p1572930731128900