### PR TITLE
feat(kube-oidc-proxy): added caSystemDefault and caCertPemHostPath

### DIFF
--- a/staging/kube-oidc-proxy/Chart.yaml
+++ b/staging/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.2.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/mesosphere/charts
 name: kube-oidc-proxy
-version: 0.2.0
+version: 0.2.1
 sources:
 - https://github.com/jetstack/kube-oidc-proxy
 maintainers:

--- a/staging/kube-oidc-proxy/templates/deployment.yaml
+++ b/staging/kube-oidc-proxy/templates/deployment.yaml
@@ -47,10 +47,10 @@ spec:
           - "--oidc-client-id=$(OIDC_CLIENT_ID)"
           - "--oidc-issuer-url=$(OIDC_ISSUER_URL)"
           - "--oidc-username-claim=$(OIDC_USERNAME_CLAIM)"
-          {{- if or .Values.oidc.caPEM .Values.oidc.caSecretName }}
+          {{- if .Values.oidc.caSystemDefault }}
+          # Not setting `--oidc-ca-file` to use CA bundle from the image
+          {{- else if or .Values.oidc.caPEM .Values.oidc.caSecretName .Values.oidc.caCertPemHostPath }}
           - "--oidc-ca-file=/etc/oidc/oidc-ca.pem"
-          {{- else if and .Values.oidc.caKubernetesDefault }}
-          # disabled --oidc-ca-file to use container image available root CAs
           {{- else }}
           - "--oidc-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           {{ end }}
@@ -143,20 +143,24 @@ spec:
               key: api-audiences
         {{ end }}
         volumeMounts:
-          {{ if or .Values.oidc.caPEM .Values.oidc.caSecretName }}
+          {{- if .Values.oidc.caSystemDefault }}
+          # No need to mount volumes. Use the CA bundle in the image.
+          {{- else if or .Values.oidc.caPEM .Values.oidc.caSecretName }}
           - name: kube-oidc-proxy-config
             mountPath: /etc/oidc
             readOnly: true
-          {{ else if .Values.oidc.caCertPemHostPath }}
+          {{- else if .Values.oidc.caCertPemHostPath }}
           - name: ca-cert-pem
-            mountPath: {{ .Values.oidc.caCertPemMountPath }}
+            mountPath: /etc/oidc/oidc-ca.pem
             readOnly: true
           {{ end }}
           - name: kube-oidc-proxy-tls
             mountPath: /etc/oidc/tls
             readOnly: true
       volumes:
-        {{ if .Values.oidc.caPEM }}
+        {{- if .Values.oidc.caSystemDefault }}
+        # No need to mount volumes. Use the CA bundle in the image.
+        {{- else if .Values.oidc.caPEM }}
         - name: kube-oidc-proxy-config
           secret:
             secretName: {{ include "kube-oidc-proxy.fullname" . }}-config

--- a/staging/kube-oidc-proxy/templates/deployment.yaml
+++ b/staging/kube-oidc-proxy/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
           - "--oidc-username-claim=$(OIDC_USERNAME_CLAIM)"
           {{- if or .Values.oidc.caPEM .Values.oidc.caSecretName }}
           - "--oidc-ca-file=/etc/oidc/oidc-ca.pem"
+          {{- else if and .Values.oidc.caKubernetesDefault }}
+          # disabled --oidc-ca-file to use container image available root CAs
           {{- else }}
           - "--oidc-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           {{ end }}
@@ -145,6 +147,10 @@ spec:
           - name: kube-oidc-proxy-config
             mountPath: /etc/oidc
             readOnly: true
+          {{ else if .Values.oidc.caCertPemHostPath }}
+          - name: ca-cert-pem
+            mountPath: {{ .Values.oidc.caCertPemMountPath }}
+            readOnly: true
           {{ end }}
           - name: kube-oidc-proxy-tls
             mountPath: /etc/oidc/tls
@@ -164,6 +170,11 @@ spec:
             items:
             - key: ca.crt
               path: oidc-ca.pem
+        {{- else if .Values.oidc.caCertPemHostPath }}
+        - name: ca-cert-pem
+          hostPath:
+            path: {{ .Values.oidc.caCertPemHostPath }}
+            type: File
         {{ end }}
         - name: kube-oidc-proxy-tls
           secret:

