### PR TITLE
[cert-manager-setup] allow for multiple clusterissuers

### DIFF
--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.7
+version: 0.1.8
 appVersion: 0.10.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/ci/general-test-values.yaml
+++ b/staging/cert-manager-setup/ci/general-test-values.yaml
@@ -1,0 +1,28 @@
+# This test ensures we can create an issuer, a certificate and a clusterissuer
+
+issuers:
+  - name: my-root-issuer
+    secretName: kubernetes-root-ca
+
+certificates:
+  - name: my-certificate
+    # where to store this certificate
+    secretName: my-certificate-secret
+    issuerRef:
+      name: my-root-issuer
+      kind: Issuer
+      # These are the default usages for reference
+      usages:
+        - "digital signature"
+        - "key encipherment"
+    commonName: cert-manager
+    duration: 87600h
+    dnsNames:
+      - example.com
+      - www.example.com
+
+clusterissuers:
+  - name: my-ca
+    spec:
+      ca:
+        secretName: my-certificate-secret

--- a/staging/cert-manager-setup/ci/test-values.yaml
+++ b/staging/cert-manager-setup/ci/test-values.yaml
@@ -1,3 +1,5 @@
+# These test values are used for chart testing
+# DO NOT EDIT unless you know what you are doing
 clusterissuer:
   name: kubernetes-ca
   spec:

--- a/staging/cert-manager-setup/requirements.yaml
+++ b/staging/cert-manager-setup/requirements.yaml
@@ -3,4 +3,3 @@ dependencies:
     version: 0.10.1
     repository: https://charts.jetstack.io
     condition: installCertManager
-

