### PR TITLE
fix: disable awsebscsiprovisioner snapshot-controller and correct ebs-external-attacher-role

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - name: alejandroEsc
   - name: gpaul
   - name: hectorj2f
-version: 0.3.4
+version: 0.3.5
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/templates/roles.yaml
+++ b/stable/awsebscsiprovisioner/templates/roles.yaml
@@ -74,16 +74,16 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csinodeinfos"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/stable/awsebscsiprovisioner/templates/statefulset-snapshot-controller.yaml
+++ b/stable/awsebscsiprovisioner/templates/statefulset-snapshot-controller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.snapshotter.enabled }}
+{{- if and .Values.snapshotter.enabled (or (gt (.Capabilities.KubeVersion.Minor | int) 17) (eq (.Capabilities.KubeVersion.Minor | int) 17)) }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
- the snapshot controller is working beginning with kubernetes version 1.17
- changed / updated the permissions for the `ebs-external-attacher-role` as the `patch` permission is a must have now.
- changed / updated the `apiGroups` and `resources` for `ebs-external-attacher-role` as these are the ones from upstream and we have same here https://github.com/mesosphere/charts/pull/511/files#diff-2deb8043c4fff4cb398fc42fad8e771fR45-R46
more details see https://kubernetes-csi.github.io/docs/csi-node-object.html
quote: ```In the move from alpha to beta, the API Group for this object changed from csi.storage.k8s.io/v1alpha1 to storage.k8s.io/v1beta1.```



[D2IQ-64990]

[D2IQ-64990]: https://jira.d2iq.com/browse/D2IQ-64990