### PR TITLE
knative: Added requirements.yaml and enable/disable switches to knative

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative
-version: 0.1.0
+version: 0.1.1
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:

--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative
-version: 0.1.1
+version: 0.2.0
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: serving
-version: 0.1.0
+version: 0.1.1
 kubeVersion: ">=1.14.0"
 description: "Knative Serving"
 sources:

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: serving
-version: 0.1.1
+version: 0.2.0
 kubeVersion: ">=1.14.0"
 description: "Knative Serving"
 sources:

--- a/staging/knative/charts/serving/templates/custom-metrics-apiservice.yaml
+++ b/staging/knative/charts/serving/templates/custom-metrics-apiservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.customMetricsApiservice }}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
@@ -14,3 +15,4 @@ spec:
     namespace: knative-serving
   version: v1beta1
   versionPriority: 100
+{{- end }}

--- a/staging/knative/charts/serving/templates/gateway.yaml
+++ b/staging/knative/charts/serving/templates/gateway.yaml
@@ -16,6 +16,7 @@ spec:
       name: http
       number: 80
       protocol: HTTP
+{{- if .Values.gateway.https.enabled }}
   - hosts:
     - '*'
     port:
@@ -24,3 +25,4 @@ spec:
       protocol: HTTPS
     tls:
       mode: PASSTHROUGH
+{{- end }}

--- a/staging/knative/charts/serving/templates/namespace.yaml
+++ b/staging/knative/charts/serving/templates/namespace.yaml
@@ -4,4 +4,7 @@ metadata:
   labels:
     istio-injection: enabled
     serving.knative.dev/release: {{ .Chart.AppVersion | quote }}
+    {{- if .Values.namespace.additionalLabels }}
+{{ toYaml .Values.namespace.additionalLabels | indent 4 }}
+    {{- end }}
   name: knative-serving

--- a/staging/knative/charts/serving/templates/namespace.yaml
+++ b/staging/knative/charts/serving/templates/namespace.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     istio-injection: enabled
     serving.knative.dev/release: {{ .Chart.AppVersion | quote }}
-    {{- if .Values.namespace.additionalLabels }}
-{{ toYaml .Values.namespace.additionalLabels | indent 4 }}
+    {{- if .Values.namespaceKnativeServing.additionalLabels }}
+{{ toYaml .Values.namespaceKnativeServing.additionalLabels | indent 4 }}
     {{- end }}
   name: knative-serving

--- a/staging/knative/charts/serving/values.yaml
+++ b/staging/knative/charts/serving/values.yaml
@@ -9,5 +9,5 @@ gateway:
   https:
     enabled: true
 
-namespace:
+namespaceKnativeServing:
   additionalLabels: {}

--- a/staging/knative/charts/serving/values.yaml
+++ b/staging/knative/charts/serving/values.yaml
@@ -1,3 +1,13 @@
 global:
   serviceLabels: {}
 domain: example.com
+
+customMetricsApiservice:
+  enabled: true
+
+gateway:
+  https:
+    enabled: true
+
+namespace:
+  additionalLabels: {}

--- a/staging/knative/requirements.yaml
+++ b/staging/knative/requirements.yaml
@@ -6,5 +6,5 @@ dependencies:
     version: 0.1.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 0.1.1
+    version: 0.2.0
     condition: serving.enabled

--- a/staging/knative/requirements.yaml
+++ b/staging/knative/requirements.yaml
@@ -1,0 +1,10 @@
+dependencies:
+  - name: eventing
+    version: 0.1.0
+    condition: eventing.enabled
+  - name: eventing-sources
+    version: 0.1.0
+    condition: eventing-sources.enabled
+  - name: serving
+    version: 0.1.1
+    condition: serving.enabled

--- a/staging/knative/values.yaml
+++ b/staging/knative/values.yaml
@@ -1,4 +1,19 @@
 global:
   serviceLabels: {}
+
+eventing:
+  enabled: true
+
+eventing-sources:
+  enabled: true
+
 serving:
+  enabled: true
   domain: example.com
+  customMetricsApiservice:
+    enabled: true
+  gateway:
+    https:
+      enabled: true
+  namespace:
+    additionalLabels: {}

