### PR TITLE
fix: reduce kommander CPU limit

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.3.16
+version: 0.3.17

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -24,7 +24,7 @@ kommander-ui:
       cpu: "100m"
     limits:
       memory: "512Mi"
-      cpu: "2000m"
+      cpu: "500m"
 
   readinessProbe:
     initialDelaySeconds: 15


### PR DESCRIPTION
The Kommander CPU limit is a little too loose for its actual requirements. Javascript is single-threaded, after all.