### PR TITLE
chore: Do not add chart sources to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ publish:
 	rm -rf $(NON_DOCS_FILES)
 	git checkout $(GIT_REF) -- $(NON_DOCS_FILES)
 	$(MAKE) GIT_REF=$(GIT_REF) all
+	git add -A docs
 	git reset $(NON_DOCS_FILES)
 	git clean -fdx
-	git add -A .
 	git commit -m "$(LAST_COMMIT_MESSAGE)"
 	git push publish master
 	git checkout -


### PR DESCRIPTION
This works in combination with the master cleanup (see #372) to keep a clean master branch, with only chart repo packages and no chart sources.

Please merge #372 first so I don't have to rebase that, although that wouldn't be too hard anyway.