### PR TITLE
[kommander, opsportal] Add clusterroles for well known endpoints

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.3.23
+version: 0.3.24

--- a/stable/kommander/templates/ingress-roles.yaml
+++ b/stable/kommander/templates/ingress-roles.yaml
@@ -1,0 +1,265 @@
+{{- if .Values.rbac.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-base-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander
+  - /ops/portal/kommander/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-base-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander
+  - /ops/portal/kommander/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-base-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander
+  - /ops/portal/kommander/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-ui-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/ui
+  - /ops/portal/kommander/ui/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-ui-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/ui
+  - /ops/portal/kommander/ui/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-ui-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/ui
+  - /ops/portal/kommander/ui/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-monitoring-view
+rules:
+- nonResourceURLs:
+  - /ops/poratl/kommander/monitoring
+  - /ops/portal/kommander/monitoring/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-monitoring-edit
+rules:
+- nonResourceURLs:
+  - /ops/poratl/kommander/monitoring
+  - /ops/portal/kommander/monitoring/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-monitoring-admin
+rules:
+- nonResourceURLs:
+  - /ops/poratl/kommander/monitoring
+  - /ops/portal/kommander/monitoring/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-grafana-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/monitoring/grafana
+  - /ops/portal/kommander/monitoring/grafana/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-grafana-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/monitoring/grafana
+  - /ops/portal/kommander/monitoring/grafana/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-grafana-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/monitoring/grafana
+  - /ops/portal/kommander/monitoring/grafana/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-karma-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/monitoring/karma
+  - /ops/portal/kommander/monitoring/karma/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-karma-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/monitoring/karma
+  - /ops/portal/kommander/monitoring/karma/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-karma-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/kommander/monitoring/karma
+  - /ops/portal/kommander/monitoring/karma/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-query-view
+rules:
+- nonResourceURLs:
+  - /ops/poratl/kommander/monitoring/query
+  - /ops/portal/kommander/monitoring/query/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-query-edit
+rules:
+- nonResourceURLs:
+  - /ops/poratl/kommander/monitoring/query
+  - /ops/portal/kommander/monitoring/query/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kommander-query-admin
+rules:
+- nonResourceURLs:
+  - /ops/poratl/kommander/monitoring/query
+  - /ops/portal/kommander/monitoring/query/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+{{- end }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -132,3 +132,6 @@ grafana:
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces
       searchNamespace: null
+
+rbac:
+  enabled: true

--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.1.33
+version: 0.1.34
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/templates/ingress-roles.yaml
+++ b/stable/opsportal/templates/ingress-roles.yaml
@@ -1,0 +1,310 @@
+{{- if .Values.opsportal.rbac.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-kibana-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/kibana
+  - /ops/portal/kibana/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-kibana-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/kibana
+  - /ops/portal/kibana/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-kibana-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/kibana
+  - /ops/portal/kibana/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-traefik-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/traefik
+  - /ops/portal/traefik/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-traefik-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/traefik
+  - /ops/portal/traefik/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-traefik-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/traefik
+  - /ops/portal/traefik/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-prometheus-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/prometheus
+  - /ops/portal/prometheus/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-prometheus-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/prometheus
+  - /ops/portal/prometheus/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-prometheus-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/prometheus
+  - /ops/portal/prometheus/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-grafana-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/grafana
+  - /ops/portal/grafana/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-grafana-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/grafana
+  - /ops/portal/grafana/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-grafana-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/grafana
+  - /ops/portal/grafana/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-alertmanager-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/alertmanager
+  - /ops/portal/alertmanager/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-alertmanager-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/alertmanager
+  - /ops/portal/alertmanager/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-alertmanager-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/alertmanager
+  - /ops/portal/alertmanager/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-portal-view
+rules:
+- nonResourceURLs:
+  - /ops/portal
+  - /ops/portal/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-portal-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal
+  - /ops/portal/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-portal-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal
+  - /ops/portal/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-graphql-view
+rules:
+- nonResourceURLs:
+  - /ops/portal/graphql
+  - /ops/portal/graphql/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-graphql-edit
+rules:
+- nonResourceURLs:
+  - /ops/portal/graphql
+  - /ops/portal/graphql/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-graphql-admin
+rules:
+- nonResourceURLs:
+  - /ops/portal/graphql
+  - /ops/portal/graphql/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+{{- end }}

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -18,6 +18,8 @@ secrets:
 
 # DEPRECATED, DO NOT USE
 opsportal:
+  rbac:
+    enabled: true
   ingress:
     paths:
       # kibana


### PR DESCRIPTION
# Description
This patch adds roles for protected endpoints under /ops/portal. This is a temporary solution for konvoy 1.3.1 RBAC. In 1.4 we will align these roles with the chart which defines the ingress.

## Why the temporary solution
For kibana, we intended to wrap the upstream chart, however, this strategy would introduce a breaking change which is not acceptable for a bugfix release. 