### PR TITLE
fix: Add /private prefix for OSX docker mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ LAST_COMMIT_MESSAGE := $(shell git log -1 --pretty=format:'%B')
 CT_VERSION ?= v2.4.0
 
 TMPDIR := $(shell mktemp -d)
+ifeq ($(shell uname),Darwin)
+	# OSX requires /private prefix as symlink doesn't work when
+	# mounting /var/folders/
+	TMPDIR := /private${TMPDIR}
+endif
+
 HELM := $(shell bash -c "command -v helm")
 ifeq ($(HELM),)
 	HELM := $(TMPDIR)/helm


### PR DESCRIPTION
## What changes were proposed in this pull request?

`make ct.lint` was failing on OSX due to /var/folders not having file
sharing permissions for Docker on Mac. The problem is OSX symlinks /var
to /private/var. Adding the folder to Docker shared paths didn't seem to
fix the issue either.

Without fix:  
```sh
 > make ct.lint
docker run -t --rm -u 502:20 -v /Users/samtran/Dev/mesosphere/k8s/svt-charts:/charts -v /Users/samtran/Dev/mesosphere/k8s/svt-charts/test/ct.yaml:/etc/ct/ct.yaml -v /var/folders/12/6g69fhjn06v3l_l9nyjl33700000gp/T/tmp.gw5rmN1F:/.helm -w /charts quay.io/helmpack/chart-testing:v2.4.0 ct lint
docker: Error response from daemon: Mounts denied:
The path /var/folders/12/6g69fhjn06v3l_l9nyjl33700000gp/T/tmp.gw5rmN1F
is not shared from OS X and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.
See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
.
ERRO[0000] error waiting for container: context canceled
make: *** [Makefile:113: ct.lint] Error 125
```

with fix
```sh
 > make ct.lint
docker run -t --rm -u 502:20 -v /Users/samtran/Dev/mesosphere/k8s/svt-charts:/charts -v /Users/samtran/Dev/mesosphere/k8s/svt-charts/test/ct.yaml:/etc/ct/ct.yaml -v /private/var/folders/12/6g69fhjn06v3l_l9nyjl33700000gp/T/tmp.WnUl4qap:/.helm -w /charts quay.io/helmpack/chart-testing:v2.4.0 ct lint
Linting charts...
Using config file:  /etc/ct/ct.yaml
...
```