### PR TITLE
[opsportal] remove application ingress records

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.1.29
+version: 0.1.30
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/templates/hooks-roles.yaml
+++ b/stable/opsportal/templates/hooks-roles.yaml
@@ -20,7 +20,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "opsportal.fullname" . }}-admin
-  # namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "opsportal.fullname" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -33,14 +32,11 @@ rules:
 - apiGroups: ["*"]
   resources: ["*"]
   verbs: ["*"]
-
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "opsportal.fullname" . }}
-  # namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "opsportal.fullname" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/opsportal/templates/ingress-opsportal.yaml
+++ b/stable/opsportal/templates/ingress-opsportal.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.opsportal.ingress.paths }}
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
@@ -17,4 +18,5 @@ spec:
         paths:
 {{- with .Values.opsportal.ingress.paths }}
 {{ toYaml . | indent 10 }}
+{{- end }}
 {{- end }}

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -16,6 +16,7 @@ secrets:
     repository: "mesosphere/kubeaddons-addon-initializer"
     tag: "v0.1.6"
 
+# DEPRECATED, DO NOT USE
 opsportal:
   ingress:
     paths:


### PR DESCRIPTION
Removed ingress records of apps from opsportal, these will be now produced in each application. Added deprecation notice, and remove ingress records.

https://jira.d2iq.com/browse/DCOS-63429

