### PR TITLE
fix: grafana dashboard job only if defaultDashboardsEnabled

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.7.4
+version: 8.7.5
 appVersion: 0.35.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/mesosphere-hooks/grafana-default-dashboard-hook.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/grafana-default-dashboard-hook.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -47,4 +48,4 @@ data:
     DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/search/?query={{ .Values.mesosphereResources.hooks.grafana.dashboardName | urlquery }} | jq '.[0].id')
     echo "setting home dashboard to ID" $DASHBOARD_ID
     $CURL -X PUT -H "Content-Type: application/json" -H "X-Forwarded-User: $X_FORWARDED_USER" -d '{"theme":"","homeDashboardId":'"$DASHBOARD_ID"',"timezone":""}' {{ .Values.mesosphereResources.hooks.grafana.serviceURL }}/api/org/preferences
-
+{{- end }}


### PR DESCRIPTION
This affects the prometheus-operator by not deploying the job grafana-default-dashboard if we set defaultDashboardsEnabled to false.

Related ticket: https://jira.d2iq.com/browse/D2IQ-66014

This was tested by deploying the updated chart combined with a `values.yaml` specifying:
```
grafana:
            defaultDashboardsEnabled: false
```