### PR TITLE
tfa: add an option to stage TFA

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.2.13
+version: 0.2.14
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/deployment.yaml
+++ b/staging/traefik-forward-auth/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.traefikForwardAuth.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -152,3 +153,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -17,6 +17,11 @@ service:
   port: 4181
 
 traefikForwardAuth:
+  # If set to false, do not install the TFA deployment.
+  # TFA will refuse to start up if the OIDC provider is not ready.
+  # This chart option allows us to stage TFA to the cluster and then
+  # later update it with proper OIDC provider information.
+  enabled: true
   clientId: traefik-forward-auth
   clientSecret:
     value: "do-not-use"


### PR DESCRIPTION
Provide an option to skip installing the TFA deployment. TFA will
refuse to start up if the OIDC provider is not ready. This chart option
allows us to stage TFA to the cluster and then later update it with
proper OIDC provider information when available.

https://jira.d2iq.com/browse/D2IQ-64824