### PR TITLE
dispatch: fix api versions and app selectors

### DIFF
--- a/stable/dispatch/Chart.yaml
+++ b/stable/dispatch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.3.0"
 description: Installs Dispatch into a Kubernetes cluster
 name: dispatch
-version: 0.3.4
+version: 0.3.5
 tillerVersion: ">=2.14.2"
 home: https://github.com/mesosphere/dispatch
 maintainers:

--- a/stable/dispatch/charts/minio/Chart.yaml
+++ b/stable/dispatch/charts/minio/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/minio/minio
-version: 2.5.13
+version: 2.5.14

--- a/stable/dispatch/charts/minio/templates/deployment.yaml
+++ b/stable/dispatch/charts/minio/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.mode "standalone" }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "minio.fullname" . }}

--- a/stable/dispatch/charts/tekton/Chart.yaml
+++ b/stable/dispatch/charts/tekton/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: tekton
-version: 0.1.0
+version: 0.1.1

--- a/stable/dispatch/charts/tekton/templates/tekton.yaml
+++ b/stable/dispatch/charts/tekton/templates/tekton.yaml
@@ -543,6 +543,9 @@ metadata:
   name: tekton-pipelines-controller
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-controller
   template:
     metadata:
       annotations:
@@ -607,6 +610,9 @@ metadata:
   name: tekton-pipelines-webhook
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-webhook
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Follow up to https://github.com/mesosphere/charts/pull/275

Tested with Konvoy this time and a few other changes to support Kubernetes v1.16.