### PR TITLE
fix: federate karma-proxy only to Konvoy clusters

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.5.4
+version: 0.5.5

--- a/stable/kommander/charts/kommander-karma/Chart.yaml
+++ b/stable/kommander/charts/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.8
+version: 0.3.9
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander/charts/kommander-karma/templates/federated-addon.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/federated-addon.yaml
@@ -10,7 +10,9 @@ metadata:
 spec:
   placement:
     clusterSelector:
-      matchLabels: {}
+      matchExpressions:
+        - {key: kommander.mesosphere.io/cluster-type, operator: Exists, values: []}
+        - {key: kommander.mesosphere.io/cluster-type, operator: In, values: [Konvoy]}
   template:
     metadata:
       namespace: kubeaddons


### PR DESCRIPTION
Previously we federated karma-proxy to non-Konvoy clusters without reason. Now that we can differentiate cluster types we are able to fix this with this PR.

https://jira.d2iq.com/browse/D2IQ-65932