### PR TITLE
CI: changed branch since we are working off master now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,14 +102,14 @@ $(TMPDIR)/.helm/repository/local/index.yaml: $(HELM)
 .PHONY: ct.lint
 ct.lint:
 ifneq (,$(wildcard /teamcity/system/git))
-	$(DRUN) git fetch origin dev
+	$(DRUN) git fetch origin master
 endif
 	$(DRUN) ct lint
 
 .PHONY: ct.test
 ct.test:
 ifneq (,$(wildcard /teamcity/system/git))
-	$(DRUN) git fetch origin dev
+	$(DRUN) git fetch origin master
 endif
 	test/e2e-kind.sh $(CT_VERSION)
 

--- a/test/ct-e2e.yaml
+++ b/test/ct-e2e.yaml
@@ -1,5 +1,5 @@
 debug: true
-target-branch: dev
+target-branch: master
 chart-dirs:
   - stable
   - staging

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -1,5 +1,5 @@
 debug: true
-target-branch: dev
+target-branch: master
 chart-dirs:
   - stable
   - staging


### PR DESCRIPTION
I am seeing a lot of runs against charts that were not changed, and this is because we have not updated CI to point to master branch and instead it has been pointing to the dev branch. This should fix these issues. 