### PR TITLE
staging/velero: bump minio k8s operator to 1.0.6 (security update)

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -16,4 +16,4 @@ name: velero
 sources:
 - https://github.com/heptio/velero
 tillerVersion: '>=2.10.0'
-version: 2.2.10
+version: 2.2.11

--- a/staging/velero/templates/miniobackend.yaml
+++ b/staging/velero/templates/miniobackend.yaml
@@ -126,7 +126,7 @@ spec:
       serviceAccountName: minio-operator-sa
       containers:
       - name: minio-operator
-        image: minio/k8s-operator:1.0.1
+        image: minio/k8s-operator:1.0.6
         command: ["minio-operator"]
         args:
         - "-logtostderr=true"


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-62691

Our `velero` chart is modified and includes `minio` deployemnt. The `minio` is not included in upstream `velero` chart - https://github.com/vmware-tanzu/helm-charts/blob/f721d7a7138e0c3138a89fe9c097c35d9e4ee2cd/README.md

Builds:

- aws - https://teamcity.mesosphere.io/viewLog.html?buildId=2547553&buildTypeId=ClosedSource_MkeLite_MkeLiteE2e
- azure - https://teamcity.mesosphere.io/viewLog.html?buildId=2547551&buildTypeId=ClosedSource_Konvoy_KonvoyE2eAzure
- docker - https://teamcity.mesosphere.io/viewLog.html?buildId=2547555&buildTypeId=ClosedSource_Konvoy_KonvoyE2eDocker