--- a/staging/cert-manager-setup/templates/certificates.yaml
+++ b/staging/cert-manager-setup/templates/certificates.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.certificates }}
+{{- range .Values.certificates }}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ .name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  isCA: true
+  commonName: cert-manager
+  duration: {{ .duration | default "87600h" | quote }}
+  secretName: {{ .secretName }}
+  issuerRef:
+    name: {{ .issuerRef.name }}
+    kind: {{ .issuerRef.kind }}
+{{- if .issuerRef.usages }}
+    usages:
+  {{- range .issuerRef.usages }}
+    - {{ . | quote -}}
+  {{- end }}
+{{- end }}
+{{- if .dnsNames }}
+  dnsNames:
+  {{- range .dnsNames }}
+    - {{ . | quote -}}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/staging/cert-manager-setup/templates/clusterissuer.yaml
+++ b/staging/cert-manager-setup/templates/clusterissuer.yaml
@@ -1,0 +1,47 @@
+# DEPRECATED, this file should be deleted soon
+{{ if .Values.clusterissuer }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: kubernetes-root-issuer
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  ca:
+    secretName: kubernetes-root-ca
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: kubernetes-intermediate-ca
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  isCA: true
+  commonName: cert-manager
+  duration: 87600h
+  secretName: kubernetes-intermediate-ca
+  issuerRef:
+    name: kubernetes-root-issuer
+    kind: Issuer
+    # These are the default usages for reference
+    usages:
+      - "digital signature"
+      - "key encipherment"
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: {{ required "clusterissuer must have a name" .Values.clusterissuer.name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+{{ required "clusterissuer must have a spec" .Values.clusterissuer.spec | toYaml | indent 4 }}
+{{ end }}

--- a/staging/cert-manager-setup/templates/clusterissuers.yaml
+++ b/staging/cert-manager-setup/templates/clusterissuers.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.clusterissuers }}
+{{- range .Values.clusterissuers }}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: {{ required "clusterissuer must have a name" .name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+{{ required "clusterissuer must have a spec" .spec | toYaml | indent 4 }}
+{{- end }}
+{{- end }}

--- a/staging/cert-manager-setup/templates/clusterrole.yaml
+++ b/staging/cert-manager-setup/templates/clusterrole.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: read-apiservices
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: "before-hook-creation"
+    "helm.sh/hook-weight": "-4"
 rules:
 - apiGroups: ["apiregistration.k8s.io"]
   resources: ["apiservices"]

--- a/staging/cert-manager-setup/templates/clusterrole.yaml
+++ b/staging/cert-manager-setup/templates/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
-    "helm.sh/hook-weight": "-7"
+    helm.sh/hook-weight: "-7"
 rules:
 - apiGroups:
   - "apiregistration.k8s.io"

--- a/staging/cert-manager-setup/templates/clusterrole.yaml
+++ b/staging/cert-manager-setup/templates/clusterrole.yaml
@@ -1,12 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: read-apiservices
+  name: cert-manager-setup-apiservices
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: "before-hook-creation"
-    "helm.sh/hook-weight": "-4"
+    helm.sh/hook-delete-policy: before-hook-creation
+    "helm.sh/hook-weight": "-7"
 rules:
-- apiGroups: ["apiregistration.k8s.io"]
-  resources: ["apiservices"]
-  verbs: ["get", "watch", "list"]
+- apiGroups:
+  - "apiregistration.k8s.io"
+  resources:
+  - "apiservices"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"

--- a/staging/cert-manager-setup/templates/clusterrolebinding.yaml
+++ b/staging/cert-manager-setup/templates/clusterrolebinding.yaml
@@ -3,6 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: read-apiservices-rolebinding
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: "before-hook-creation"
+    "helm.sh/hook-weight": "-3"
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}

--- a/staging/cert-manager-setup/templates/clusterrolebinding.yaml
+++ b/staging/cert-manager-setup/templates/clusterrolebinding.yaml
@@ -1,17 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: read-apiservices-rolebinding
+  name: cert-manager-setup-apiservices
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: "before-hook-creation"
-    "helm.sh/hook-weight": "-3"
+    helm.sh/hook-delete-policy: before-hook-creation
+    "helm.sh/hook-weight": "-7"
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: default
 roleRef:
   kind: ClusterRole
-  name: read-apiservices
+  name: cert-manager-setup-apiservices
   apiGroup: rbac.authorization.k8s.io

--- a/staging/cert-manager-setup/templates/issuers.yaml
+++ b/staging/cert-manager-setup/templates/issuers.yaml
@@ -1,46 +1,19 @@
-{{ if .Values.clusterissuer }}
+{{- if .Values.issuers }}
+{{- $namespace := .Release.Namespace }}
+{{- range .Values.issuers }}
+---
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
-  name: kubernetes-root-issuer
-  namespace: {{ .Release.Namespace }}
+  name: {{ .name }}
+  namespace: {{ .namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   ca:
-    secretName: kubernetes-root-ca
----
-apiVersion: certmanager.k8s.io/v1alpha1
-kind: Certificate
-metadata:
-  name: kubernetes-intermediate-ca
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
-spec:
-  isCA: true
-  commonName: cert-manager
-  duration: 87600h
-  secretName: kubernetes-intermediate-ca
-  issuerRef:
-    name: kubernetes-root-issuer
-    kind: Issuer
-    # These are the default usages for reference
-    usages: 
-    - "digital signature"
-    - "key encipherment"
----
-apiVersion: certmanager.k8s.io/v1alpha1
-kind: ClusterIssuer
-metadata:
-  name: {{ required "clusterissuer must have a name" .Values.clusterissuer.name }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": before-hook-creation
-spec:
-{{ required "clusterissuer must have a spec" .Values.clusterissuer.spec | toYaml | indent 4 }}
-{{ end }}
+    secretName: {{ .secretName }}
+{{- end }}
+{{- end }}
+

--- a/staging/cert-manager-setup/templates/post-install-hook-job.yaml
+++ b/staging/cert-manager-setup/templates/post-install-hook-job.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "cert-manager-setup.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-setup.labels" . | indent 4 }}
   annotations:
@@ -13,31 +14,10 @@ spec:
     metadata:
       name: "wait-for-cert-manager-webhook"
     spec:
+      serviceAccountName: default
       restartPolicy: Never
       containers:
       - name: {{ .Chart.Name }}
         image: bitnami/kubectl:latest
         imagePullPolicy: IfNotPresent
-        command: ["kubectl", "wait", "--for=condition=Available", "--timeout=300s", "apiservice", "v1beta1.webhook.certmanager.k8s.io"]
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ include "cert-manager-setup.fullname" . }}-sleep
-  labels:
-{{ include "cert-manager-setup.labels" . | indent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-spec:
-  template:
-    metadata:
-      name: "sleep"
-    spec:
-      restartPolicy: Never
-      containers:
-      - name: {{ .Chart.Name }}
-        image: ubuntu:xenial
-        imagePullPolicy: IfNotPresent
-        command: ["sleep", "30"]
+        command: ["kubectl", "wait", "--for=condition=Available", "--timeout=360s", "apiservice", "v1beta1.webhook.certmanager.k8s.io"]

--- a/staging/cert-manager-setup/values.yaml
+++ b/staging/cert-manager-setup/values.yaml
@@ -5,6 +5,51 @@
 nameOverride: ""
 fullnameOverride: ""
 
+issuers: []
+#  - name: kubernetes-root-issuer
+#    secretName: kubernetes-root-ca
+
+certificates: []
+#  - name: kubernetes-intermediate-ca
+#    # where to store this certificate
+#    secretName: my-certificate-secret
+#    issuerRef:
+#      name: kubernetes-root-issuer
+#      kind: Issuer
+#      # These are the default usages for reference
+#      usages:
+#        - "digital signature"
+#        - "key encipherment"
+#    commonName: cert-manager
+#    duration: 87600h
+#    dnsNames: []
+#  - name: my-certificate
+#    # where to store this certificate
+#    secretName: my-certificate-secret
+#    issuerRef:
+#      name: kubernetes-root-issuer
+#      kind: Issuer
+#      # These are the default usages for reference
+#      usages:
+#        - "digital signature"
+#        - "key encipherment"
+#    commonName: cert-manager
+#    duration: 87600h
+#    dnsNames:
+#      - example.com
+#      - www.example.com
+
+clusterissuers: []
+#  - name: kubernetes-ca
+#    spec:
+#      ca:
+#        secretName: kubernetes-intermediate-ca
+#  - name: my-ca
+#    spec:
+#      ca:
+#        secretName: my-certificate-secret
+
+# DEPRECATED, please use the above issuers, certificates and clusterissuers
 clusterissuer: {}
   # name: kubernetes-ca
   # spec:

--- a/staging/cert-manager-setup/values.yaml
+++ b/staging/cert-manager-setup/values.yaml
@@ -12,7 +12,7 @@ issuers: []
 certificates: []
 #  - name: kubernetes-intermediate-ca
 #    # where to store this certificate
-#    secretName: my-certificate-secret
+#    secretName: kubernetes-intermediate-ca
 #    issuerRef:
 #      name: kubernetes-root-issuer
 #      kind: Issuer


### PR DESCRIPTION
This change allows one to define multiple certificates, issuers and clusterissuers. Note that it maintains backwards compatibility. 
- fixes a job issue where SA is not defined and so task cannot complete, this is particularly harmful for upgrades
- removes job that contains a sleep, that isnt necessary.

tested out the chart as mentioned below