### PR TITLE
kommander: Fixes to the clusters summary dashboard

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 - name: alejandroEsc
 - name: jimmidyson
 name: kommander
-version: 0.4.15
+version: 0.4.16

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-clusters.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-clusters.yaml
@@ -2669,7 +2669,7 @@ data:
       },
       "timezone": "",
       "title": "Kubernetes / Compute Resources / Clusters",
-      "uid": "efa86fd1d0c121a26444b636a3f509a8",
+      "uid": "f0U1EswWk",
       "version": 1
     }
 {{- end }}

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-clusters.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-clusters.yaml
@@ -11,16 +11,7 @@ metadata:
 data:
   k8s-resources-clusters-dashboard.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_KOMMANDERPROMETHEUS",
-          "label": "KommanderPrometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
+      "__inputs": [],
       "__requires": [
         {
           "type": "grafana",
@@ -70,12 +61,12 @@ data:
       "gnetId": null,
       "graphTooltip": 0,
       "id": null,
-      "iteration": 1582226941429,
+      "iteration": 1582323837127,
       "links": [],
       "panels": [
         {
           "cacheTimeout": null,
-          "datasource": "${DS_KOMMANDERPROMETHEUS}",
+          "datasource": "$datasource",
           "gridPos": {
             "h": 6,
             "w": 24,
@@ -124,7 +115,7 @@ data:
           "pluginVersion": "6.6.0",
           "targets": [
             {
-              "expr": "count(thanos_store_nodes_grpc_connections)",
+              "expr": "count(prometheus_build_info)",
               "refId": "A"
             }
           ],

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-clusters.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-clusters.yaml
@@ -2668,7 +2668,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Kubernetes / Compute Resources / Clusters",
+      "title": "Kubernetes / Compute Resources / Cluster [Global]",
       "uid": "f0U1EswWk",
       "version": 1
     }

--- a/stable/kommander/templates/grafana/hooks-home-dashboard.yaml
+++ b/stable/kommander/templates/grafana/hooks-home-dashboard.yaml
@@ -83,7 +83,7 @@ data:
     set -o errexit
     set -o pipefail
     CURL="curl --verbose --fail --max-time 30 --retry 20 --retry-connrefused"
-    DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.grafana.hooks.serviceURL }}/api/dashboards/uid/{{ .Values.grafana.hooks.homeDashboardUID }} | jq '.dashboard.id')
+    DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.grafana.hooks.serviceURL }}/api/search/?query={{ .Values.grafana.hooks.dashboardName | urlquery }} | jq '.[0].id')
     echo "setting home dashboard to ID" $DASHBOARD_ID
     $CURL -X PUT -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"homeDashboardId":'"$DASHBOARD_ID"'}' {{ .Values.grafana.hooks.serviceURL }}/api/org/preferences
 ---

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -34,8 +34,7 @@ grafana:
     image: dwdraju/alpine-curl-jq
     secretKeyRef: ops-portal-username
     serviceURL: http://kommander-kubeaddons-grafana.kommander
-    # This is the UID of the "Kubernetes / Compute Resources / Clusters" summary dashboard
-    homeDashboardUID: efa86fd1d0c121a26444b636a3f509a8
+    dashboardName: "Kubernetes / Compute Resources / Clusters"
     kommanderServiceAccount: kommander-kubeaddons
 
   ## Do not deploy default dashboards.

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -34,7 +34,7 @@ grafana:
     image: dwdraju/alpine-curl-jq
     secretKeyRef: ops-portal-username
     serviceURL: http://kommander-kubeaddons-grafana.kommander
-    dashboardName: "Kubernetes / Compute Resources / Clusters"
+    dashboardName: "Kubernetes / Compute Resources / Cluster [Global]"
     kommanderServiceAccount: kommander-kubeaddons
 
   ## Do not deploy default dashboards.


### PR DESCRIPTION
Fixed the cluster summary dashboard which wasn't getting automatically imported correctly (reworked the query to use the same datasource instead of trying to use two on the same dashboard which seems to be causing issues) and also added `[Global]` to the dashboard name and changed the uid so it's different from the konvoy-equivalent dashboard's name/uid (just to avoid potential name and uid collisions if someone were to ever deploy a grafana that pulls in both sets of dashboards).

I'll be opening another PR later today adding more central dashboards (porting over the base k8s dashboards from konvoy), wanted to keep them separate since this one's a bug fix.