--- a/staging/knative/values.yaml
+++ b/staging/knative/values.yaml
@@ -15,5 +15,5 @@ serving:
   gateway:
     https:
       enabled: true
-  namespace:
+  namespaceKnativeServing:
     additionalLabels: {}


### PR DESCRIPTION
Added configurable options to knative chart:
- Added requirements.yaml to allow turn on/off individual knative components.
- Made knative serving api service configurable, which may conflict with the konvoy custom metrics api service.
- Made knative serving gateway https host configurable, which may conflict with the default istio gateway.
- Made knative serving namespace metadata label configurable, which allows operators to add istio ca override or any additional labels.

helm install:
```
➜  kubeflow-poc git:(gilbert/dev) ✗ helm install --name knative-kubeaddons ~/workspace/mesosphere/charts/staging/knative
NAME:   knative-kubeaddons
LAST DEPLOYED: Wed Mar 25 22:23:56 2020
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ClusterRole
NAME                                AGE
addressable-resolver                1s
broker-addressable-resolver         1s
channel-addressable-resolver        1s
channelable-manipulator             1s
custom-metrics-server-resources     1s
eventing-broker-filter              1s
eventing-broker-ingress             1s
eventing-config-reader              1s
eventing-sources-github-controller  1s
knative-eventing-controller         1s
knative-eventing-webhook            1s
knative-serving-admin               1s
knative-serving-certmanager         1s
knative-serving-core                1s
knative-serving-istio               1s
service-addressable-resolver        1s
serving-addressable-resolver        1s

==> v1/ClusterRoleBinding
NAME                                          AGE
custom-metrics:system:auth-delegator          1s
eventing-controller                           1s
eventing-controller-manipulator               1s
eventing-controller-resolver                  1s
eventing-sources-github-addressable-resolver  1s
eventing-sources-github-controller            1s
eventing-webhook                              1s
hpa-controller-custom-metrics                 1s
knative-serving-controller-admin              1s

==> v1/ConfigMap
NAME                     AGE
config-autoscaler        1s
config-certmanager       1s
config-defaults          1s
config-deployment        1s
config-domain            1s
config-gc                1s
config-istio             1s
config-logging           1s
config-network           1s
config-observability     1s
config-tracing           1s
default-channel-webhook  1s

==> v1/Deployment
NAME                    AGE
activator               1s
autoscaler              1s
controller              1s
eventing-controller     1s
eventing-webhook        1s
networking-certmanager  1s
networking-istio        1s
sources-controller      1s
webhook                 1s

==> v1/Namespace
NAME              AGE
knative-eventing  1s
knative-serving   1s
knative-sources   1s

==> v1/Pod(related)
NAME                                     AGE
activator-78b7bb5748-rdtbk               1s
autoscaler-755848975f-shddf              1s
controller-7759c484c8-hpc2l              1s
eventing-controller-84dc4f59cd-mnm9v     1s
eventing-webhook-77f7bcf4bd-rzbrd        1s
github-controller-manager-0              1s
networking-certmanager-5f8896c6cc-p62lq  1s
networking-istio-7cd58d75b8-p7lxr        1s
sources-controller-84b9cb88cd-kzr7w      1s
webhook-85c9cbf945-fhpbw                 1s

==> v1/RoleBinding
NAME                        AGE
custom-metrics-auth-reader  1s

==> v1/Service
NAME                AGE
activator-service   1s
autoscaler          1s
controller          1s
eventing-webhook    1s
github-controller   1s
sources-controller  1s
webhook             1s

==> v1/ServiceAccount
NAME                       AGE
controller                 1s
eventing-controller        1s
eventing-webhook           1s
github-controller-manager  1s

==> v1/StatefulSet
NAME                       AGE
github-controller-manager  1s

==> v1alpha1/Image
NAME         AGE
queue-proxy  1s

==> v1alpha3/Gateway
NAME                     AGE
cluster-local-gateway    1s
knative-ingress-gateway  1s

==> v1beta1/APIService
NAME                           AGE
v1beta1.custom.metrics.k8s.io  1s
```

