### PR TITLE
[test] Add chart install and upgrade testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GIT_REMOTE_URL ?= $(shell git remote get-url origin)
 # - git@github.com:mesosphere/charts.git
 GITHUB_USER := $(shell git remote get-url origin | sed -E 's|.*github.com[/:]([^/]+)/charts.*|\1|')
 
-GIT_REF = $(shell git rev-parse HEAD)	
+GIT_REF = $(shell git rev-parse HEAD)
 LAST_COMMIT_MESSAGE := $(shell git log -1 --pretty=format:'%B')
 NON_DOCS_FILES := $(filter-out docs,$(wildcard *))
 
@@ -105,5 +105,5 @@ $(TMPDIR)/.helm/repository/local/index.yaml: $(HELM)
 ct.lint:
 ifneq (,$(wildcard /teamcity/system/git))
 	$(DRUN) git fetch origin dev
-endif	
+endif
 	$(DRUN) ct lint

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.6.12
+version: 1.6.13
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/config-openssl.yaml
+++ b/stable/dex/templates/config-openssl.yaml
@@ -8,10 +8,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
   name: {{ template "dex.fullname" . }}-openssl-config
-  annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 data:
   openssl.conf: |
 {{ .Files.Get "config/openssl.conf" | indent 4 }}

--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.6
+version: 0.1.7
 appVersion: 0.10.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/ci/test-values.yaml
+++ b/staging/cert-manager-setup/ci/test-values.yaml
@@ -1,0 +1,5 @@
+clusterissuer:
+  name: kubernetes-ca
+  spec:
+    ca:
+      secretName: kubernetes-intermediate-ca

--- a/test/ct-e2e.yaml
+++ b/test/ct-e2e.yaml
@@ -1,0 +1,38 @@
+debug: true
+target-branch: dev
+chart-dirs:
+  - stable
+  - staging
+excluded-charts:
+  - common
+  - dex-controller # Moved to a different helm repo
+  - azuredisk-csi-driver  # DCOS-62804
+  - defaultstorageclass   # DCOS-62803
+  - dispatch              # DCOS-62802
+  - gcpdiskprovisioner    # DCOS-62801
+  - kommander             # DCOS-62800
+  - kommander-karma       # DCOS-62799
+  - kommander-thanos      # DCOS-62798
+  - mtls-proxy            # DCOS-62805
+  - dex-k8s-authenticator # DCOS-62806
+  - flagger               # DCOS-62809
+  - gatekeeper            # DCOS-62810
+  - generic-ingress       # DCOS-62811
+  - istio                 # DCOS-62812
+  - knative               # DCOS-62813
+  - kube-oidc-proxy       # DCOS-62814
+  - kudo                  # DCOS-62815
+  - nvidia                # DCOS-62816
+  - prometheus-operator   # DCOS-62817
+  - traefik               # DCOS-62818
+  - traefik-forward-auth  # DCOS-62819
+chart-repos:
+  - mesosphere-staging=https://mesosphere.github.io/charts/staging
+  - mesosphere-stable=https://mesosphere.github.io/charts/stable
+  - kubefed-charts=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
+  - jetstack-charts=https://charts.jetstack.io
+  - kommander-cluster-lifecycle=https://mesosphere.github.io/kommander-cluster-lifecycle/charts
+  - banzaicloud=https://kubernetes-charts.banzaicloud.com
+  - helm-stable=https://kubernetes-charts.storage.googleapis.com/
+  - dex-controller=https://mesosphere.github.io/dex-controller/charts
+helm-extra-args: --timeout 600

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly CT_VERSION=v2.4.0
+readonly KIND_VERSION=v0.6.1
+readonly CLUSTER_NAME=chart-testing
+readonly K8S_VERSION=v1.16.3
+
+tmp=$(mktemp -d)
+
+run_ct_container() {
+    echo 'Running ct container...'
+    docker run --rm --interactive --detach --network host --name ct \
+        --volume "$(pwd)/test/ct-e2e.yaml:/etc/ct/ct.yaml" \
+        --volume "$(pwd):/workdir" \
+        --workdir /workdir \
+        "quay.io/helmpack/chart-testing:$CT_VERSION" \
+        cat
+    echo
+}
+
+cleanup() {
+    echo 'Removing ct container...'
+    docker kill ct > /dev/null 2>&1
+    "${tmp}/kind" delete cluster --name "$CLUSTER_NAME"
+    rm -rf "${tmp}"
+    echo 'Done!'
+}
+
+docker_exec() {
+    docker exec --interactive ct "$@"
+}
+
+create_kind_cluster() {
+    echo 'Downloading kind...'
+
+    curl -sSLo "${tmp}/kind" \
+        "https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VERSION/kind-$(uname)-amd64"
+    chmod +x "${tmp}/kind"
+
+    "${tmp}/kind" create cluster --name "$CLUSTER_NAME" \
+        --config test/kind-config.yaml --image "kindest/node:$K8S_VERSION" \
+        --wait 60s
+
+    docker_exec mkdir -p /root/.kube
+
+    echo 'Copying kubeconfig to container...'
+    "${tmp}/kind" get kubeconfig --name "$CLUSTER_NAME" > "${tmp}/kube.config"
+    docker cp "${tmp}/kube.config" ct:/root/.kube/config
+
+    docker_exec kubectl cluster-info
+    echo
+
+    docker_exec kubectl get nodes
+    echo
+
+    echo 'Cluster ready!'
+    echo
+}
+
+install_local-path-provisioner() {
+    # kind doesn't support Dynamic PVC provisioning yet, this is one ways to
+    # get it working
+    # https://github.com/rancher/local-path-provisioner
+
+    # Remove default storage class. It will be recreated by
+    # local-path-provisioner
+    docker_exec kubectl delete storageclass standard
+
+    echo 'Installing local-path-provisioner...'
+    docker_exec kubectl apply -f \
+        https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+    echo
+}
+
+install_tiller() {
+    echo 'Installing tiller...'
+    docker_exec kubectl --namespace kube-system create serviceaccount tiller
+    docker_exec kubectl create clusterrolebinding tiller-cluster-rule \
+        --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+    docker_exec helm init --history-max 10 --service-account tiller --wait
+    echo
+}
+
+install_certmanager() {
+    echo 'Generating root ca...'
+    docker_exec apk add openssl
+    docker_exec openssl genrsa -out /tmp/ca.key 4096
+    docker_exec openssl req -x509 -new -nodes -key /tmp/ca.key \
+        -sha256 -days 1 -out /tmp/ca.crt -subj "/CN=testing"
+    echo
+
+    echo 'Installing cert-manager...'
+    docker_exec kubectl create namespace cert-manager
+    docker_exec kubectl create secret tls kubernetes-root-ca \
+        --namespace=cert-manager --cert=/tmp/ca.crt --key=/tmp/ca.key
+    docker_exec helm install \
+        --values staging/cert-manager-setup/ci/test-values.yaml \
+        --namespace cert-manager staging/cert-manager-setup
+    echo
+}
+
+main() {
+    run_ct_container
+    trap cleanup EXIT
+
+    create_kind_cluster
+    install_local-path-provisioner
+    install_tiller
+    install_certmanager
+
+    docker_exec ct lint-and-install --upgrade --debug "$@"
+    echo
+}
+
+main "$@"

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker


### PR DESCRIPTION
* Adds a testing script that tests the charts using `ct lint-and-install --upgrade`.
* Backports a fix from upstream `dex` chart to allow install and upgrade to succeed (https://github.com/helm/charts/pull/18380)
* Clean up EOL whitespace