### PR TITLE
fix velero deployments

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -16,4 +16,4 @@ name: velero
 sources:
 - https://github.com/heptio/velero
 tillerVersion: '>=2.10.0'
-version: 2.2.7
+version: 2.2.8

--- a/staging/velero/templates/deployment.yaml
+++ b/staging/velero/templates/deployment.yaml
@@ -13,8 +13,10 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/name: {{ include "velero.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      helm.sh/chart: {{ include "velero.chart" . }}
   template:
     metadata:
       labels:

--- a/staging/velero/templates/miniobackend.yaml
+++ b/staging/velero/templates/miniobackend.yaml
@@ -115,6 +115,9 @@ metadata:
     helm.sh/chart: {{ include "velero.chart" . }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: minio-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
when upgrading apps/v1 in #194, the labelSelectors and labels must match

see: https://stackoverflow.com/questions/48582951/deployment-invalid-spec-template-metadata-labels-invalid-value