### PR TITLE
kommander: Fix upgrade bug

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.3.24
+version: 0.3.25

--- a/stable/kommander/templates/grafana/opsportal-username-secret.yaml
+++ b/stable/kommander/templates/grafana/opsportal-username-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "kommander.labels" . | indent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
@@ -23,7 +23,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - kubectl create secret generic {{ .Values.grafana.hooks.secretKeyRef }} -n {{ .Release.Namespace }} --from-literal=username=$(kubectl get secret ops-portal-credentials --namespace=kubeaddons --export -o jsonpath="{.data.username}" | base64 --decode)
+            - kubectl create secret generic {{ .Values.grafana.hooks.secretKeyRef }} -n {{ .Release.Namespace }} -oyaml --dry-run --from-literal=username=$(kubectl get secret ops-portal-credentials --namespace=kubeaddons --export -o jsonpath="{.data.username}" | base64 --decode) | kubectl apply -f -
       restartPolicy: OnFailure
 ---
 apiVersion: batch/v1

--- a/stable/kommander/templates/hooks-kubeaddons.yaml
+++ b/stable/kommander/templates/hooks-kubeaddons.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "kommander.labels" . | indent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,pre-delete
+    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 rules:
@@ -27,7 +27,7 @@ metadata:
   labels:
 {{ include "kommander.labels" . | indent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,pre-delete
+    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 roleRef:


### PR DESCRIPTION
There's a [bug](https://mesosphere.slack.com/archives/CN5S0UKAA/p1580762260057800) in upgrading kommander chart to >=0.3.21
```
$ kubectl -n kommander describe pod set-kommander-grafana-home-dashboard-td4s2
...  
Warning  Failed     57s (x8 over 2m20s)  kubelet, ip-10-0-128-187.us-west-2.compute.internal  Error: secret "ops-portal-username" not found
```
I added a `pre-upgrade` hook to the `copy-ops-portal-username` job to ensure that the username secret is copied over in upgrades as well as installs. Also modified the kubectl command to ensure that it does not fail if the resource already exists.

## Testing [WIP]
I tested this by hosting the chart on my GH. I `konvoy up` with base addons version `stable-1.15.6-4`, then redeployed with the hosted updated kommander chart 0.3.25 (`kubernetes-base-addons` branch is `gracedo/test_kommander_grafana_upgrade`). I also tested upgrade path from `0.3.24`->`0.3.25` to ensure that the copy job doesn't fail if the secret already exists.