### PR TITLE
 test: detect teamcity and mount git 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GITHUB_USER := $(shell git remote get-url origin | sed -E 's|.*github.com[/:]([^
 GIT_REF = $(shell git rev-parse HEAD)
 LAST_COMMIT_MESSAGE := $(shell git log -1 --pretty=format:'%B')
 NON_DOCS_FILES := $(filter-out docs,$(wildcard *))
+CT_VERSION ?= v2.4.0
 
 TMPDIR := $(shell mktemp -d)
 HELM := $(shell bash -c "command -v helm")
@@ -26,11 +27,11 @@ endif
 ifeq (,$(wildcard /teamcity/system/git))
 DRUN := docker run -t --rm -u $(shell id -u):$(shell id -g) \
 			-v ${PWD}:/charts -v ${PWD}/test/ct.yaml:/etc/ct/ct.yaml -v $(TMPDIR):/.helm \
-			-w /charts quay.io/helmpack/chart-testing:v2.3.3
+			-w /charts quay.io/helmpack/chart-testing:$(CT_VERSION)
 else
 DRUN := docker run -t --rm -v /teamcity/system/git:/teamcity/system/git -v ${PWD}:/charts \
 			-v ${PWD}/test/ct.yaml:/etc/ct/ct.yaml -w /charts \
-			quay.io/helmpack/chart-testing:v2.3.3
+			quay.io/helmpack/chart-testing:$(CT_VERSION)
 endif
 
 .SECONDEXPANSION:
@@ -113,7 +114,7 @@ ct.test:
 ifneq (,$(wildcard /teamcity/system/git))
 	$(DRUN) git fetch origin dev
 endif
-	test/e2e-kind.sh
+	test/e2e-kind.sh $(CT_VERSION)
 
 .PHONY: lint
 lint: ct.lint

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -4,7 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v2.4.0
 readonly KIND_VERSION=v0.6.1
 readonly CLUSTER_NAME=chart-testing
 readonly K8S_VERSION=v1.16.3
@@ -17,7 +16,7 @@ run_ct_container() {
         --volume "$(pwd)/test/ct-e2e.yaml:/etc/ct/ct.yaml" \
         --volume "$(pwd):/workdir" \
         --workdir /workdir \
-        "quay.io/helmpack/chart-testing:$CT_VERSION" \
+        "quay.io/helmpack/chart-testing:$1" \
         cat
     echo
 }
@@ -104,7 +103,8 @@ install_certmanager() {
 }
 
 main() {
-    run_ct_container
+    run_ct_container "$1"
+    shift
     trap cleanup EXIT
 
     create_kind_cluster

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -12,9 +12,14 @@ tmp=$(mktemp -d)
 
 run_ct_container() {
     echo 'Running ct container...'
+    teamcity_volume=()
+    if [[ -n ${TEAMCITY_VERSION+x} ]]; then
+        teamcity_volume=(-v /teamcity/system/git:/teamcity/system/git)
+    fi
     docker run --rm --interactive --detach --network host --name ct \
         --volume "$(pwd)/test/ct-e2e.yaml:/etc/ct/ct.yaml" \
         --volume "$(pwd):/workdir" \
+        "${teamcity_volume[@]}" \
         --workdir /workdir \
         "quay.io/helmpack/chart-testing:$1" \
         cat


### PR DESCRIPTION
Fixes the integration test script such that it successfully runs on TC (see last run in https://github.com/mesosphere/charts/pull/346).

Also consolidates the version of the `chart-testing` docker image to a single variable held in the `Makefile`