### PR TITLE
missing volumesnapshots/status permission

### DIFF
--- a/stable/awsebscsiprovisioner/Chart.yaml
+++ b/stable/awsebscsiprovisioner/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - name: alejandroEsc
   - name: gpaul
   - name: hectorj2f
-version: 0.3.5
+version: 0.3.6
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/awsebscsiprovisioner/templates/roles.yaml
+++ b/stable/awsebscsiprovisioner/templates/roles.yaml
@@ -139,6 +139,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
[D2IQ-66019]

The missing `volumesnapshots/status` permission for `ebs-csi-controller-sa` leads to the following error message:

```
E0325 13:03:34.201182       1 goroutinemap.go:150] Operation for "create-kubeaddons/ebs-volume-snapshot[33fd69c5-4c65-497b-ab32-096e98c0e27c]" failed. No retries permitted until 2020-03-25 13:05:36.201159485 +0000 UTC m=+4622.225139898 (durationBeforeRetry 2m2s). Error: "snapshot controller failed to update kubeaddons/ebs-volume-snapshot on API server: volumesnapshots.snapshot.storage.k8s.io \"ebs-volume-snapshot\" is forbidden: User \"system:serviceaccount:kube-system:ebs-csi-controller-sa\" cannot update resource \"volumesnapshots/status\" in API group \"snapshot.storage.k8s.io\" in the namespace \"kubeaddons\""
I0325 13:06:34.100708       1 snapshot_controller.go:615] createSnapshot: Creating snapshot kubeaddons/ebs-volume-snapshot through the plugin ...
E0325 13:06:34.205178       1 snapshot_controller.go:370] createSnapshot [create-kubeaddons/ebs-volume-snapshot[33fd69c5-4c65-497b-ab32-096e98c0e27c]]: error occurred in createSnapshotOperation: snapshot controller failed to update kubeaddons/ebs-volume-snapshot on API server: volumesnapshots.snapshot.storage.k8s.io "ebs-volume-snapshot" is forbidden: User "system:serviceaccount:kube-system:ebs-csi-controller-sa" cannot update resource "volumesnapshots/status" in API group "snapshot.storage.k8s.io" in the namespace "kubeaddons"
```

[D2IQ-66019]: https://jira.d2iq.com/browse/D2IQ-66019