### PR TITLE
nfs-server-provisioner: move pvc to the correct ns

### DIFF
--- a/staging/nfs-server-provisioner/Chart.yaml
+++ b/staging/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.6.0
+version: 0.6.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/staging/nfs-server-provisioner/templates/statefulset.yaml
+++ b/staging/nfs-server-provisioner/templates/statefulset.yaml
@@ -119,6 +119,7 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        namespace: {{ .Release.Namespace }}
       spec:
         accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
       {{- if .Values.persistence.storageClass }}


### PR DESCRIPTION
The PVC object of the statefulset should be in the same namespace as the
statefulset itself. This patch fixed the issue.