### PR TITLE
chore: move values from addon to chart

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.5.3
+version: 0.5.4

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -1,3 +1,7 @@
+ingress:
+  extraAnnotations:
+    traefik.ingress.kubernetes.io/priority: "2"
+
 federate:
   kubeaddonsInitializer:
     repository: "mesosphere/kubeaddons-addon-initializer"
@@ -6,24 +10,45 @@ federate:
 
 kommander-cluster-lifecycle:
   enabled: true
+  certificates:
+    issuer:
+      name: kubernetes-ca
+      kind: ClusterIssuer
+  konvoy:
+    allowUnofficialReleases: true
+  kubefed:
+    controllermanager:
+      annotations:
+        secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+      webhook:
+        annotations:
+          secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
 
 kommander-thanos:
   enabled: true
   thanosAddress: "prometheus-kubeaddons-prom-prometheus.kubeaddons.svc.cluster.local:10901"
   kommanderServiceAccount: kommander-kubeaddons
+  thanos:
+    query:
+      deploymentAnnotations:
+        secret.reloader.stakater.com/reload: kommander-thanos-client-tls
 
 kommander-karma:
   enabled: true
   alertmanagerAddress: "prometheus-kubeaddons-prom-alertmanager.kubeaddons.svc.cluster.local:9093"
   kommanderServiceAccount: kommander-kubeaddons
   kommanderKarmaConfigMap: kommander-kubeaddons-config
+  karma:
+    deployment:
+      annotations:
+        configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+        secret.reloader.stakater.com/reload: kommander-karma-client-tls
 
 kubeaddons-catalog:
   enabled: true
-
   image:
     repository: mesosphere/kubeaddons-catalog
-    tag: "v0.8.2"
+    tag: "v0.8.3"
     pullPolicy: IfNotPresent
 
 grafana:
@@ -162,6 +187,7 @@ kommander-ui:
       traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
       traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
     path: /ops/portal/kommander/ui
+  kubernetesVersionsSelection: '["1.16.4", "1.16.3"]'
 
 portalRBAC:
   grafana:


### PR DESCRIPTION
first step to address kommander chart not being able to install w/o addon. I was _not_ able to install the chart on its own, but that is no change to before. we need to fix that going forward

This PR adds everything from addon to chart, companioning PR removing these things from addon: 