### PR TITLE
Reset Kommander appVersion to 1.0.0

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.184.0
+appVersion: 1.0.0
 description: Kommander
 home: https://github.com/mesosphere/kommander
 maintainers:

--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.3.16
+version: 0.3.17


### PR DESCRIPTION
appVersion field is supposed to be the Kommander version we're going to communicate, so it should start with 1.0.0 when we release GA.

https://helm.sh/docs/topics/charts/#the-appversion-field