### PR TITLE
chore: update awsebscsiprovisioner chart

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 description: AWS EBS CSI driver and storage provisioner
 name: awsebscsiprovisioner
 maintainers:
   - name: alejandroEsc
   - name: gpaul
   - name: hectorj2f
-version: 0.3.3
+version: 0.3.4
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/ci/annotations-kube2iam-usage.yaml
+++ b/stable/awsebscsiprovisioner/ci/annotations-kube2iam-usage.yaml
@@ -1,0 +1,7 @@
+# Check that statefulSet.podAnnoations is rendered
+statefulSetCSIController:
+  podAnnotations:
+    iam.amazonaws.com/role: ebs-csi-driver-role
+statefulSetCSISnapshotController:
+  podAnnotations:
+    iam.amazonaws.com/role: ebs-csi-snapshot-controller-role

--- a/stable/awsebscsiprovisioner/ci/more-specific-settings.yaml
+++ b/stable/awsebscsiprovisioner/ci/more-specific-settings.yaml
@@ -1,0 +1,21 @@
+# Check that statefulSet.podAnnoations is rendered
+replicas: 2
+extraVolumeTags:
+  konvoy: cluster-name-random
+  konvoy-version: 1.4.2
+storageclass:
+  isDefault: true
+  reclaimPolicy: Delete
+  volumeBindingMode: WaitForFirstConsumer
+  type: io1
+  fstype: xfs
+  iopsPerGB: 100
+  encrypted: true
+  kmsKeyId: arn:aws:kms:us-west-2:123456789011:key/d72124e7-ffff-1111-zzzz-4f820a16908e
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.ebs.csi.aws.com/zone
+    values:
+    - us-west-2a
+    - us-west-2b
+    - us-west-2c

--- a/stable/awsebscsiprovisioner/templates/_helpers.tpl
+++ b/stable/awsebscsiprovisioner/templates/_helpers.tpl
@@ -43,3 +43,16 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Convert the `--extra-volume-tags` command line arg from a map.
+*/}}
+{{- define "aws-ebs-csi-driver.extra-volume-tags" -}}
+{{- $result := dict "pairs" (list) -}}
+{{- range $key, $value := .Values.extraVolumeTags -}}
+{{- $noop := printf "%s=%s" $key $value | append $result.pairs | set $result "pairs" -}}
+{{- end -}}
+{{- if gt (len $result.pairs) 0 -}}
+- --extra-volume-tags={{- join "," $result.pairs -}}
+{{- end -}}
+{{- end -}}

--- a/stable/awsebscsiprovisioner/templates/csidriver.yaml
+++ b/stable/awsebscsiprovisioner/templates/csidriver.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: ebs.csi.aws.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false

--- a/stable/awsebscsiprovisioner/templates/daemonset.yaml
+++ b/stable/awsebscsiprovisioner/templates/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
             privileged: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args:
+            - node
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=5

