### PR TITLE
fix: add trailing slashes

### DIFF
--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -35,6 +35,9 @@ podDisruptionBudget: {}
 
 resources: {}
 
+## detault is false, which caused some trouble with "broken" urls when trailing slash wasnt added manuelly, this will add it automatically
+keepTrailingSlashes: true
+
 debug:
   enabled: false
 


### PR DESCRIPTION
seems like theres a config setting which solves our trailing slash issues: https://docs.traefik.io/v1.7/configuration/commons/#main-section

⚠️ I'm not sure if this breaks some of our addons since it seems like having `path: some/path/w/o/railing/slash` will break now. 