--- a/staging/kube-oidc-proxy/values.yaml
+++ b/staging/kube-oidc-proxy/values.yaml
@@ -27,14 +27,32 @@ oidc:
   usernameClaim: ""
 
   # CA cert that will verify TLS connection to OIDC issuer URL.
-  # If not provided default hosts root CA's will be used. This
-  # should be provided in PEM format, for example:
+  # If not provided service account CA will be used.
+  #
+  # Specify only one of the following values.
+  # ---
+  # caPEM
+  # This should be provided in PEM format, for example:
   # caPEM: |
   #    -----BEGIN CERTIFICATE-----
   #           ...
   #    -----END CERTIFICATE-----
   caPEM:
-  caSecretName:   # specify caPEM or caSecretName
+  # ---
+  # caSecretName, which includes ca.crt, tls.crt and tls.key
+  caSecretName:
+  # ---
+  # caKubernetesDefault, will disable (not set) the --oidc-ca-file flag
+  # to be able to use container image available root CA's
+  caKubernetesDefault: false
+  # ---
+  # caCertPemHostPath, which points to a cert.pem including CA's on your hostMachine
+  # should be used if you issue an certificate from an ACME provider like letsencrypt
+  # it will be mounted read-only and only one file e.g. /etc/ssl/cert.pem.
+  # you can define the target within the container through caCertPemMountPath.
+  # This should be used in combination with caKubernetesDefault: true
+  caCertPemHostPath:
+  caCertPemMountPath: /etc/ssl/cert.pem
 
   usernamePrefix:
   groupsClaim:

--- a/staging/kube-oidc-proxy/values.yaml
+++ b/staging/kube-oidc-proxy/values.yaml
@@ -26,6 +26,19 @@ oidc:
   issuerUrl: ""
   usernameClaim: ""
 
+  # The following `caXXX` options affect the `--oidc-ca-file` flag to
+  # the proxy. One can choose one of the following:
+  # 1. Use system defaults by setting `caSystemDefault` to `true`
+  # 2. Use a custom CA by setting `caPEM` or `caSecretName`
+  # 3. Use a custom CA mounted from the host using `caCertPemHostPath`
+  # The earlier item in this list will take precedence over the later
+  # items in this list. For instance, if `caSystemDefault` is set to
+  # `true`, the `caPEM`, `caSecretName` or `caCertPemHostPath` will be
+  # ignored even if they are set.
+  # -----------------------------------------------------------------
+  # caSystemDefault, will disable (not set) the --oidc-ca-file flag
+  # to be able to use container image available root CA's
+  caSystemDefault: false
   # CA cert that will verify TLS connection to OIDC issuer URL.
   # If not provided service account CA will be used.
   #
@@ -38,21 +51,12 @@ oidc:
   #           ...
   #    -----END CERTIFICATE-----
   caPEM:
-  # ---
   # caSecretName, which includes ca.crt, tls.crt and tls.key
   caSecretName:
-  # ---
-  # caKubernetesDefault, will disable (not set) the --oidc-ca-file flag
-  # to be able to use container image available root CA's
-  caKubernetesDefault: false
-  # ---
-  # caCertPemHostPath, which points to a cert.pem including CA's on your hostMachine
-  # should be used if you issue an certificate from an ACME provider like letsencrypt
-  # it will be mounted read-only and only one file e.g. /etc/ssl/cert.pem.
-  # you can define the target within the container through caCertPemMountPath.
-  # This should be used in combination with caKubernetesDefault: true
+  # caCertPemHostPath, which points to a CA bundle on your host
+  # machine to use for the proxy. For example:
+  # caCertPemHostPath: /etc/ssl/certs/ca-bundle.crt
   caCertPemHostPath:
-  caCertPemMountPath: /etc/ssl/cert.pem
 
   usernamePrefix:
   groupsClaim:


### PR DESCRIPTION
Allow to use system default CA in the image or a bundle from the hosting OS.

Tested with the following combinations by checking `helm template` output:
```yaml
oidc:
  caSystemDefault: true
```
```yaml
oidc:
  caCertPemHostPath: /etc/ssl/certs/ca-bundle.crt
```
```yaml
oidc:
  caSystemDefault: true # This will take precedence.
  caCertPemHostPath: /etc/ssl/certs/ca-bundle.crt
```

[D2IQ-65234]: https://jira.d2iq.com/browse/D2IQ-65234