### PR TITLE
[opsportal] add opsportal and kibana RBAC roles

### DIFF
--- a/stable/opsportal/templates/ingress-opsportal-roles.yaml
+++ b/stable/opsportal/templates/ingress-opsportal-roles.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.opsportalRBAC.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "opsportal.fullname" . }}-admin
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- nonResourceURLs:
+  - {{ .Values.opsportalRBAC.path | trimSuffix "/"}}
+  - {{ .Values.opsportalRBAC.path | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "opsportal.fullname" . }}-view
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- nonResourceURLs:
+  - {{ .Values.opsportalRBAC.path | trimSuffix "/"}}
+  - {{ .Values.opsportalRBAC.path | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "opsportal.fullname" . }}-edit
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- nonResourceURLs:
+  - {{ .Values.opsportalRBAC.path | trimSuffix "/"}}
+  - {{ .Values.opsportalRBAC.path | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+{{- end }}

--- a/stable/opsportal/templates/kibana-roles.yaml
+++ b/stable/opsportal/templates/kibana-roles.yaml
@@ -1,0 +1,60 @@
+## Kibana is deployed from an upstream chart so we must introduce a temporary
+## cross application dependency
+## This template should be removed in 1.4 https://jira.d2iq.com/browse/D2IQ-63746
+{{- if .Values.kibanaRBAC.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "opsportal.fullname" . }}-kibana-edit
+  lables:
+    app: {{ template "opsportal.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- nonResourceURLs:
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/"}}
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "opsportal.fullname" . }}-kibana-admin
+  lables:
+    app: {{ template "opsportal.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- nonResourceURLs:
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/"}}
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "opsportal.fullname" . }}-kibana-view
+  lables:
+    app: {{ template "opsportal.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- nonResourceURLs:
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/"}}
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+{{- end }}

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -74,3 +74,11 @@ kommander-ui:
       traefik.ingress.kubernetes.io/auth-type: forward
       traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
       traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+
+opsportalRBAC:
+  enabled: true
+  path: /ops/portal
+
+kibanaRBAC:
+  enabled: true
+  path: /ops/portal/kibana


### PR DESCRIPTION
This adds the base /ops/portal roles as well as roles for /ops/portal/kibana. We need to add kibana roles in the opsportal chart until https://jira.d2iq.com/browse/D2IQ-63746 is completed. 