### PR TITLE
chore: fix generic-ingress chart

### DIFF
--- a/staging/generic-ingress/templates/ingresses.yaml
+++ b/staging/generic-ingress/templates/ingresses.yaml
@@ -18,4 +18,4 @@ spec:
         {{- with $ingress.paths -}}
           {{ toYaml . | nindent 10 }}
         {{- end }}
-{{- end }}
+{{ end }}


### PR DESCRIPTION
The YAML is not valid due to `---` being aligned to the wrong place.
This patch fixed it.

Tested with the following:
```
helm template -f new-values.yaml . | yamllint -
```

`new-values.yaml` the same we use in KCL
https://github.com/mesosphere/kommander-cluster-lifecycle/blob/mh/kubefed/ops-portal-ingress/chart/kommander-cluster-lifecycle/templates/federatedaddon_ops_portal_ingress.yaml#L27-L75