### PR TITLE
kommander: Add kommander prom datasource for thanos querier dashboard

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,7 +3,7 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.150.12"
 description: Kommander
-version: 0.2.18
+version: 0.2.19
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/kommander/templates/grafana/dashboards/thanos-query-dashboard.yaml
+++ b/stable/kommander/templates/grafana/dashboards/thanos-query-dashboard.yaml
@@ -55,7 +55,7 @@ data:
       "gnetId": null,
       "graphTooltip": 1,
       "id": null,
-      "iteration": 1571948617065,
+      "iteration": 1574381793185,
       "links": [],
       "panels": [
         {
@@ -943,8 +943,8 @@ data:
         "list": [
           {
             "current": {
-              "text": "Prometheus",
-              "value": "Prometheus"
+              "text": "KommanderPrometheus",
+              "value": "KommanderPrometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -954,7 +954,7 @@ data:
             "options": [],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "KommanderPrometheus",
             "skipUrlSync": false,
             "type": "datasource"
           },

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -178,9 +178,14 @@ grafana:
       datasources:
       - name: ThanosQuery
         type: prometheus
-        url: http://kommander-kubeaddons-thanos-query-http:10902/
+        url: http://kommander-kubeaddons-thanos-query-http.kommander:10902/
         access: proxy
         isDefault: true
+      - name: KommanderPrometheus
+        type: prometheus
+        url: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090/
+        access: proxy
+        isDefault: false
 
   ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
   ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards


### PR DESCRIPTION
This adds an additional datasource `KommanderPrometheus` to the centralized Grafana running on Kommander, which points to the Prometheus (kubeaddon) running on the Kommander cluster. The Thanos Querier dashboard is modified to use the datasource `KommanderPrometheus` instead of `ThanosQuery`, which Kommander cluster metrics don't roll up to (so currently this dashboard is empty).

![image](https://user-images.githubusercontent.com/5897740/69398909-ff8db880-0ca0-11ea-8f32-678cff7646e6.png)

![image](https://user-images.githubusercontent.com/5897740/69398719-534bd200-0ca0-11ea-8110-26156846bcbe.png)
