### PR TITLE
[kommander] feat: add default folder for kommander

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 - name: alejandroEsc
 - name: jimmidyson
 name: kommander
-version: 0.2.27
+version: 0.2.28

--- a/stable/kommander/templates/folder.yaml
+++ b/stable/kommander/templates/folder.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.folders.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.folders.default.namespace }}
+  {{- with .Values.folders.default.annotations }}
+  {{- with .Values.folders.default.labels }}
+{{- end -}}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -170,6 +170,16 @@ grafana:
     #   hosts:
     #   - grafana.example.com
 
+  folders: 
+    enabled: true
+    default: 
+      namespace: kommander-default-folder
+      labels:
+        kommanderType: folder
+      annotations:
+        kommander.d2iq.io/description: Default folder
+        kommander.d2iq.io/display-name: Default
+
   ## Configure grafana datasources
   ## ref: http://docs.grafana.org/administration/provisioning/#datasources
   ##


### PR DESCRIPTION
When kommander is installed, add a default folder (namespace).

Disclaimer I'm not sure this is the correct way to do this! Goal is to have this yaml file applied at install time.