### PR TITLE
allow federating kube-system resources

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 - name: alejandroEsc
 - name: jimmidyson
 name: kommander
-version: 0.2.27
+version: 0.2.28

--- a/stable/kommander/templates/federated-kube-system.yaml
+++ b/stable/kommander/templates/federated-kube-system.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.kubefed.enabled }}
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedNamespace
+metadata:
+  name: kube-system
+  namespace: kube-system
+  labels:
+{{ include "kommander.labels" . | indent 4 }}
+spec:
+  placement:
+    clusterSelector:
+      matchLabels: {}
+  template:
+    spec: {}
+{{- end }}


### PR DESCRIPTION
We have need to override the ingress record for the dashboard when a cluster joins federation. The dashboard is currently being deployed to the kube-system namespace. If it is not acceptable to federate objects in kube-system, perhaps we could migrate the dashboard to kubeaddons. 