--- a/stable/awsebscsiprovisioner/templates/daemonset.yaml
+++ b/stable/awsebscsiprovisioner/templates/daemonset.yaml
@@ -16,6 +16,9 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/name: {{ include "aws-ebs-csi-driver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.node.podAnnotations }}
+      annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
+    {{- end }}
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/stable/awsebscsiprovisioner/templates/roles.yaml
+++ b/stable/awsebscsiprovisioner/templates/roles.yaml
@@ -4,6 +4,19 @@ kind: ServiceAccount
 metadata:
   name: ebs-csi-controller-sa
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.controller.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-snapshot-controller
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.snapshot.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 
 ---
 kind: ClusterRole
@@ -20,15 +33,24 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding
@@ -95,7 +117,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
@@ -108,6 +130,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete"]
@@ -124,6 +152,77 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: ebs-external-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-snapshot-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-snapshot-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-snapshot-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: ebs-csi-snapshot-controller-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-snapshot-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: ebs-csi-snapshot-controller-leaderelection
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 
@@ -153,7 +252,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 
 ---
 kind: ClusterRoleBinding
@@ -169,12 +268,3 @@ roleRef:
   name: ebs-external-resizer-role
   apiGroup: rbac.authorization.k8s.io
 {{- end}}
-
----
-apiVersion: storage.k8s.io/v1beta1
-kind: CSIDriver
-metadata:
-  name: ebs.csi.aws.com
-spec:
-  attachRequired: true
-  podInfoOnMount: false

--- a/stable/awsebscsiprovisioner/templates/statefulset-snapshot-controller.yaml
+++ b/stable/awsebscsiprovisioner/templates/statefulset-snapshot-controller.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.snapshotter.enabled }}
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: ebs-csi-snapshot-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  serviceName: ebs-csi-snapshot-controller
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ebs-csi-snapshot-controller
+      app.kubernetes.io/name: {{ include "aws-ebs-csi-driver.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+    {{- if .Values.statefulSetCSISnapshotController.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.statefulSetCSISnapshotController.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
+      labels:
+        app: ebs-csi-snapshot-controller
+        app.kubernetes.io/name: {{ include "aws-ebs-csi-driver.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccount: ebs-csi-snapshot-controller
+      containers:
+        - name: ebs-csi-snapshot-controller
+          image: "{{ .Values.snapshotter.image.repository }}:{{ .Values.snapshotter.image.tag }}"
+          args:
+            - --v=5
+            - --leader-election=false
+{{- end }}

--- a/stable/awsebscsiprovisioner/templates/statefulset.yaml
+++ b/stable/awsebscsiprovisioner/templates/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
         - name: ebs-plugin
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args :
+            - controller
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=5
@@ -74,6 +75,8 @@ spec:
             {{- if .Values.provisioner.enableVolumeScheduling }}
             - --feature-gates=Topology=true
             {{- end}}
+            - --enable-leader-election
+            - --leader-election-type=leases
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -85,6 +88,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
+            - --leader-election=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -97,6 +101,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --connection-timeout=15s
+            - --leader-election=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/stable/awsebscsiprovisioner/templates/statefulset.yaml
+++ b/stable/awsebscsiprovisioner/templates/statefulset.yaml
@@ -6,12 +6,18 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   serviceName: ebs-csi-controller
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: ebs-csi-controller
   template:
     metadata:
+    {{- if .Values.statefulSetCSIController.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.statefulSetCSIController.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
       labels:
         app: ebs-csi-controller
         app.kubernetes.io/name: {{ include "aws-ebs-csi-driver.name" . }}
@@ -30,6 +36,7 @@ spec:
           args :
             - controller
             - --endpoint=$(CSI_ENDPOINT)
+            {{ include "aws-ebs-csi-driver.extra-volume-tags" . }}
             - --logtostderr
             - --v=5
           env:

--- a/stable/awsebscsiprovisioner/templates/storageclass.yaml
+++ b/stable/awsebscsiprovisioner/templates/storageclass.yaml
@@ -24,6 +24,9 @@ parameters:
   {{- if .Values.storageclass.encrypted }}
   encrypted: {{ .Values.storageclass.encrypted | quote }}
   {{- end }}
+  {{- if .Values.storageclass.kmsKeyId }}
+  kmsKeyId: {{ .Values.storageclass.kmsKeyId | quote }}
+  {{- end }}
 {{- if .Values.storageclass.allowedTopologies }}
 {{- with .Values.storageclass.allowedTopologies }}
 allowedTopologies:

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -26,13 +26,12 @@ registrar:
       repository: "quay.io/k8scsi/csi-node-driver-registrar"
       tag: "v1.1.0"
 
-
 provisioner:
   # True if enable volume scheduling for dynamic volume provisioning
   enableVolumeScheduling: false
   image:
     repository: "quay.io/k8scsi/csi-provisioner"
-    tag: "v1.3.0"
+    tag: "v1.4.0"
 
 attacher:
   image:

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -36,7 +36,7 @@ provisioner:
 attacher:
   image:
     repository: "quay.io/k8scsi/csi-attacher"
-    tag: "v1.2.0"
+    tag: "v1.2.1"
 
 snapshotter:
   # True if enable volume snapshot

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -50,7 +50,7 @@ resizer:
   enabled: false
   image:
     repository: "quay.io/k8scsi/csi-resizer"
-    tag: "v0.2.0"
+    tag: "v0.4.0"
 
 # AWS key id and access key
 # these are optional and can be left as is

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -8,7 +8,7 @@ image:
 liveness:
   image:
     repository: "quay.io/k8scsi/livenessprobe"
-    tag: "v1.1.0"
+    tag: "v1.2.0"
 
 tolerations:
   - effect: NoSchedule

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -43,7 +43,7 @@ snapshotter:
   enabled: false
   image:
     repository: "quay.io/k8scsi/csi-snapshotter"
-    tag: "v1.1.0"
+    tag: "v1.2.2"
 
 resizer:
   # True if enable volume resizing

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -1,6 +1,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# replicas of the CSI-Controller
+replicas: 1
+
 image:
   repository: "amazon/aws-ebs-csi-driver"
   tag: "v0.5.0"
@@ -20,6 +23,18 @@ tolerations:
 
 env: {}
 
+node:
+  # annotations for the pods running on each node as started per DaemonSet
+  podAnnotations: {}
+
+statefulSetCSIController:
+  # if you want to use kube2iam or kiam roles define it here as podAnnotation for the CSI-Controller (statefulSet)
+  podAnnotations: {}
+
+statefulSetCSISnapshotController:
+  # if you want to use kube2iam or kiam roles define it here as podAnnotation for the CSI-Snapshot-Controller (statefulSet)
+  podAnnotations: {}
+
 registrar:
   node:
     image:
@@ -38,6 +53,13 @@ attacher:
     repository: "quay.io/k8scsi/csi-attacher"
     tag: "v2.0.0"
 
+resizer:
+  # True if enable volume resizing
+  enabled: false
+  image:
+    repository: "quay.io/k8scsi/csi-resizer"
+    tag: "v0.4.0"
+
 snapshotter:
   # True if enable volume snapshot
   enabled: false
@@ -45,12 +67,23 @@ snapshotter:
     repository: "quay.io/k8scsi/csi-snapshotter"
     tag: "v1.2.2"
 
-resizer:
-  # True if enable volume resizing
-  enabled: false
+snapshot-controller:
   image:
-    repository: "quay.io/k8scsi/csi-resizer"
-    tag: "v0.4.0"
+    repository: "quay.io/k8scsi/snapshot-controller"
+    tag: "v2.0.1"
+
+# Extra volume tags to attach to each dynamically provisioned volume.
+# ---
+# extraVolumeTags:
+#   key1: value1
+#   key2: value2
+extraVolumeTags: {}
+
+serviceAccount:
+  controller:
+    annotations: {}
+  snapshot:
+    annotations: {}
 
 # AWS key id and access key
 # these are optional and can be left as is
@@ -64,11 +97,15 @@ storageclass:
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
   type: gp2
+  fstype: ext4
+  iopsPerGB: null
+  encrypted: false
+  kmsKeyId: null
   allowedTopologies: []
-  allowVolumeExpansion: true
   # - matchLabelExpressions:
   #   - key: topology.ebs.csi.aws.com/zone
   #     values:
   #     - us-west-2a
   #     - us-west-2b
   #     - us-west-2c
+  allowVolumeExpansion: true

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -8,7 +8,7 @@ image:
 liveness:
   image:
     repository: "quay.io/k8scsi/livenessprobe"
-    tag: "v1.2.0"
+    tag: "v2.0.0"
 
 tolerations:
   - effect: NoSchedule
@@ -24,19 +24,19 @@ registrar:
   node:
     image:
       repository: "quay.io/k8scsi/csi-node-driver-registrar"
-      tag: "v1.1.0"
+      tag: "v1.2.0"
 
 provisioner:
   # True if enable volume scheduling for dynamic volume provisioning
   enableVolumeScheduling: false
   image:
     repository: "quay.io/k8scsi/csi-provisioner"
-    tag: "v1.4.0"
+    tag: "v1.5.0"
 
 attacher:
   image:
     repository: "quay.io/k8scsi/csi-attacher"
-    tag: "v1.2.1"
+    tag: "v2.0.0"
 
 snapshotter:
   # True if enable volume snapshot

--- a/stable/awsebscsiprovisioner/values.yaml
+++ b/stable/awsebscsiprovisioner/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 image:
   repository: "amazon/aws-ebs-csi-driver"
-  tag: "v0.4.0"
+  tag: "v0.5.0"
 
 liveness:
   image:

--- a/test/ct-e2e.yaml
+++ b/test/ct-e2e.yaml
@@ -9,6 +9,7 @@ excluded-charts:
   - azuredisk-csi-driver  # DCOS-62804
   - defaultstorageclass   # DCOS-62803
   - dispatch              # DCOS-62802
+  - gcpdisk-csi-driver    # D2IQ-65765
   - gcpdiskprovisioner    # DCOS-62801
   - kommander             # DCOS-62800
   - kommander-karma       # DCOS-62799

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -130,6 +130,12 @@ install_dummylb() {
     echo
 }
 
+replace_priority_class_name_system_x_critical() {
+    echo 'Replacing priorityClassName: system-X-critical'
+    grep -rl "priorityClassName: system-" . | xargs sed -i 's/system-.*-critical/null/g'
+    echo
+}
+
 main() {
     run_ct_container "$1"
     shift
@@ -141,7 +147,11 @@ main() {
     install_dummylb
     install_certmanager
 
-    docker_exec ct lint-and-install --upgrade --debug "$@"
+    docker_exec ct lint --debug "$@"
+
+    replace_priority_class_name_system_x_critical
+
+    docker_exec ct install --upgrade --debug "$@"
     echo
 }
 


### PR DESCRIPTION
# Bump aws-ebs-csi-driver from 0.4.0 to 0.5.0

[Documentation](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v0.5.0/docs/README.md)

filename  | sha512 hash
--------- | ------------
[v0.5.0.zip](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/archive/v0.5.0.zip) | `c53327e090352a7f79ee642dbf8c211733f4a2cb78968ec688a1eade55151e65f1f97cd228d22168317439f1db9f3d2f07dcaa2873f44732ad23aaf632cbef3a`
[v0.5.0.tar.gz](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/archive/v0.5.0.tar.gz) | `ec4963d34c601cdf718838d90b8aa6f36b16c9ac127743e73fbe76118a606d41aced116aaaab73370c17bcc536945d5ccd735bc5a4a00f523025c8e41ddedcb8`

* Add a cmdline option to add extra volume tags ([#353](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/353), [@jieyu](https://github.com/jieyu))
* Switch to use kustomize for manifest ([#360](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/360), [@leakingtapan](https://github.com/leakingtapan))
* enable users to set ec2-endpoint for nonstandard regions ([#369](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/369), [@amdonov](https://github.com/amdonov))
* Add standard volume type ([#379](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/379), [@leakingtapan](https://github.com/leakingtapan))
* Update aws sdk version to enable EKS IAM for SA ([#386](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/386), [@leakingtapan](https://github.com/leakingtapan))
* Implement different driver modes and AWS Region override for controller service ([#438](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/438), [@rfranzke](https://github.com/rfranzke))
* Add manifest files for snapshotter 2.0 ([#452](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/452), [@leakingtapan](https://github.com/leakingtapan))

* Return success if instance or volume are not found ([#375](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/375), [@bertinatto](https://github.com/bertinatto))
* Patch k8scsi sidecars CVE-2019-11255 ([#413](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/413), [@jnaulty](https://github.com/jnaulty))
* Handle mount flags in NodeStageVolume ([#430](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/430), [@bertinatto](https://github.com/bertinatto))

* Run upstream e2e test suites with migration  ([#341](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/341), [@wongma7](https://github.com/wongma7))
* Use new test framework for test orchestration ([#359](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/359), [@leakingtapan](https://github.com/leakingtapan))
* Update to use 1.16 cluster with inline test enabled ([#362](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/362), [@leakingtapan](https://github.com/leakingtapan))
* Enable leader election ([#380](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/380), [@leakingtapan](https://github.com/leakingtapan))
* Update go mod and mount library ([#388](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/388), [@leakingtapan](https://github.com/leakingtapan))
* Refactor NewCloud by pass in region ([#394](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/394), [@leakingtapan](https://github.com/leakingtapan))
* helm: provide an option to set extra volume tags ([#396](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/396), [@jieyu](https://github.com/jieyu))
* Allow override for csi-provisioner image ([#401](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/401), [@gliptak](https://github.com/gliptak))
* Enable volume expansion e2e test for CSI migration ([#407](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/407), [@leakingtapan](https://github.com/leakingtapan))
* Swith to use kops 1.16 ([#409](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/409), [@leakingtapan](https://github.com/leakingtapan))
* Added tolerations for node support ([#420](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/420), [@zerkms](https://github.com/zerkms))
* Update helm chart to better match available values and add the ability to add annotations ([#423](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/423), [@krmichel](https://github.com/krmichel))
* [helm] Also add toleration support to controller ([#433](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/433), [@jyaworski](https://github.com/jyaworski))
* Add ec2:ModifyVolume action ([#434](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/434), [@zodiac12k](https://github.com/zodiac12k))
* Schedule the EBS CSI DaemonSet on all nodes by default ([#441](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/441), [@pcfens](https://github.com/pcfens))

# bump livenessprobe from 1.1.0 to 2.0.0

## Changes since v1.1.0

### Action Required

- Introduce V(5) on the health check begin/success log lines to allow filtering of these entries from logs. If you would like to retain these log entries the action required would be to set `-v==5` or higher for the livenessprobe container. ([#57](https://github.com/kubernetes-csi/livenessprobe/pull/57), [@stefansedich](https://github.com/stefansedich))
- Deprecated "--connection-timeout" argument has been removed. ([#59](https://github.com/kubernetes-csi/livenessprobe/pull/59), [@msau42](https://github.com/msau42))

### Other Notable Changes

- Fix nil pointer bug when driver responds with not ready ([#58](https://github.com/kubernetes-csi/livenessprobe/pull/58), [@scuzhanglei](https://github.com/scuzhanglei))
- Migrated to Go modules, so the source builds also outside of GOPATH. ([#53](https://github.com/kubernetes-csi/livenessprobe/pull/53), [@pohly](https://github.com/pohly))

# bump csi external-provisioner from 1.3.0 to 1.4.0

## Changelog since v1.3.0

### Deprecations
All external-provisioner versions < 1.4.0 are deprecated and will stop
functioning in Kubernetes v1.20. See
[#323](https://github.com/kubernetes-csi/external-provisioner/pull/323) and
[k/k#80978](https://github.com/kubernetes/kubernetes/pull/80978) for more
details. Upgrade your external-provisioner to v1.4+ before Kubernetes v1.20.

### New Features
None

### Bug Fixes

- Fixes migration scenarios for Topology, fstype, and accessmodes for the kubernetes.io/gce-pd in-tree plugin ([#277](https://github.com/kubernetes-csi/external-provisioner/pull/277), [@davidz627](https://github.com/davidz627))
- Checks if volume content source is populated if creating a volume from a snapshot source. ([#283](https://github.com/kubernetes-csi/external-provisioner/pull/283), [@zhucan](https://github.com/zhucan))
- Fixes issue when SelfLink removal is turned on in Kubernetes. ([#323](https://github.com/kubernetes-csi/external-provisioner/pull/323), [@msau42](https://github.com/msau42))
- CSI driver can return `CreateVolumeResponse` with size 0, which means unknown volume size. 
In this case, Provisioner will use PVC requested size as PV size rather than 0 bytes ([#271](https://github.com/kubernetes-csi/external-provisioner/pull/271), [@hoyho](https://github.com/hoyho))
- Fixed potential leak of volumes after CSI driver timeouts. ([#312](https://github.com/kubernetes-csi/external-provisioner/pull/312), [@jsafrane](https://github.com/jsafrane))
- Fixes issue where provisioner provisions volumes for in-tree PVC's which have not been migrated ([#341](https://github.com/kubernetes-csi/external-provisioner/pull/341), [@davidz627](https://github.com/davidz627))
- Send the CSI volume_id instead of  PVC Name to the csi-driver in volumeCreate when datasource  is PVC ([#310](https://github.com/kubernetes-csi/external-provisioner/pull/310), [@Madhu-1](https://github.com/Madhu-1))
- Fixes nil pointer derefence in log when migration turned on ([#342](https://github.com/kubernetes-csi/external-provisioner/pull/342), [@davidz627](https://github.com/davidz627))
- Handle deletion of CSI migrated volumes ([#273](https://github.com/kubernetes-csi/external-provisioner/pull/273), [@ddebroy](https://github.com/ddebroy))
- Reduced logging noise of unrelated PVCs. Emit event on successful provisioning. ([#351](https://github.com/kubernetes-csi/external-provisioner/pull/351), [@jsafrane](https://github.com/jsafrane))
- Added extra verification of source Snapshot and PersistentVolumeClaim before provisioning. ([#352](https://github.com/kubernetes-csi/external-provisioner/pull/352), [@jsafrane](https://github.com/jsafrane))

# bump csi external-attacher from 1.2.0 to 1.2.1

## Bug Fixes

* Fixed handling of ControllerUnpublish errors. The attacher will retry to ControllerUnpublish a volume after any error except for NotFound. (#168, @jsafrane)

# bump external-snapshotter from 1.1.0 to 1.2.2
  
## Breaking Changes

* Changes the API group name for the fake VolumeSnapshot object to "snapshot.storage.k8s.io" to be in-sync with the group name of the real VolumeSnapshot object. As a result, the generated interfaces for clientset and informers of VolumeSnapshot are also changed from "VolumeSnapshot" to "Snapshot". (#123, @xing-yang)

**NOTE:** The shapshotter is not being used so these breaking changes have no user impact. The prior version that was included would not work with any of our supported Kubernetes versions.

## New Features

* Adds Finalizer on the snapshot source PVC to prevent it from being deleted when a snapshot is being created from it. (#47, @xing-yang)

## Other Notable Changes

* Add Status subresource for VolumeSnapshot. (#121, @zhucan)
* Cherry picks PR #138: Prebound snapshots will work correctly with CSI drivers that does not support ListSnasphots.(#156, @hakanmemisoglu)
* Cherry picks PR #172: Added extra verification of source PersistentVolumeClaim before creating snapshot.(#173, @xing-yang)

# bump external-resizer from 0.2.0 to 0.4.0
  
## New Features

* Add prometheus metrics to CSI external-resizer under the /metrics endpoint. This can be enabled via the "--metrics-address" and "--metrics-path" options. (#67, @saad-ali)

## Bug Fixes

* Avoid concurrent processing of same PVCs (#6, @mlmhl)
* Exit on CSI gRPC conn loss (#55, @ggriffiths)
* Verify claimref associated with PVs before resizing (#57, @gnufied)

## Other Notable Changes

* Migrated to Go modules, so the source builds also outside of GOPATH. (#60, @pohly)

