### PR TITLE
Jg/fix version numbers

### DIFF
--- a/stable/kommander-karma/Chart.yaml
+++ b/stable/kommander-karma/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.0
+appVersion: 1.0.0
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts

--- a/stable/kommander-karma/Chart.yaml
+++ b/stable/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.7
+version: 0.3.8
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.0
+appVersion: 1.0.0
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts

--- a/stable/kommander-thanos/Chart.yaml
+++ b/stable/kommander-thanos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.12
+version: 0.1.13
 maintainers:
   - name: branden
   - name: gracedo


### PR DESCRIPTION
turns out not the quoting, but not following semver was the issue 🤦‍♂ this time we validated by deploying it manually on a cluster, so we know it works (well, hopefully…)

thing is that when using the appversion field in clusterrole defintions, these have to have valid semver fields. its something we should double check in the first place, sounds like we need to require semver compatible appversions b/c of the way we use them down the line. cc @jr0d 