### PR TITLE
Add karma chart with deployment.annotations parameter

### DIFF
--- a/staging/karma/.helmignore
+++ b/staging/karma/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/staging/karma/Chart.yaml
+++ b/staging/karma/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: "v0.50"
+description: A Helm chart for Karma - an UI for Prometheus Alertmanager
+name: karma
+home: https://github.com/prymitive/karma
+sources:
+  - https://hub.docker.com/r/lmierzwa/karma/
+  - https://github.com/prymitive/karma
+version: 1.2.1
+maintainers:
+- name: davidkarlsen
+  email: david@davidkarlsen.com
+- name: prymitive
+  email: l.mierzwa@gmail.com

--- a/staging/karma/Chart.yaml
+++ b/staging/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://hub.docker.com/r/lmierzwa/karma/
   - https://github.com/prymitive/karma
-version: 1.2.1
+version: 1.3.0
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/staging/karma/OWNERS
+++ b/staging/karma/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- davidkarlsen
+- prymitive
+reviewers:
+- davidkarlsen
+- prymitive

--- a/staging/karma/README.md
+++ b/staging/karma/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the karma chart and the
 | `service.type`                      | Type of Service                                        | `ClusterIP`                               |
 | `service.port`                      | Port for kubernetes service                            | `80`                                      |
 | `service.annotations`               | Annotations to add to the service                      | `{}`                                      |
+| `deployment.annotations`            | Annotations to add to the deployment                   | `{}`                                      |
 | `resources.requests.cpu`            | CPU resource requests                                  |                                           |
 | `resources.limits.cpu`              | CPU resource limits                                    |                                           |
 | `resources.requests.memory`         | Memory resource requests                               |                                           |

--- a/staging/karma/README.md
+++ b/staging/karma/README.md
@@ -1,0 +1,82 @@
+# Karma
+
+Karma is an ASL2 licensed alert dashboard for Prometheus Alertmanager.
+
+## Introduction
+
+This chart deploys karma to your cluster via a Deployment and Service.
+Optionally you can also enable ingress.
+
+# Prerequisites
+
+- Kubernetes 1.9+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`, run:
+
+```bash
+$ helm install --name my-release stable/karma
+```
+
+After a few seconds, you should see service statuses being written to the configured output.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the karma chart and their default values.
+
+|             Parameter               |            Description                                 |                    Default                |
+|-------------------------------------|--------------------------------------------------------|-------------------------------------------|
+| `replicaCount`                      | Number of replicas                                     | `1`                                       |
+| `image.repository`                  | The image to run                                       | `lmierzwa/karma`                          |
+| `image.tag`                         | The image tag to pull                                  | `v0.50`                                   |
+| `image.pullPolicy`                  | Image pull policy                                      | `IfNotPresent`                            |
+| `nameOverride`                      | Override name of app                                   | ``                                        |
+| `fullnameOverride`                  | Override full name of app                              | ``                                        |
+| `service.type`                      | Type of Service                                        | `ClusterIP`                               |
+| `service.port`                      | Port for kubernetes service                            | `80`                                      |
+| `service.annotations`               | Annotations to add to the service                      | `{}`                                      |
+| `resources.requests.cpu`            | CPU resource requests                                  |                                           |
+| `resources.limits.cpu`              | CPU resource limits                                    |                                           |
+| `resources.requests.memory`         | Memory resource requests                               |                                           |
+| `resources.limits.memory`           | Memory resource limits                                 |                                           |
+| `ingress`                           | Settings for ingress                                   | `{}`                                      |
+| `nodeSelector`                      | Settings for nodeselector                              | `{}`                                      |
+| `tolerations`                       | Settings for toleration                                | `{}`                                      |
+| `affinity`                          | Settings for affinity                                  | `{}`                                      |
+| `securityContext`                   | Settings for security context                          | `{}`                                      |
+| `serviceAccount.create`             | Create service-account                                 | `true`                                    |
+| `serviceAccount.name`               | Override service-account name                          | ``                                        |
+| `livenessProbe.delay`               | Specify delay in executing probe                       | `5`                                       |
+| `livenessProbe.period`              | Speicy period of liveness probe                        | `5`                                       |
+| `livenessProbe.path`                | Specify path liveness probe should hit                 | `/`                                       |
+| `configMap.enabled`                 | Provide a custom karma configuration                   | `false`                                   |
+| `configMap.rawConfig`               | A karma compatible YAML configuration                  | ``                                        |
+| `certSecretNames`                   | Mount Alertmanager certificates to `/etc/certs/<name>` | `[]`                                      |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    stable/karma
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/karma
+```
+
+> **Tip**: You will have to define the URL to alertmanager in env-settings in [values.yaml](values.yaml), under key ALERTMANAGER_URI .

--- a/staging/karma/ci/test-values.yaml
+++ b/staging/karma/ci/test-values.yaml
@@ -1,0 +1,3 @@
+env:
+- name: ALERTMANAGER_URI
+  value: http://monitoring-prometheus-alertmanager

--- a/staging/karma/templates/NOTES.txt
+++ b/staging/karma/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "karma.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "karma.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "karma.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "karma.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/staging/karma/templates/_helpers.tpl
+++ b/staging/karma/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "karma.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "karma.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "karma.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "karma.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "karma.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/staging/karma/templates/configmap.yaml
+++ b/staging/karma/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.configMap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: "{{ template "karma.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: "{{ .Release.Name }}-config"
+data:
+  karma.conf: |
+{{ toYaml .Values.configMap.rawConfig | indent 4 }}
+{{- end }}
+

