### PR TITLE
traefik: add objects depending on useCertManager

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.10
+version: 1.72.11
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/certificate.yaml
+++ b/staging/traefik/templates/certificate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ssl.useCertManager }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
@@ -31,4 +32,4 @@ spec:
   # The commonName will get replaced by kubeaddons-config
   # init-container for traefik
   commonName: traefik.localhost.localdomain
-
+{{- end }}

--- a/staging/traefik/templates/init-cert-job.yaml
+++ b/staging/traefik/templates/init-cert-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ssl.useCertManager }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -39,3 +40,4 @@ spec:
           value: "konvoyconfig-kubeaddons"
         - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
           value: "clusterHostname"
+{{- end }}


### PR DESCRIPTION
Tested via `helm install /Users/armand/Code/charts/staging/traefik --dry-run --values=/Users/armand/Desktop/traefik.yaml`.