### PR TITLE
Prevent name collision of karma and thanos resources

### DIFF
--- a/stable/kommander-karma/Chart.yaml
+++ b/stable/kommander-karma/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0"
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: branden

--- a/stable/kommander-karma/templates/_helpers.tpl
+++ b/stable/kommander-karma/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Create a truncated name suitable for resources that need shorter names, such as addons.
 */}}
 {{- define "kommander-karma.short-name-prefix" -}}
-{{- include "kommander-karma.fullname" . | trunc 30 -}}
+{{- include "kommander-karma.fullname" . | trunc 36 -}}
 {{- end -}}
 
 {{/*

--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0"
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: branden

--- a/stable/kommander-thanos/templates/_helpers.tpl
+++ b/stable/kommander-thanos/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Create a truncated name suitable for resources that need shorter names, such as addons.
 */}}
 {{- define "kommander-thanos.short-name-prefix" -}}
-{{- include "kommander-thanos.fullname" . | trunc 30 -}}
+{{- include "kommander-thanos.fullname" . | trunc 36 -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
This PR increases the length of the shortnames for these charts, which reduces the likelihood that they will generate resources with the same name.

This is intended to fix an issue where deploying Konvoy leads to this Helm error: `Error: release kommander-kubeaddons failed: federatedaddons.types.kubefed.io \"kommander-kubeaddons-kommander-proxy\" already exists`. Without this change, the `kommander-karma` and `kommander-thanos` subcharts create `FederatedAddons` that coincidentally have the same name.