### PR TITLE
make: add lint and test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,16 @@ ifneq (,$(wildcard /teamcity/system/git))
 	$(DRUN) git fetch origin dev
 endif
 	$(DRUN) ct lint
+
+.PHONY: ct.test
+ct.test:
+ifneq (,$(wildcard /teamcity/system/git))
+	$(DRUN) git fetch origin dev
+endif
+	test/e2e-kind.sh
+
+.PHONY: lint
+lint: ct.lint
+
+.PHONY: test
+test: ct.test


### PR DESCRIPTION
Adds `test` and `lint` targets that pull in target deps. Add the `ct.test` target that calls the e2e test script.