### PR TITLE
Add useCertManager option to traefik

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.8
+version: 1.72.9
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/README.md
+++ b/staging/traefik/README.md
@@ -127,6 +127,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `ssl.cipherSuites`                     | Specify a non-empty list of TLS ciphers to override the default one | None |
 | `ssl.sniStrict`                        | Enable strict SNI checking, so that connections cannot be made if a matching certificate does not exist.                     | false                                             |
 | `ssl.generateTLS`                      | Generate self sign cert by Helm. If it's `true` the `defaultCert` and the `defaultKey` parameters will be ignored.           | false                                             |
+| `ssl.useCertManager`                   | Whether an external cert manager is being used. If this is `true`, `generateTLS`, `defaultCert`, and `defaultKey` will be ignored.| false                                        |
 | `ssl.defaultCN`                        | Specify generated self sign cert CN                                                                                          | ""                                                |
 | `ssl.defaultSANList`                   | Specify generated self sign cert SAN list                                                                                    | `[]`                                              |
 | `ssl.defaultIPList`                    | Specify generated self sign cert IP list                                                                                     | `[]`                                              |

--- a/staging/traefik/templates/default-cert-secret.yaml
+++ b/staging/traefik/templates/default-cert-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ssl.enabled }}
+{{- if and (.Values.ssl.enabled) (not .Values.ssl.useCertManager) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -123,6 +123,7 @@ ssl:
   upstream: false
   insecureSkipVerify: false
   generateTLS: false
+  useCertManager: false
   # defaultCN: "example.com"
     # or *.example.com
   defaultSANList: []


### PR DESCRIPTION
This disables the creation of default-cert-secret when an external
certificate manager is being used.

Addresses: https://jira.mesosphere.com/browse/DCOS-60978