### PR TITLE
kommander-thanos/karma: Cleanup job hook weights

### DIFF
--- a/stable/kommander-karma/Chart.yaml
+++ b/stable/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.2
+version: 0.3.3
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-karma/templates/cleanup-configmap.yaml
+++ b/stable/kommander-karma/templates/cleanup-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "kommander-karma.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ .Values.kommanderServiceAccount }}
       containers:
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.16.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.7
+version: 0.1.8
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-thanos/templates/query-stores-configmap.yaml
+++ b/stable/kommander-thanos/templates/query-stores-configmap.yaml
@@ -27,7 +27,7 @@ metadata:
 {{ $labels }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: {{ $sa }}
       containers:
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.16.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
Change the cleanup job hook weights for kommander-thanos and kommander-karma, so that sa/clusterroles are all set up prior to these cleanup scripts to avoid permission errors.

## Testing
Please see the Testing section of https://github.com/mesosphere/charts/pull/386