### PR TITLE
chore: bump traefik image from 1.7.12 to 1.7.23

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.72.16
-appVersion: 1.7.12
+version: 1.72.17
+appVersion: 1.7.23
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -1,6 +1,6 @@
 ## Default values for Traefik
 image: traefik
-imageTag: 1.7.12
+imageTag: 1.7.23
 
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
dcca37fe Prepare release v1.7.23
a610f0b2 Force http/1.1 for upgrade (Traefik v1)
ded285be Fix sameSite (Traefik v1)
4b31d330 fix: max TLS version.
5a6652fc Prepare release v1.7.22
91b0e2e4 Complete TLS example for Kubernetes Ingress in user guide
554bceb7 Skip redirection with invalid regex syntax.
ce762126 fix: manual provider code name.
d474c87c Updated rbac and demonset example bloc
86277223 Update to go1.14
09fa1e65 Fix typo in user guide.
c3125104 Clear closed hijacked h2c connections
31786f71 Prepare release v1.7.21
d7ed42d6 Fix sample for ssl-header in docs
4c709c2f Improve rate-limiting doc
8dac0767 Fix finding proper provided certificate when ACME is enabled
0b039499 don't create http client in each request in forward auth
21249754 Fix dnspod update.
e4725619 Update the k8s api version in the documentation
d24f7822 fix: skip ECS container when information are missing instead of panic.
3f1925e2 Add edge case for root path with rewrite-target
a8393faf Prepare release v1.7.20
4b8ece5b Truncate key for identification in log
7574bb92 Add a warning note regarding optional TLS mutual auth
f68b6294 fix: location header rewrite.
f9e9e110 Prepare release v1.7.19
772c9ca4 Allow Default Certificate to work on macOS 10.15
208d0fa4 Update DaemonSet apiVersion
9f72b6d1 Add functions to support precise float compute of weight (#5663)
29ef0079 Backport Go 1.13 integration test fixes
590a0d67 Fix Location response header http to https when SSL
74ad83f0 Prepare release v1.7.18
d707c8ba Prepare release v1.7.17
640eb62c Avoid closing stdout when the accesslog handler is closed
21671086 Actually send header and code during WriteHeader, if needed
226f20b6 Add note clarifying client certificate header
151be83b Update docs links.
d1a8c7fa Update Traefik image version.
254dc38c Prepare release v1.7.16
24d084d7 implement Flusher and Hijacker for codeCatcher
df5f5300 Prepare release v1.7.15
753d1739 error pages: do not buffer response when it's not an error
ffd1f122 Add TLS minversion constraint
f98b57fd Fix wrong handling of insecure tls auth forward ingress annotation
2d37f088 Improve Access Logs Documentation page
a7dbcc28 Consider default cert domain in certificate store
f4f62e7f Update Acme doc - Vultr Wildcard & Root
4cae8bcb Finish kubernetes throttling refactoring
bee370ec Throttle Kubernetes config refresh
f1d016b8 Typo in basic auth usersFile label consul-catalog
4defbbe8 Kubernetes support for Auth.HeaderField
f397342f Prepare release v1.7.14
989a59cc Update to go1.12.8
c5b71592 Make hijackConnectionTracker.Close thread safe
9de3129a Prepare release v1.7.13
40ab1f32 Wrr loadbalancer honors old weight on recovered servers
73e05616 Update lego
0a89cccd warning should not be a fail status
b102e6de Add missing KeyUsages for default generated certificate
2064a6f8 Add example for CLI
72e2ddff Updating Service Fabric documentation
7db41967 Fixed doc link for AlibabaCloud
a8680a87 Fixes the TLS Mutual Authentication documentation
7e11fa11 Update Docker version.
489b5a61 Format YAML example on user guide
8027e8ee Check for multiport services on Global Backend Ingress
d35d5bd2 Update documentation to clarify the default format for logs
8e47bded Clear TLS client headers if TLSMutualAuth is optional
51419a92 Update Slack support channel references to Discourse community forum
32fd52c6 Use dynamodbav tags to override json tags.
468e4ebd Add remarks about Rancher 2
92a57384 Allows logs to use local time zone instead of UTC
2067a433 Improve API / Dashboard wording in documentation
16f1f851 Use the latest stable version of traefik in the docs
8e992c7c Update docker api version