### PR TITLE
Add chart version bump to fix lint failure

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.3.17
+version: 0.3.18


### PR DESCRIPTION
All PRs are failing claiming that the kommander chart version needs bumped. The last commit did not bump the chart version but somehow passed CI. This fixes the CI failures.