### PR TITLE
Workaround for PrometheusRuleFailures alert #D2IQ-65026

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.7.3
+version: 8.7.4
 appVersion: 0.35.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver-error.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver-error.yaml
@@ -49,12 +49,6 @@ spec:
           and
           status_class_5xx:apiserver_request_total:ratio_rate2h{job="apiserver"} > (3*0.010000)
         )
-        or
-        (
-          status_class_5xx:apiserver_request_total:ratio_rate3d{job="apiserver"} > (0.010000)
-          and
-          status_class_5xx:apiserver_request_total:ratio_rate6h{job="apiserver"} > (0.010000)
-        )
       labels:
         job: apiserver
         severity: warning
@@ -113,15 +107,6 @@ spec:
         job: apiserver
       record: status_class:apiserver_request_total:rate1d
     - expr: |-
-        sum by (status_class) (
-          label_replace(
-            rate(apiserver_request_total{job="apiserver"}[3d]
-          ), "status_class", "${1}xx", "code", "([0-9])..")
-        )
-      labels:
-        job: apiserver
-      record: status_class:apiserver_request_total:rate3d
-    - expr: |-
         sum(status_class:apiserver_request_total:rate5m{job="apiserver",status_class="5xx"})
         /
         sum(status_class:apiserver_request_total:rate5m{job="apiserver"})
@@ -163,11 +148,4 @@ spec:
       labels:
         job: apiserver
       record: status_class_5xx:apiserver_request_total:ratio_rate1d
-    - expr: |-
-        sum(status_class:apiserver_request_total:rate3d{job="apiserver",status_class="5xx"})
-        /
-        sum(status_class:apiserver_request_total:rate3d{job="apiserver"})
-      labels:
-        job: apiserver
-      record: status_class_5xx:apiserver_request_total:ratio_rate3d
 {{- end }}


### PR DESCRIPTION
### Description
This is a workaround for the `PrometheusRuleFailures` alert and Prometheus slowness [observed](https://mesosphere.slack.com/archives/CPF8FQ4PN/p1583179108061300)  on the Soak cluster.

### Changes by this PR

- Deleting the `status_class:apiserver_request_total:rate3d` record.
- Deleting the `status_class_5xx:apiserver_request_total:ratio_rate3d` record.
- Modifying the `ErrorBudgetBurn` alert.
- Changing the `prometheus-operator` chart version from `8.7.3` to `8.7.4`

### Related tickets
Jira ticket: https://jira.d2iq.com/browse/D2IQ-65026.
GH issue on the upstream repository: https://github.com/coreos/prometheus-operator/issues/3036
