### PR TITLE
Set catalog address for kommander chart

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -3,7 +3,7 @@ name: kommander
 home: https://github.com/mesosphere/kommander
 appVersion: "1.153.1"
 description: Kommander
-version: 0.2.20
+version: 0.2.21
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/kommander/templates/deployment.yaml
+++ b/stable/kommander/templates/deployment.yaml
@@ -71,3 +71,5 @@ spec:
               value: {{ .Values.hostPollingInterval | quote }}
             - name: SUPPORTED_KUBERNETES_VERSIONS
               value: {{ .Values.kubernetesVersionsSelection | toJson  }}
+            - name: KUBEADDONS_ADDRESS
+              value: {{ .Values.kubeaddonsAddress | quote }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -8,6 +8,7 @@ clusterPollingInterval: 3000
 hostPollingInterval: 3000
 clusterPollingThrottleFactor: 1
 kubernetesVersionsSelection: '[{"kubernetesVersion":"1.15.5","konvoyVersion":"v1.3.0-beta6","kubeaddonsVersion":"kommander-beta6"}]'
+kubeaddonsAddress: http://kubeaddons-catalog.kubeaddons.svc
 
 # Mode must be either production|konvoy
 mode: production


### PR DESCRIPTION
We need to overwrite our base address of the catalog. without the overwrite we assume it lives under http://kommander-kubeaddons-kubeaddons-catalog.kommander.svc. Running this kommander chart version won't work against konvoy without this fix