### PR TITLE
fix: probe values under high load

### DIFF
--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.1.1"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.1.13
+version: 1.1.14
 home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mintel/dex-k8s-authenticator

--- a/staging/dex-k8s-authenticator/templates/deployment.yaml
+++ b/staging/dex-k8s-authenticator/templates/deployment.yaml
@@ -60,12 +60,16 @@ spec:
           containerPort: {{ default "5555" .Values.dexK8sAuthenticator.port }}
           protocol: TCP
         livenessProbe:
+          failureThreshold: {{ .Values.dexK8sAuthenticator.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.dexK8sAuthenticator.livenessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.dexK8sAuthenticator.livenessProbe.periodSeconds }}
           initialDelaySeconds: {{ .Values.dexK8sAuthenticator.livenessProbe.initialDelaySeconds }}
           httpGet:
             path: {{ template "dex-k8s-authenticator.healthCheckPath" . }}
             port: http
         readinessProbe:
+          failureThreshold: {{ .Values.dexK8sAuthenticator.readinessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.dexK8sAuthenticator.readinessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.dexK8sAuthenticator.readinessProbe.periodSeconds }}
           initialDelaySeconds: {{ .Values.dexK8sAuthenticator.readinessProbe.initialDelaySeconds }}
           httpGet:

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -15,11 +15,15 @@ dexK8sAuthenticator:
   port: 5555
   debug: false
   livenessProbe:
-    periodSeconds: 10
-    initialDelaySeconds: 10
+    failureThreshold: 6
+    periodSeconds: 60
+    initialDelaySeconds: 15
+    timeoutSeconds: 30
   readinessProbe:
-    periodSeconds: 10
-    initialDelaySeconds: 10
+    failureThreshold: 3
+    periodSeconds: 30
+    initialDelaySeconds: 15
+    timeoutSeconds: 30
   web_path_prefix: /
   # logoUrl: http://<path-to-your-logo.png>
   # tlsCert: /path/to/dex-client.crt

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -15,15 +15,15 @@ dexK8sAuthenticator:
   port: 5555
   debug: false
   livenessProbe:
-    failureThreshold: 3 # For Clusters with high load use 'failureThreshold: 6'
-    periodSeconds: 10 # For Clusters with high load use 'periodSeconds: 30'
-    initialDelaySeconds: 10 # For Clusters with high load us 'initialDelaySeconds: 15'
-    timeoutSeconds: 10 # For Clusters with high load use 'timeoutSeconds: 30'
+    failureThreshold: 3   # Under high load use 'failureThreshold: 6'
+    periodSeconds: 10   # Under high load use 'periodSeconds: 30'
+    initialDelaySeconds: 10   # Under high load use 'initialDelaySeconds: 15'
+    timeoutSeconds: 10   # Under high load use 'timeoutSeconds: 30'
   readinessProbe:
-    failureThreshold: 3 
-    periodSeconds: 10 # For Clusters with high load use 'periodSeconds: 30'
-    initialDelaySeconds: 10 # For Clusters with high load use 'initialDelaySeconds: 15'
-    timeoutSeconds: 10 # For Clusters with high load use 'timeoutSeconds: 30'
+    failureThreshold: 3
+    periodSeconds: 10   # Under high load use 'periodSeconds: 30'
+    initialDelaySeconds: 10   # Under high load use 'initialDelaySeconds: 15'
+    timeoutSeconds: 10   # Under high load use 'timeoutSeconds: 30'
   web_path_prefix: /
   # logoUrl: http://<path-to-your-logo.png>
   # tlsCert: /path/to/dex-client.crt

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -15,15 +15,15 @@ dexK8sAuthenticator:
   port: 5555
   debug: false
   livenessProbe:
-    failureThreshold: 6
-    periodSeconds: 60
-    initialDelaySeconds: 15
-    timeoutSeconds: 30
+    failureThreshold: 3 # For Clusters with high load use 'failureThreshold: 6'
+    periodSeconds: 10 # For Clusters with high load use 'periodSeconds: 30'
+    initialDelaySeconds: 10 # For Clusters with high load us 'initialDelaySeconds: 15'
+    timeoutSeconds: 10 # For Clusters with high load use 'timeoutSeconds: 30'
   readinessProbe:
-    failureThreshold: 3
-    periodSeconds: 30
-    initialDelaySeconds: 15
-    timeoutSeconds: 30
+    failureThreshold: 3 
+    periodSeconds: 10 # For Clusters with high load use 'periodSeconds: 30'
+    initialDelaySeconds: 10 # For Clusters with high load use 'initialDelaySeconds: 15'
+    timeoutSeconds: 10 # For Clusters with high load use 'timeoutSeconds: 30'
   web_path_prefix: /
   # logoUrl: http://<path-to-your-logo.png>
   # tlsCert: /path/to/dex-client.crt


### PR DESCRIPTION
This is done to fix constant restart when dex-k8s-auth is under load of >= 50 konvoyclusters.

related to: https://jira.d2iq.com/browse/D2IQ-56464