### PR TITLE
dka: allow using system default CA

### DIFF
--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.1.1"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.1.14
+version: 1.1.15
 home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mintel/dex-k8s-authenticator

--- a/staging/dex-k8s-authenticator/html-templates/linux-mac-common.html
+++ b/staging/dex-k8s-authenticator/html-templates/linux-mac-common.html
@@ -68,7 +68,9 @@ EOF</code></pre>
       <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt="">
     </button>
   <pre><code>kubectl config set-cluster {{ .Username }}-{{ .ClusterName }} \
+  {{- if or .K8sCaPem .K8sCaURI }}
     --certificate-authority=${HOME}/.kube/certs/{{ .Username }}-{{ .ClusterName}}/k8s-ca.crt \
+  {{- end }}
     --server={{ .K8sMasterURI }}</code></pre>
   </div>
 

--- a/staging/dex-k8s-authenticator/templates/configmap.yaml
+++ b/staging/dex-k8s-authenticator/templates/configmap.yaml
@@ -32,7 +32,9 @@ data:
     {{- end }}
     {{- if .Values.caCerts.enabled }}
     caCerts: "true"
-    {{- if .Values.caCerts.secrets }}
+    {{- if .Values.caCerts.useSystemDefault }}
+    caCertPath: ""
+    {{- else if .Values.caCerts.secrets }}
     caCertPath: /certs/{{ .filename }}
     {{- else }}
     caCertPath: /certs/ca.crt

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -75,8 +75,14 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+# By default, Kubernetes CA will be used. If `caCerts.enabled` is set to
+# `true`, one can choose one of the following:
+# 1. Using system defaults by setting `caCerts.useSystemDefault` to `true`
+# 2. Using custom CA from a secret
+# If both are set, using system default would take precedence.
 caCerts:
   enabled: false
+  useSystemDefault: false
   # specify either caSecretName or secrets
   caSecretName:
   secrets: {}


### PR DESCRIPTION
This is for the case when the traefik ingress uses a valid Let's Encrypt
cert that can be trusted by the system default root CA bundles.
Currently, we always display the k8s root CA in the /token page for the
kubectl setup instructions. And k8s root CA cannot validate the Let's
Encrypt cert, leading to authentication errors. See more details in:
https://jira.d2iq.com/browse/D2IQ-65233

This patch introduces an option to use system default CA bundles. This
requires an extra step change in the corresponding repo (coming soon).