### PR TITLE
Readd Dispatchfile

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -1,0 +1,71 @@
+#!starlark
+# vi:syntax=python
+#
+
+git = "src-git"
+
+def secretVar(name, key):
+    return k8s.corev1.EnvVarSource(secretKeyRef=k8s.corev1.SecretKeySelector(localObjectReference=k8s.corev1.LocalObjectReference(name=name), key=key))
+
+gitResource(git,
+    url="$(context.git.url)",
+    revision="$(context.git.commit)")
+
+dindTask("publish", inputs=[git], steps=[
+  v1.Container(
+    name = "publish-charts",
+    workingDir =  "/workspace/src-git",
+    args = [
+      "/bin/bash", "-c",
+      """
+      apt-get update
+      apt-get install -qq git build-essential
+      git fetch origin master --unshallow
+      export GIT_REMOTE_URL=https://mesosphere:${GITHUB_USER_TOKEN}@github.com/mesosphere/charts.git
+      make publish
+      """
+    ],
+    env=[k8s.corev1.EnvVar(name="GITHUB_USER_TOKEN", valueFrom=secretVar("scmtoken", "password"))]
+  )
+])
+
+dindTask("lint", inputs=[git], steps=[
+  v1.Container(
+    name = "lint-charts",
+    workingDir =  "/workspace/src-git",
+    args = [
+      "/bin/bash", "-c",
+      """
+      apt-get update
+      apt-get install -qq git build-essential
+      git fetch origin master --unshallow
+      make lint
+      """
+    ]
+  )
+])
+
+dindTask("test", inputs=[git], deps=["lint"], steps=[
+  v1.Container(
+    name = "test-charts",
+    workingDir =  "/workspace/src-git",
+    args = [
+      "/bin/bash", "-c",
+      """
+      apt-get update
+      apt-get install -qq git build-essential
+      git fetch origin master --unshallow
+      make test
+      """
+    ],
+    resources = k8s.corev1.ResourceRequirements(
+      limits = {
+        "cpu": k8s.resource_quantity("1000m"),
+        "memory": k8s.resource_quantity("6Gi")
+      }
+    )
+  )
+])
+
+action(tasks=["test"], on=pullRequest(branches=["*"]))
+action(tasks=["publish"], on=push(branches=["master"]))

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -3,3 +3,22 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker
+# These kubeadm config patches are required for running Kind inside a docker container.
+# We started running Kind in a kubernetes pod as part of the CI transition to Dispatch.
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: JoinConfiguration
+  metadata:
+    name: config
+  nodeRegistration:
+    kubeletExtraArgs:
+      cgroup-root: "/kubelet"
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: InitConfiguration
+  metadata:
+    name: config
+  nodeRegistration:
+    kubeletExtraArgs:
+      cgroup-root: "/kubelet"


### PR DESCRIPTION
This reverts commit 44fef52.
and adds a simple fix at this line: https://github.com/mesosphere/charts/compare/fix_dispatchfile?expand=1#diff-37eda1430799e62f92596aa54fae0596R49

This initially was reverted because the Dispatch build was failing and causing TeamCity CI to fail as well. The problem was a certain entrypoint.sh that was being downloaded. That file was in a private repo and required a token in its URL. That token was not a security hazard; it only exposed that single revision of that single file. However, little did I know, that token expires after a few days, which was causing the failure. We are also trying to upstream that file in the kubernetes-sigs/kind repo, so there is no harm in making it public. I added it as a gist for the d2iq-dispatch user so we can download it from there. I also added the -f switch to the "curl" commands. It would have made debugging this issue much easier in the first place.