### PR TITLE
[opsportal, kube-oidc-proxy] Chart updates

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/templates/ingress-opsportal-roles.yaml
+++ b/stable/opsportal/templates/ingress-opsportal-roles.yaml
@@ -32,9 +32,17 @@ rules:
 - nonResourceURLs:
   - {{ .Values.opsportalRBAC.path | trimSuffix "/"}}
   - {{ .Values.opsportalRBAC.path | trimSuffix "/" }}/*
+  - {{ .Values.opsportalRBAC.graphqlPath | trimSuffix "/"}}
   verbs:
   - get
   - head
+# Posting to graphql is required for ops portal viewing
+- nonResourceURLs:
+    - {{ .Values.opsportalRBAC.graphqlPath | trimSuffix "/"}}
+  verbs:
+    - get
+    - head
+    - post
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -49,6 +49,7 @@ kommander-ui:
 opsportalRBAC:
   enabled: true
   path: /ops/portal
+  graphqlPath: /ops/portal/graphql
 
 kibanaRBAC:
   enabled: true

--- a/staging/kube-oidc-proxy/Chart.yaml
+++ b/staging/kube-oidc-proxy/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "v0.1.1"
+appVersion: "v0.2.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/mesosphere/charts
 name: kube-oidc-proxy
-version: 0.1.8
+version: 0.1.9
 sources:
 - https://github.com/jetstack/kube-oidc-proxy
 maintainers:

--- a/staging/kube-oidc-proxy/templates/clusterrole.yaml
+++ b/staging/kube-oidc-proxy/templates/clusterrole.yaml
@@ -29,8 +29,23 @@ rules:
   - "userextras/scopes"
   verbs:
   - "impersonate"
+- apiGroups:
+    - "authentication.k8s.io"
+  resources:
+    - "tokenreviews"
+  verbs:
+    - "create"
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
 # kube-oidc-proxy init container requires to list services in order to get
 # load balancer hostname
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"

--- a/staging/kube-oidc-proxy/values.yaml
+++ b/staging/kube-oidc-proxy/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/kube-oidc-proxy
-  tag: v0.1.1
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
* Enable posting in /ops/portal/graphql
   * Required for the operations portal to load with only the `view` role
* Enable token passthrough
   * https://jira.d2iq.com/browse/D2IQ-63673
