### PR TITLE
awsebs: switch to io1 as default vol types

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - name: alejandroEsc
   - name: gpaul
   - name: hectorj2f
-version: 0.3.2
+version: 0.3.3
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -64,9 +64,10 @@ storageclass:
   isDefault: false
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
-  type: gp2
+  type: io1
   allowedTopologies: []
   allowVolumeExpansion: true
+  iopsPerGB: "1000"
   # - matchLabelExpressions:
   #   - key: topology.ebs.csi.aws.com/zone
   #     values:

--- a/stable/awsebsprovisioner/Chart.yaml
+++ b/stable/awsebsprovisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: awsebsprovisioner
 home: https://kubernetes.io/docs/concepts/storage/storage-classes/
-version: 0.1.4
+version: 0.1.5
 appVersion: "1.0"
 description: AWS EBS storage provisioner for konvoy
 maintainers:

--- a/stable/awsebsprovisioner/values.yaml
+++ b/stable/awsebsprovisioner/values.yaml
@@ -2,5 +2,6 @@ storageclass:
   isDefault: true
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
-  type: gp2
+  type: io1
   allowVolumeExpansion: true
+  iopsPerGB: "1000"


### PR DESCRIPTION
In relation to this change https://github.com/mesosphere/konvoy/pull/1009, we should adapt the chart to use `io1` instead of `gp2`.