### PR TITLE
[prometheus-operator] fix: revert update that removed crds installation check.

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.7.2
+version: 8.7.3
 appVersion: 0.35.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/prometheus-operator/crds.yaml
+++ b/staging/prometheus-operator/templates/prometheus-operator/crds.yaml
@@ -1,6 +1,8 @@
 {{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.createCustomResource -}}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The original crd management had a check to not install crds if they exist, this was removed in a huge update and so was missed.