### PR TITLE
[kommander] remove older versions of kubernetes

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 - name: alejandroEsc
 - name: jimmidyson
 name: kommander
-version: 0.3.8
+version: 0.3.9

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -7,7 +7,7 @@ logoutRedirectPath: /ops/landing
 clusterPollingInterval: 3000
 hostPollingInterval: 3000
 clusterPollingThrottleFactor: 1
-kubernetesVersionsSelection: '["1.16.3", "1.15.6", "1.15.5", "1.15.4"]'
+kubernetesVersionsSelection: '["1.16.4", "1.16.3", "1.15.6"]'
 kubeaddonsAddress: kommander-kubeaddons-kubeaddons-catalog
 
 # Mode must be either production|konvoy


### PR DESCRIPTION
These versions fail to install, I think because they are using older versions of konvoy configured [here](https://github.com/mesosphere/kubernetes-base-addons/blob/master/addons/kommander/1.163.x/kommander-1.yaml#L51).  We could maybe change that to use the latest konvoy? I'm not sure we need these versions so I am ok just removing as options.

thoughts @jimmidyson ?