### PR TITLE
add rbac roles for opsportal

### DIFF
--- a/stable/kommander-karma/Chart.yaml
+++ b/stable/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.4
+version: 0.3.5
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-karma/templates/ingress-roles.yaml
+++ b/stable/kommander-karma/templates/ingress-roles.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.portalRBAC.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-karma-admin
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.karma.ingress.path | trimSuffix "/"}}
+      - {{ .Values.karma.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-karma-view
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.karma.ingress.path | trimSuffix "/"}}
+      - {{ .Values.karma.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - get
+      - head
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-karma-edit
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.karma.ingress.path | trimSuffix "/"}}
+      - {{ .Values.karma.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+      - patch
+{{- end}}

--- a/stable/kommander-karma/values.yaml
+++ b/stable/kommander-karma/values.yaml
@@ -80,3 +80,6 @@ karma:
 
   certSecretNames:
     - kommander-karma-client-tls
+
+portalRBAC:
+  enabled: true

--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.9
+version: 0.1.10
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-thanos/templates/ingress-roles.yaml
+++ b/stable/kommander-thanos/templates/ingress-roles.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.portalRBAC.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-thanos-admin
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.thanos.query.http.ingress.path | trimSuffix "/"}}
+      - {{ .Values.thanos.query.http.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-thanos-view
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.thanos.query.http.ingress.path | trimSuffix "/"}}
+      - {{ .Values.thanos.query.http.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - get
+      - head
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-thanos-edit
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.thanos.query.http.ingress.path | trimSuffix "/"}}
+      - {{ .Values.thanos.query.http.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+      - patch
+{{- end}}

--- a/stable/kommander-thanos/values.yaml
+++ b/stable/kommander-thanos/values.yaml
@@ -62,3 +62,5 @@ thanos:
         hosts:
           - ""
         tls: []
+portalRBAC:
+  enabled: true

--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.4.18
+version: 0.4.19

--- a/stable/kommander/templates/grafana/ingress-roles.yaml
+++ b/stable/kommander/templates/grafana/ingress-roles.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.portalRBAC.grafana.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-thanos-admin
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.grafana.ingress.path | trimSuffix "/"}}
+      - {{ .Values.grafana.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-thanos-view
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.grafana.ingress.path | trimSuffix "/"}}
+      - {{ .Values.grafana.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - get
+      - head
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-monitoring-thanos-edit
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - nonResourceURLs:
+      - {{ .Values.grafana.ingress.path | trimSuffix "/"}}
+      - {{ .Values.grafana.ingress.path | trimSuffix "/" }}/*
+    verbs:
+      - get
+      - head
+      - post
+      - put
+      - patch
+{{- end}}

--- a/stable/kommander/templates/kommander-ui/ingress-roles.yaml
+++ b/stable/kommander/templates/kommander-ui/ingress-roles.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.portalRBAC.kommanderUserInterface.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-admin
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- nonResourceURLs:
+  - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}
+  - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}/*
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-view
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- nonResourceURLs:
+  - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}
+  - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opsportal-kommander-edit
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- nonResourceURLs:
+  - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}
+  - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}/*
+  verbs:
+  - get
+  - head
+  - post
+  - put
+  - patch
+{{- end}}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -74,6 +74,7 @@ grafana:
       traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
       traefik.ingress.kubernetes.io/priority: "2"
 
+
     ## Labels to be added to the Ingress
     ##
     labels: {}
@@ -131,3 +132,19 @@ grafana:
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces
       searchNamespace: null
+
+kommander-ui:
+  ingress:
+    traefikFrontendRuleType: PathPrefixStrip
+    extraAnnotations:
+      traefik.ingress.kubernetes.io/priority: "2"
+      traefik.ingress.kubernetes.io/auth-type: forward
+      traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+      traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
+    path: /ops/portal/kommander/ui
+
+portalRBAC:
+  grafana:
+    enabled: true
+  kommanderUserInterface:
+    enabled: true


### PR DESCRIPTION

https://jira.d2iq.com/browse/D2IQ-64340

adds roles for:
 /ops/portal/kommander/ui
/ops/portal/kommander/monitoring/grafana
/ops/portal/kommander/monitoring/query
/ops/portal/kommander/monitoring/grafana