### PR TITLE
chore: bump ingress priority for karma and thanos

### DIFF
--- a/stable/kommander-karma/Chart.yaml
+++ b/stable/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.5
+version: 0.3.6
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-karma/values.yaml
+++ b/stable/kommander-karma/values.yaml
@@ -27,7 +27,7 @@ karma:
       traefik.ingress.kubernetes.io/auth-response-headers: "X-Forwarded-User"
       traefik.ingress.kubernetes.io/auth-type: "forward"
       traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
-      traefik.ingress.kubernetes.io/priority: "2"
+      traefik.ingress.kubernetes.io/priority: "4"
     path: "/ops/portal/kommander/monitoring/karma"
     hosts:
       - ""

--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.10
+version: 0.1.11
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-thanos/values.yaml
+++ b/stable/kommander-thanos/values.yaml
@@ -57,7 +57,7 @@ thanos:
           traefik.ingress.kubernetes.io/auth-response-headers: "X-Forwarded-User"
           traefik.ingress.kubernetes.io/auth-type: "forward"
           traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
-          traefik.ingress.kubernetes.io/priority: "2"
+          traefik.ingress.kubernetes.io/priority: "4"
         path: "/ops/portal/kommander/monitoring/query"
         hosts:
           - ""


### PR DESCRIPTION
The reason is the same as that in
https://github.com/mesosphere/charts/pull/474

When attaching kommander to itself, we observed an issue that the
kommander karma and thanos route (/ops/portal/kommander/monitoring/...,
priority 2) will be overrided by the ops portal overrides (/ops/portal,
priority 3).

Apparently, traefik will first evaluate priority and then do the longest
prefix match on the route path. As a result, we won't be able to see
Kommander karma and thanos UIs after self attaching.

This patch fixed the issue by bumping route priorities to 4.