### PR TITLE
chore: add enabled property to deploy tests

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.13
+version: 1.72.14
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/tests/test-configmap.yaml
+++ b/staging/traefik/templates/tests/test-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testFramework.enabled  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,4 +13,4 @@ data:
     @test "Test Access" {
       curl -D - http://{{ template "traefik.fullname" . }}/
     }
-
+{{end}}

--- a/staging/traefik/templates/tests/test-configmap.yaml
+++ b/staging/traefik/templates/tests/test-configmap.yaml
@@ -13,4 +13,4 @@ data:
     @test "Test Access" {
       curl -D - http://{{ template "traefik.fullname" . }}/
     }
-{{end}}
+{{- end }}

--- a/staging/traefik/templates/tests/test.yaml
+++ b/staging/traefik/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testFramework.enabled  }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -40,3 +41,4 @@ spec:
   - name: tools
     emptyDir: {}
   restartPolicy: Never
+{{end}}

--- a/staging/traefik/templates/tests/test.yaml
+++ b/staging/traefik/templates/tests/test.yaml
@@ -41,4 +41,4 @@ spec:
   - name: tools
     emptyDir: {}
   restartPolicy: Never
-{{end}}
+{{- end }}

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -10,6 +10,7 @@ imageTag: 1.7.12
 
 
 testFramework:
+  enabled: false
   image: "dduportal/bats"
   tag: "0.4.0"
 


### PR DESCRIPTION
We were deploying the test resources, that should not happen on production.