### PR TITLE
Retry requests when setting Grafana's home dashboard

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.3.8
+version: 8.3.9
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/mesosphere-hooks/post-install-hooks.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/post-install-hooks.yaml
@@ -40,7 +40,11 @@ metadata:
 data:
   run.sh: |-
     #!/bin/bash
-    DASHBOARD_ID=$(curl --fail -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/search/?query=Kubernetes+%2F+Compute+Resources+%2F+Cluster | jq '.[0].id')
-    echo $DASHBOARD_ID
-    curl -X PUT -v --fail  -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"theme":"","homeDashboardId":'"$DASHBOARD_ID"',"timezone":""}' {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/org/preferences
+    set -o nounset
+    set -o errexit
+    set -o pipefail
+    CURL="curl --verbose --fail --max-time 60 --retry 10 --retry-connrefused"
+    DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/search/?query=Kubernetes+%2F+Compute+Resources+%2F+Cluster | jq '.[0].id')
+    echo "setting home dashboard to ID" $DASHBOARD_ID
+    $CURL -X PUT -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"theme":"","homeDashboardId":'"$DASHBOARD_ID"',"timezone":""}' {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/org/preferences
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-62216

This fixes an issue that may cause the Grafana home dashboard to be empty. If the job that sets Grafana's home dashboard runs before Grafana's API is ready, it will fail after one attempt. This PR changes the job to retry requests that fail with transient errors.

## Testing

I tested this PR by deploying a Konvoy cluster with the prometheus and prometheusadapter addons disabled, deploying the prometheus-operator chart from this branch, browsing to `/ops/portal/grafana`, and observing that the home dashboard is set to "Kubernetes / Compute Resources / Cluster".