### PR TITLE
kommander: bump kommander-ui ingress priority

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.4.21
+version: 0.4.22

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -156,7 +156,7 @@ kommander-ui:
   ingress:
     traefikFrontendRuleType: PathPrefixStrip
     extraAnnotations:
-      traefik.ingress.kubernetes.io/priority: "2"
+      traefik.ingress.kubernetes.io/priority: "4"
       traefik.ingress.kubernetes.io/auth-type: forward
       traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
       traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User


### PR DESCRIPTION
When attaching kommander to itself, we observed an issue that the
kommander UI route (/ops/portal/kommander/ui, priority 2) will be
overrided by the ops portal overrides (/ops/portal, priority 3).

Apparently, traefik will first evaluate priority and then do the longest
prefix match on the route path. As a result, we won't be able to see
Kommander UI after self attaching.

This patch fixed the issue by bumping kommander UI route priority to 4.

Tested on a live cluster and problem goes away after this change.