### PR TITLE
fix(cert-manager-setup): `usages` definition

### DIFF
--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.9
+version: 0.1.10
 appVersion: 0.10.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/ci/general-test-values.yaml
+++ b/staging/cert-manager-setup/ci/general-test-values.yaml
@@ -11,10 +11,10 @@ certificates:
     issuerRef:
       name: my-root-issuer
       kind: Issuer
-      # These are the default usages for reference
-      usages:
-        - "digital signature"
-        - "key encipherment"
+    # These are the default usages for reference
+    usages:
+      - "digital signature"
+      - "key encipherment"
     commonName: cert-manager
     duration: 87600h
     dnsNames:

--- a/staging/cert-manager-setup/templates/certificates.yaml
+++ b/staging/cert-manager-setup/templates/certificates.yaml
@@ -20,9 +20,9 @@ spec:
   issuerRef:
     name: {{ .issuerRef.name }}
     kind: {{ .issuerRef.kind }}
-{{- if .issuerRef.usages }}
-    usages:
-  {{- range .issuerRef.usages }}
+{{- if .usages }}
+  usages:
+  {{- range .usages }}
     - {{ . | quote -}}
   {{- end }}
 {{- end }}

--- a/staging/cert-manager-setup/templates/clusterissuer.yaml
+++ b/staging/cert-manager-setup/templates/clusterissuer.yaml
@@ -29,10 +29,10 @@ spec:
   issuerRef:
     name: kubernetes-root-issuer
     kind: Issuer
-    # These are the default usages for reference
-    usages:
-      - "digital signature"
-      - "key encipherment"
+  # These are the default usages for reference
+  usages:
+    - "digital signature"
+    - "key encipherment"
 ---
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer

--- a/staging/cert-manager-setup/values.yaml
+++ b/staging/cert-manager-setup/values.yaml
@@ -17,9 +17,9 @@ certificates: []
 #      name: kubernetes-root-issuer
 #      kind: Issuer
 #      # These are the default usages for reference
-#      usages:
-#        - "digital signature"
-#        - "key encipherment"
+#    usages:
+#      - "digital signature"
+#      - "key encipherment"
 #    commonName: cert-manager
 #    duration: 87600h
 #    dnsNames: []


### PR DESCRIPTION
- `usages` is not part of an Issuer / IssuerRef, it belongs to the Certificate

see https://docs.cert-manager.io/en/release-0.10/reference/api-docs/index.html#certificate-v1alpha1

[D2IQ-65995]

[D2IQ-65995]: https://jira.d2iq.com/browse/D2IQ-65995