helm list:
```
➜  kubeflow-poc git:(gilbert/dev) ✗ helm list
NAME                                     	REVISION	UPDATED                 	STATUS  	CHART                       	APP VERSION 	NAMESPACE   
awsebscsiprovisioner-kubeaddons          	1       	Wed Mar 25 17:41:05 2020	DEPLOYED	awsebscsiprovisioner-0.3.3  	0.4.0       	kube-system 
cert-manager-kubeaddons                  	1       	Wed Mar 25 17:39:43 2020	DEPLOYED	cert-manager-setup-0.1.9    	0.10.1      	cert-manager
dashboard-kubeaddons                     	1       	Wed Mar 25 17:39:51 2020	DEPLOYED	kubernetes-dashboard-2.0.0  	2.0.0-beta6 	kubeaddons  
defaultstorageclass-protection-kubeaddons	1       	Wed Mar 25 17:40:56 2020	DEPLOYED	defaultstorageclass-0.0.1   	0.0.1       	kubeaddons  
dex-k8s-authenticator-kubeaddons         	1       	Wed Mar 25 17:42:31 2020	DEPLOYED	dex-k8s-authenticator-1.1.15	v1.1.1      	kubeaddons  
dex-kubeaddons                           	1       	Wed Mar 25 17:42:05 2020	DEPLOYED	dex-2.8.4                   	2.22.0      	kubeaddons  
external-dns-kubeaddons                  	1       	Wed Mar 25 17:39:43 2020	DEPLOYED	external-dns-2.16.1         	0.5.18      	kubeaddons  
gatekeeper-kubeaddons                    	1       	Wed Mar 25 17:40:52 2020	DEPLOYED	gatekeeper-0.3.3            	3.0.4-beta.1	kubeaddons  
istio-kubeaddons                         	1       	Wed Mar 25 17:41:17 2020	DEPLOYED	istio-1.4.3                 	1.4.3       	istio-system
knative-kubeaddons                       	1       	Wed Mar 25 22:23:56 2020	DEPLOYED	knative-0.1.0               	v0.7.1      	default     
konvoyconfig-kubeaddons                  	1       	Wed Mar 25 17:39:43 2020	DEPLOYED	konvoyconfig-0.0.2          	0.0.1       	kubeaddons  
kube-oidc-proxy-kubeaddons               	1       	Wed Mar 25 17:42:33 2020	DEPLOYED	kube-oidc-proxy-0.2.1       	v0.2.0      	kubeaddons  
nfsserverprovisioner-kubeaddons          	1       	Wed Mar 25 17:41:11 2020	DEPLOYED	nfs-server-provisioner-0.6.0	2.3.0       	kubeaddons  
opsportal-kubeaddons                     	1       	Wed Mar 25 17:39:43 2020	DEPLOYED	opsportal-0.2.11            	1.0.0       	kubeaddons  
prometheus-kubeaddons                    	1       	Wed Mar 25 17:41:11 2020	DEPLOYED	prometheus-operator-8.3.11  	0.34.0      	kubeaddons  
prometheusadapter-kubeaddons             	1       	Wed Mar 25 17:43:08 2020	DEPLOYED	prometheus-adapter-2.0.0    	v0.5.0      	kubeaddons  
reloader-kubeaddons                      	1       	Wed Mar 25 17:39:44 2020	DEPLOYED	reloader-v0.0.49            	v0.0.49     	kubeaddons  
traefik-forward-auth-kubeaddons          	1       	Wed Mar 25 17:42:36 2020	DEPLOYED	traefik-forward-auth-0.2.13 	latest      	kubeaddons  
traefik-kubeaddons                       	1       	Wed Mar 25 17:40:52 2020	DEPLOYED	traefik-1.72.17             	1.7.23      	kubeaddons  
velero-kubeaddons                        	1       	Wed Mar 25 17:42:04 2020	DEPLOYED	velero-3.0.1                	1.0.1       	velero 
```

Manual test with the following knative serving service:
```
➜  kubeflow-poc git:(gilbert/dev) ✗ cat knative-hello.yaml 
apiVersion: serving.knative.dev/v1alpha1
kind: Service
metadata:
  name: helloworld-python
  namespace: default
spec:
  template:
    spec:
      containers:
        - image: docker.io/gilbertsong/helloworld-python
          env:
            - name: TARGET
              value: "Python Sample v1"
```