### PR TITLE
[kommander-karma] [kommander-thanos] Modify UI links

### DIFF
--- a/stable/kommander-karma/Chart.yaml
+++ b/stable/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-karma/README.md
+++ b/stable/kommander-karma/README.md
@@ -32,14 +32,14 @@ karma:
       traefik.ingress.kubernetes.io/auth-type: "forward"
       traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
       traefik.ingress.kubernetes.io/priority: "2"
-    path: "/kommander/monitoring/karma"
+    path: "/ops/portal/kommander/monitoring/karma/"
     hosts:
       - ""
 
   livenessProbe:
     delay: 5
     period: 5
-    path: /kommander/monitoring/karma/
+    path: /ops/portal/kommander/monitoring/karma/
 
   configMap:
     enabled: true
@@ -74,7 +74,7 @@ karma:
       listen:
         address: "0.0.0.0"
         port: 8080
-        prefix: /kommander/monitoring/karma/
+        prefix: /ops/portal/kommander/monitoring/karma/
       log:
         config: true
         level: info

--- a/stable/kommander-karma/values.yaml
+++ b/stable/kommander-karma/values.yaml
@@ -28,14 +28,14 @@ karma:
       traefik.ingress.kubernetes.io/auth-type: "forward"
       traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
       traefik.ingress.kubernetes.io/priority: "2"
-    path: "/kommander/monitoring/karma"
+    path: "/ops/portal/kommander/monitoring/karma/"
     hosts:
       - ""
 
   livenessProbe:
     delay: 5
     period: 5
-    path: /kommander/monitoring/karma/
+    path: /ops/portal/kommander/monitoring/karma/
 
   configMap:
     enabled: true
@@ -73,7 +73,7 @@ karma:
       listen:
         address: "0.0.0.0"
         port: 8080
-        prefix: /kommander/monitoring/karma/
+        prefix: /ops/portal/kommander/monitoring/karma/
       log:
         config: true
         level: info

--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.6
+version: 0.1.7
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-thanos/README.md
+++ b/stable/kommander-thanos/README.md
@@ -58,7 +58,7 @@ thanos:
           traefik.ingress.kubernetes.io/auth-type: "forward"
           traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
           traefik.ingress.kubernetes.io/priority: "2"
-        path: "/kommander/monitoring/query"
+        path: "ops/portal/kommander/monitoring/query"
         hosts:
           - ""
         tls: []

--- a/stable/kommander-thanos/values.yaml
+++ b/stable/kommander-thanos/values.yaml
@@ -58,7 +58,7 @@ thanos:
           traefik.ingress.kubernetes.io/auth-type: "forward"
           traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
           traefik.ingress.kubernetes.io/priority: "2"
-        path: "/kommander/monitoring/query"
+        path: "/ops/portal/kommander/monitoring/query"
         hosts:
           - ""
         tls: []


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-62153
We are modifying karma and thanos (and grafana, done in followup PR) links to be behind `/ops/portal/kommander/monitoring/<>` instead of `/kommander/monitoring/<>`. Those ingress changes are done here along with chart bumps. After this PR is merged, I will open up a followup PR to do the following:

1. bump the thanos/karma dependencies in the Kommander chart
1. change the Kommander ui to point to `/ops/portal/kommander/ui` (see https://jira.mesosphere.com/browse/DCOS-62690 and we can close this PR https://github.com/mesosphere/charts/pull/338)
1. modify the grafana ingress to point to the new url
1. bump kommander chart version

Following the above PR, I will close out this ticket by bumping kommander to the updated version^ in `kubernetes-base-addons`.

## Testing
This was tested by hosting kommander-thanos and kommander-karma charts on my personal GH, then pointing kommander to my hosted charts as well as self hosting the kommander chart. I changed kommander to point to my hosted kommander chart in a branch of `kubernetes-base-addons` and used that to deploy a konvoy cluster. You can test this by using that branch: `gracedo/test_kommander_path_changes`. See below for the scrnshts of new urls working as expected:

![image](https://user-images.githubusercontent.com/5897740/72286160-6f615500-35f9-11ea-8fca-e600ef08d659.png)
![image](https://user-images.githubusercontent.com/5897740/72286189-7d16da80-35f9-11ea-9c87-e8b41a72eacb.png)
![image](https://user-images.githubusercontent.com/5897740/72286200-82742500-35f9-11ea-8d36-0af0c7e0f3a6.png)
![image](https://user-images.githubusercontent.com/5897740/72286218-89029c80-35f9-11ea-9942-129661d23e86.png)
