### PR TITLE
opsportal: bump extra-steps to fix RBAC bug

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.2.1
+version: 0.2.2
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/values.yaml
+++ b/stable/opsportal/values.yaml
@@ -14,7 +14,7 @@ secrets:
   name: ops-portal-credentials
   image:
     repository: "mesosphere/kubeaddons-addon-initializer"
-    tag: "v0.1.6"
+    tag: "v0.2.0"
 
 
 # We need to override certain values from default kommander values here


### PR DESCRIPTION
Fixes https://jira.d2iq.com/browse/D2IQ-63789

Fix from https://github.com/mesosphere/kubeaddons-extrasteps/pull/56

Bumps the addon-initializer image.