### PR TITLE
traefik: allow extra entrypoints

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.15
+version: 1.72.16
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/README.md
+++ b/staging/traefik/README.md
@@ -87,9 +87,10 @@ The following table lists the configurable parameters of the Traefik chart and t
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | `fullnameOverride`                     | Override the full resource names                                                                                             | `{release-name}-traefik` (or traefik if release-name is traefik) |
 | `image`                                | Traefik image name                                                                                                           | `traefik`                                         |
-| `imageTag`                             | The version of the official Traefik image to use                                                                             | `1.7.12`                                           |
-| `imagePullSecrets`                     | A list of image pull secrets (if needed)                                                                                     | None                                           |
+| `imageTag`                             | The version of the official Traefik image to use                                                                             | `1.7.12`                                          |
+| `imagePullSecrets`                     | A list of image pull secrets (if needed)                                                                                     | None                                              |
 | `serviceType`                          | A valid Kubernetes service type                                                                                              | `LoadBalancer`                                    |
+| `extraServicePorts`                    | Extra ports in the service record                                                                                            | `[]`                                              |
 | `loadBalancerIP`                       | An available static IP you have reserved on your cloud platform                                                              | None                                              |
 | `startupArguments`                       | A list of startup arguments which are passed to traefik                                                              | `[]`                                              |
 | `loadBalancerSourceRanges`             | List of IP CIDRs allowed access to load balancer (if supported)                                                              | None                                              |
@@ -243,8 +244,9 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `forwardAuth.entryPoints`              | Enable forward authentication for these entryPoints: "http", "https", "httpn"                                                |                                                   |
 | `forwardAuth.address`                  | URL for forward authentication                                                                                               |                                                   |
 | `forwardAuth.trustForwardHeader`       | Trust X-Forwarded-* headers                                                                                                  |                                                   |
-| `forwardAuth.authResponseHeaders`      | Set authentication response headers                                                                                                  |  `[]`                                                   |
-| `initCertJobImage`                     | Set the Docker image to be used for updating the cert-manager certificate with the load balancer SANs                        | `mesosphere/kubeaddons-addon-initializer:v0.0.7`                 |
+| `forwardAuth.authResponseHeaders`      | Set authentication response headers                                                                                                  |  `[]`                                     |
+| `initCertJobImage`                     | Set the Docker image to be used for updating the cert-manager certificate with the load balancer SANs                        | `mesosphere/kubeaddons-addon-initializer:v0.0.7`  |
+| `extraConfigEntrypoints`               | Extra configurations for the entrypoints.                                                                                    | None                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/staging/traefik/templates/configmap.yaml
+++ b/staging/traefik/templates/configmap.yaml
@@ -145,6 +145,9 @@ data:
         {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.extraConfigEntrypoints }}
+      {{- .Values.extraConfigEntrypoints | nindent 6 }}
+      {{- end }}
     [ping]
     entryPoint = "http"
     [kubernetes]

--- a/staging/traefik/templates/service.yaml
+++ b/staging/traefik/templates/service.yaml
@@ -59,3 +59,6 @@ spec:
     name: metrics
     targetPort: dash
   {{- end }}
+  {{- if .Values.extraServicePorts }}
+  {{- toYaml .Values.extraServicePorts | nindent 2 }}
+  {{- end }}

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -16,6 +16,7 @@ testFramework:
 
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
+extraServicePorts: []
 # loadBalancerIP: ""
 # loadBalancerSourceRanges: []
 whiteListSourceRange: []
@@ -489,3 +490,11 @@ initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.0.7
 
 dashboardRBAC:
   enabled: true
+
+# extraConfigEntrypoints: |
+# 	[entryPoints.velero]
+# 		address = ":9000"
+# 			[entryPoints.velero.tls]
+# 			[entryPoints.velero.tls.defaultCertificate]
+# 			certFile = "/ssl/tls.crt"
+# 			keyFile = "/ssl/tls.key"


### PR DESCRIPTION
Allow extra entrypoints to be defined (and the front end ports).

Tested with
```yaml
extraServicePorts:
  - name: velero-minio
    port: 9000
    protocol: TCP
    targetPort: 9000

extraConfigEntrypoints: |
  [entryPoints.velero]
  address = ":9000"
    [entryPoints.velero.tls]
    [entryPoints.velero.tls.defaultCertificate]
    certFile = "/ssl/tls.crt"
    keyFile = "/ssl/tls.key"
```