### PR TITLE
stable/opsportal: bump nginx container to 1.17-alpine

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0.0"
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.1.24
+version: 0.1.25
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/templates/landing.yaml
+++ b/stable/opsportal/templates/landing.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
         - name: opsportal-landing
-          image: nginx:1.15-alpine
+          image: nginx:1.17-alpine
           imagePullPolicy: IfNotPresent
           resources:
             {{ with .Values.landing.resources }}


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-62720

Upgrade from `1.15-alpine` which contains critical security issues.