### PR TITLE
[prometheus-operator] fix: hook should not call static service name

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.5.7
+version: 0.5.8

--- a/stable/kommander/templates/grafana/hooks-home-dashboard.yaml
+++ b/stable/kommander/templates/grafana/hooks-home-dashboard.yaml
@@ -34,8 +34,16 @@ spec:
             set -o errexit
             set -o pipefail
             CURL="curl --verbose --fail --max-time 30 --retry 20 --retry-connrefused"
-            DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.grafana.hooks.serviceURL }}/api/search/?query={{ .Values.grafana.hooks.dashboardName | urlquery }} | jq '.[0].id')
+            DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.grafana.hooks.serviceURL }}/api/search/?query={{ .Values.grafana.hooks.dashboardName | urlquery }} | jq '.[0].id' || true)
+            if [ "$DASHBOARD_ID" == "" ]; then
+                  echo "error: Could not retrieve dashboard id"
+                  exit 0
+            fi
             echo "setting home dashboard to ID" $DASHBOARD_ID
-            $CURL -X PUT -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"homeDashboardId":'"$DASHBOARD_ID"'}' {{ .Values.grafana.hooks.serviceURL }}/api/org/preferences
+            SET_DEFAULT=$($CURL -X PUT -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"homeDashboardId":'"$DASHBOARD_ID"'}' {{ .Values.grafana.hooks.serviceURL }}/api/org/preferences || true )
+            if [ "SET_DEFAULT" == "" ]; then
+            echo "error: Could not set default dashboard for user $X_FORWARDED_USER"
+            exit 0
+            fi
             EOF
 {{- end }}

--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.7.5
+version: 8.8.0
 appVersion: 0.35.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/mesosphere-hooks/grafana-default-dashboard-hook.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/grafana-default-dashboard-hook.yaml
@@ -44,8 +44,19 @@ data:
     set -o nounset
     set -o errexit
     set -o pipefail
-    CURL="curl --verbose --fail --max-time 60 --retry 10 --retry-connrefused"
-    DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/search/?query={{ .Values.mesosphereResources.hooks.grafana.dashboardName | urlquery }} | jq '.[0].id')
+    GRAFANA_API_URL="http://{{ .Release.Name }}-grafana.{{ .Release.Namespace }}:{{ .Values.grafana.service.port }}"
+    CURL="curl --verbose --max-time 60 --retry 10 --retry-connrefused --fail"
+    DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" $GRAFANA_API_URL/api/search/?query={{ .Values.mesosphereResources.hooks.grafana.dashboardName | urlquery }} | jq '.[0].id' || true )
+    if [ "$DASHBOARD_ID" == "" ]; then
+      echo "error: Could not retrieve dashboard id"
+      exit 0
+    fi
+    # we want to fail silently as this assumes a user exists or that grafana is set up to create a user if it doesnt
+    # not all installations of prometheus should be expected to, so we should not hold up a prometheus install because of this
     echo "setting home dashboard to ID" $DASHBOARD_ID
-    $CURL -X PUT -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"theme":"","homeDashboardId":'"$DASHBOARD_ID"',"timezone":""}' {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/org/preferences
+    SET_DEFAULT=$($CURL -X PUT -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"theme":"","homeDashboardId":'"$DASHBOARD_ID"',"timezone":""}' $GRAFANA_API_URL/api/org/preferences || true )
+    if [ "SET_DEFAULT" == "" ]; then
+      echo "error: Could not set default dashboard for user $X_FORWARDED_USER"
+      exit 0
+    fi
 {{- end }}

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -77,6 +77,7 @@ mesosphereResources:
       jobName: grafana-default-dashboard
       image: dwdraju/alpine-curl-jq
       secretKeyRef: ops-portal-credentials
+      # serviceURL is deprecated, do not use
       serviceURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
       dashboardName: "Kubernetes / Compute Resources / Cluster"
     prometheus:
@@ -469,6 +470,10 @@ grafana:
     # - secretName: grafana-general-tls
     #   hosts:
     #   - grafana.example.com
+
+  service:
+    type: ClusterIP
+    port: 80
 
   sidecar:
     dashboards:


### PR DESCRIPTION
hook should not point to static service name, it's now dynamic, and should fail silently to allow prometheus to deploy. This latter point is quite specific as for the hook to actually succeed it requires a specific configuration of grafana allowing for automatic creation of a user. 