### PR TITLE
Revert "Fix grafana internal urls"

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.3.4
+version: 8.3.3
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.3.3
+version: 8.3.5
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -448,7 +448,7 @@ grafana:
     hosts: []
 
     ## Path for grafana ingress
-    path: /ops/portal/grafana
+    path: /
 
     ## TLS configuration for grafana Ingress
     ## Secret must be manually created in the namespace


### PR DESCRIPTION
This reverts commit 97d023b2c998bb0976a58907ead4591da7ce2c6b.
Reverted because changes were made in the wrong repo.