--- a/staging/karma/templates/deployment.yaml
+++ b/staging/karma/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "karma.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.deployment.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/staging/karma/templates/deployment.yaml
+++ b/staging/karma/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "karma.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "karma.name" . }}
+    helm.sh/chart: {{ include "karma.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "karma.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "karma.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.configMap.enabled }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ template "karma.serviceAccountName" . }}
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+          {{- if .Values.configMap.enabled }}
+          - name: CONFIG_FILE
+            value: /etc/karma/karma.conf
+          {{- end }}
+          {{- with .Values.env }}
+{{ toYaml . | indent 10 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.delay }}
+            periodSeconds: {{ .Values.livenessProbe.period }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.delay }}
+            periodSeconds: {{ .Values.livenessProbe.period }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+          {{- if .Values.configMap.enabled }}
+            - name: karma-config
+              mountPath: /etc/karma
+          {{- end }}
+          {{- range .Values.certSecretNames }}
+            - name: {{ . }}
+              mountPath: /etc/certs/{{ . }}
+              readOnly: true
+          {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+      {{- if .Values.configMap.enabled }}
+      - name: karma-config
+        configMap:
+          name: {{ .Release.Name }}-config
+      {{- end }}
+      {{- range .Values.certSecretNames }}
+      - name: {{ . }}
+        secret:
+          defaultMode: 420
+          secretName: {{ . }}
+      {{- end }}

--- a/staging/karma/templates/ingress.yaml
+++ b/staging/karma/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "karma.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "karma.name" . }}
+    helm.sh/chart: {{ include "karma.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/staging/karma/templates/service.yaml
+++ b/staging/karma/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "karma.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "karma.name" . }}
+    helm.sh/chart: {{ include "karma.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "karma.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/staging/karma/templates/serviceaccount.yaml
+++ b/staging/karma/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "karma.name" . }}
+    helm.sh/chart: {{ include "karma.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ template "karma.serviceAccountName" . }}
+{{- end }}

--- a/staging/karma/values.yaml
+++ b/staging/karma/values.yaml
@@ -1,0 +1,136 @@
+# Default values for karma.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: lmierzwa/karma
+  tag: v0.50
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+# env:
+# - name: ALERTMANAGER_URI
+#   value: http://monitoring-prometheus-alertmanager
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+    # prometheus.io/scrape: "true"
+  labels: {}
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+securityContext: {}
+
+# configuration for liveness probe
+livenessProbe:
+  delay: 5
+  period: 5
+  path: /
+
+# configMap dictates if a configmap based configuration for Karma should be used
+# to provide advanced configuration. NOTE, you must use port 8080!
+configMap:
+  enabled: false
+  # rawConfig:
+  #   alertmanager:
+  #   interval: 30s
+  #   servers:
+  #     - name: local
+  #       uri: http://localhost:9093
+  #       timeout: 10s
+  #       proxy: true
+  #       headers:
+  #         x-auth-token: some-token
+  #         any-header: string-value
+  #     - name: client-auth
+  #       uri: https://localhost:9093
+  #       timeout: 10s
+  #       tls:
+  #         ca: /etc/ssl/certs/ca-bundle.crt
+  #         cert: /etc/karma/client.pem
+  #         key: /etc/karma/client.key
+  #   annotations:
+  #     default:
+  #       hidden: false
+  #     hidden:
+  #       - help
+  #     visible: []
+  #   filters:
+  #     default:
+  #       - "@receiver=by-cluster-service"
+  #   labels:
+  #     color:
+  #       static:
+  #         - job
+  #       unique:
+  #         - cluster
+  #         - instance
+  #         - "@receiver"
+  #     keep: []
+  #     strip: []
+  #   listen:
+  #     address: "0.0.0.0"
+  #     port: 8080
+  #     prefix: /
+  #   log:
+  #     config: false
+  #     level: info
+  #   jira:
+  #     - regex: DEVOPS-[0-9]+
+  #       uri: https://jira.example.com
+  #   receivers:
+  #     keep: []
+  #     strip: []
+  #   sentry:
+  #     private: secret
+  #   public: 123456789
+
+# Names of secrets that will be mounted to `/etc/certs/<secret_name>` in the karma container.
+# These secrets can be used to configure TLS for Karma's Alertmanagers by passing their paths to
+# the appropriate Karma configuration parameters. For example, secret `foo` containing a `ca.crt`
+# will yield a file at `/etc/certs/foo/ca.crt`. That path can then be provided as the value to
+# `configMap.rawConfig.alertmanager.servers[].tls.ca`.
+# See <https://github.com/prymitive/karma/blob/master/docs/CONFIGURATION.md#alertmanagers>.
+certSecretNames: []

--- a/staging/karma/values.yaml
+++ b/staging/karma/values.yaml
@@ -43,6 +43,9 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+deployment:
+  annotations: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR copies the karma chart from https://github.com/helm/charts/tree/master/stable/karma, and includes the `deployment.annotations` parameter from helm/charts#18686. Copying the chart to this repo is only necessary to pull in the changes from that PR; it can be removed once the PR is merged.

This is necessary in order to set annotations on the deployment that cause it to be restarted by [the Reloader addon](https://github.com/stakater/Reloader) when its configmap is updated.