### PR TITLE
[traefik-forward-auth] reuse secret for session key

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.2.10
+version: 0.2.11
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/deployment.yaml
+++ b/staging/traefik-forward-auth/templates/deployment.yaml
@@ -93,6 +93,11 @@ spec:
                 secretKeyRef:
                   name: {{ template "traefik-forward-auth.fullname" . }}-secret
                   key: secret
+            - name: SESSION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "traefik-forward-auth.fullname" . }}-secret
+                  key: secret
             {{- if .Values.traefikForwardAuth.allowedUser.valueFrom.secretKeyRef }}
             - name: WHITELIST
               valueFrom:


### PR DESCRIPTION
TFA now uses sessions to store group claims

