### PR TITLE
Disable Ingress by default as discussed per D2IQ-64149

### DIFF
--- a/staging/kubeaddons-catalog/Chart.yaml
+++ b/staging/kubeaddons-catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.8.3"
 description: "A Catalog service for Kubeaddons"
 name: kubeaddons-catalog
-version: 0.1.7
+version: 0.1.8
 home: https://github.com/mesosphere/kommander-catalog-api
 sources:
 - https://github.com/mesosphere/kommander-catalog-api

--- a/staging/kubeaddons-catalog/values.yaml
+++ b/staging/kubeaddons-catalog/values.yaml
@@ -10,7 +10,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 ingress:
-  enable: true
+  enable: false
   # this is a placeholder, add your own hostname for ingress prior to deployment
   hostName: catalog.kubeaddons.localhost
   path: /catalog


### PR DESCRIPTION
Per D2IQ-64149, we are experiencing the following error when requesting cert from Lets Encrypt:

`{"level":"info","msg":"legolog: [INFO] [catalog.kubeaddons.localhost] acme: Obtaining bundled SAN certificate","time":"2020-02-11T20:42:58Z"} {"level":"error","msg":"Unable to obtain ACME certificate for domains \"catalog.kubeaddons.localhost\" detected thanks to rule \"Host:catalog.kubeaddons.localhost\" : unable to generate a certificate for the domains [catalog.kubeaddons.localhost]: acme: error: 400 :: POST :: https://acme-staging-v02.api.letsencrypt.org/acme/new-order :: urn:ietf:params:acme:error:rejectedIdentifier :: Error creating new order :: Cannot issue for \"catalog.kubeaddons.localhost\": Domain name does not end with a valid public suffix (TLD), url: ","time":"2020-02-11T20:42:58Z"}`

As discussed with Sam and Shane, this could be disabled by default as it is only currently used for development. There is also a PR to make these values adjustable in the [kubeaddons-kommander](https://github.com/mesosphere/kubeaddons-kommander/pull/49) repo.