### PR TITLE
bug: fix missing metadata name parameter

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.8.1
+version: 8.8.2
 appVersion: 0.35.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/crds/crd-prometheus.yaml
+++ b/staging/prometheus-operator/crds/crd-prometheus.yaml
@@ -1,13 +1,10 @@
-# https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.35/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: monitoring.coreos.com
   names:
@@ -62,7 +59,7 @@ spec:
                   description: Specify whether the Secret or its key must be defined
                   type: boolean
               required:
-              - key
+                - key
               type: object
             additionalAlertRelabelConfigs:
               description: 'AdditionalAlertRelabelConfigs allows specifying a key
@@ -89,7 +86,7 @@ spec:
                   description: Specify whether the Secret or its key must be defined
                   type: boolean
               required:
-              - key
+                - key
               type: object
             additionalScrapeConfigs:
               description: 'AdditionalScrapeConfigs allows specifying a key of a Secret
@@ -115,7 +112,7 @@ spec:
                   description: Specify whether the Secret or its key must be defined
                   type: boolean
               required:
-              - key
+                - key
               type: object
             affinity:
               description: If specified, the pod's scheduling constraints.
@@ -174,8 +171,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -208,8 +205,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                             type: object
@@ -219,8 +216,8 @@ spec:
                             format: int32
                             type: integer
                         required:
-                        - preference
-                        - weight
+                          - preference
+                          - weight
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -270,8 +267,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchFields:
@@ -304,14 +301,14 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                             type: object
                           type: array
                       required:
-                      - nodeSelectorTerms
+                        - nodeSelectorTerms
                       type: object
                   type: object
                 podAffinity:
@@ -370,8 +367,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                      - key
-                                      - operator
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -402,7 +399,7 @@ spec:
                                   is running. Empty topologyKey is not allowed.
                                 type: string
                             required:
-                            - topologyKey
+                              - topologyKey
                             type: object
                           weight:
                             description: weight associated with matching the corresponding
@@ -410,8 +407,8 @@ spec:
                             format: int32
                             type: integer
                         required:
-                        - podAffinityTerm
-                        - weight
+                          - podAffinityTerm
+                          - weight
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -465,8 +462,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -496,7 +493,7 @@ spec:
                               topologyKey is not allowed.
                             type: string
                         required:
-                        - topologyKey
+                          - topologyKey
                         type: object
                       type: array
                   type: object
@@ -558,8 +555,8 @@ spec:
                                             type: string
                                           type: array
                                       required:
-                                      - key
-                                      - operator
+                                        - key
+                                        - operator
                                       type: object
                                     type: array
                                   matchLabels:
@@ -590,7 +587,7 @@ spec:
                                   is running. Empty topologyKey is not allowed.
                                 type: string
                             required:
-                            - topologyKey
+                              - topologyKey
                             type: object
                           weight:
                             description: weight associated with matching the corresponding
@@ -598,8 +595,8 @@ spec:
                             format: int32
                             type: integer
                         required:
-                        - podAffinityTerm
-                        - weight
+                          - podAffinityTerm
+                          - weight
                         type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
@@ -653,8 +650,8 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - key
-                                  - operator
+                                    - key
+                                    - operator
                                   type: object
                                 type: array
                               matchLabels:
@@ -684,7 +681,7 @@ spec:
                               topologyKey is not allowed.
                             type: string
                         required:
-                        - topologyKey
+                          - topologyKey
                         type: object
                       type: array
                   type: object
@@ -719,8 +716,8 @@ spec:
                         type: string
                       port:
                         anyOf:
-                        - type: integer
-                        - type: string
+                          - type: integer
+                          - type: string
                         description: Port the Alertmanager API is exposed on.
                         x-kubernetes-int-or-string: true
                       scheme:
@@ -751,7 +748,7 @@ spec:
                                       its key must be defined
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                               secret:
                                 description: Secret containing data to use for the
@@ -772,7 +769,7 @@ spec:
                                       key must be defined
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                             type: object
                           caFile:
@@ -801,7 +798,7 @@ spec:
                                       its key must be defined
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                               secret:
                                 description: Secret containing data to use for the
@@ -822,7 +819,7 @@ spec:
                                       key must be defined
                                     type: boolean
                                 required:
-                                - key
+                                  - key
                                 type: object
                             type: object
                           certFile:
@@ -854,20 +851,20 @@ spec:
                                   must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                           serverName:
                             description: Used to verify the hostname for the targets.
                             type: string
                         type: object
                     required:
-                    - name
-                    - namespace
-                    - port
+                      - name
+                      - namespace
+                      - port
                     type: object
                   type: array
               required:
-              - alertmanagers
+                - alertmanagers
               type: object
             apiserverConfig:
               description: APIServerConfig allows specifying a host and auth methods
@@ -896,7 +893,7 @@ spec:
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                     username:
                       description: The secret in the service monitor namespace that
@@ -915,7 +912,7 @@ spec:
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                   type: object
                 bearerToken:
@@ -949,7 +946,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                         secret:
                           description: Secret containing data to use for the targets.
@@ -967,7 +964,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                       type: object
                     caFile:
@@ -993,7 +990,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                         secret:
                           description: Secret containing data to use for the targets.
@@ -1011,7 +1008,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                       type: object
                     certFile:
@@ -1041,14 +1038,14 @@ spec:
                             be defined
                           type: boolean
                       required:
-                      - key
+                        - key
                       type: object
                     serverName:
                       description: Used to verify the hostname for the targets.
                       type: string
                   type: object
               required:
-              - host
+                - host
               type: object
             arbitraryFSAccessThroughSMs:
               description: ArbitraryFSAccessThroughSMs configures whether configuration
@@ -1148,7 +1145,7 @@ spec:
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
@@ -1165,7 +1162,7 @@ spec:
                                     specified API version.
                                   type: string
                               required:
-                              - fieldPath
+                                - fieldPath
                               type: object
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
@@ -1185,7 +1182,7 @@ spec:
                                   description: 'Required: resource to select'
                                   type: string
                               required:
-                              - resource
+                                - resource
                               type: object
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
@@ -1205,11 +1202,11 @@ spec:
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                           type: object
                       required:
-                      - name
+                        - name
                       type: object
                     type: array
                   envFrom:
@@ -1313,8 +1310,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -1322,8 +1319,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -1333,7 +1330,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           tcpSocket:
                             description: 'TCPSocket specifies an action involving
@@ -1346,14 +1343,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                         type: object
                       preStop:
@@ -1409,8 +1406,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -1418,8 +1415,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -1429,7 +1426,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           tcpSocket:
                             description: 'TCPSocket specifies an action involving
@@ -1442,14 +1439,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                         type: object
                     type: object
@@ -1503,8 +1500,8 @@ spec:
                                   description: The header field value
                                   type: string
                               required:
-                              - name
-                              - value
+                                - name
+                                - value
                               type: object
                             type: array
                           path:
@@ -1512,8 +1509,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1523,7 +1520,7 @@ spec:
                               Defaults to HTTP.
                             type: string
                         required:
-                        - port
+                          - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -1553,14 +1550,14 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
-                        - port
+                          - port
                         type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
@@ -1612,7 +1609,7 @@ spec:
                             Defaults to "TCP".
                           type: string
                       required:
-                      - containerPort
+                        - containerPort
                       type: object
                     type: array
                   readinessProbe:
@@ -1665,8 +1662,8 @@ spec:
                                   description: The header field value
                                   type: string
                               required:
-                              - name
-                              - value
+                                - name
+                                - value
                               type: object
                             type: array
                           path:
@@ -1674,8 +1671,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1685,7 +1682,7 @@ spec:
                               Defaults to HTTP.
                             type: string
                         required:
-                        - port
+                          - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -1715,14 +1712,14 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
-                        - port
+                          - port
                         type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
@@ -1937,8 +1934,8 @@ spec:
                                   description: The header field value
                                   type: string
                               required:
-                              - name
-                              - value
+                                - name
+                                - value
                               type: object
                             type: array
                           path:
@@ -1946,8 +1943,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1957,7 +1954,7 @@ spec:
                               Defaults to HTTP.
                             type: string
                         required:
-                        - port
+                          - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -1987,14 +1984,14 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
-                        - port
+                          - port
                         type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
@@ -2058,8 +2055,8 @@ spec:
                             in the pod
                           type: string
                       required:
-                      - devicePath
-                      - name
+                        - devicePath
+                        - name
                       type: object
                     type: array
                   volumeMounts:
@@ -2099,8 +2096,8 @@ spec:
                             exclusive. This field is beta in 1.15.
                           type: string
                       required:
-                      - mountPath
-                      - name
+                        - mountPath
+                        - name
                       type: object
                     type: array
                   workingDir:
@@ -2109,7 +2106,7 @@ spec:
                       configured in the container image. Cannot be updated.
                     type: string
                 required:
-                - name
+                  - name
                 type: object
               type: array
             disableCompaction:
@@ -2247,7 +2244,7 @@ spec:
                                     key must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                             fieldRef:
                               description: 'Selects a field of the pod: supports metadata.name,
@@ -2264,7 +2261,7 @@ spec:
                                     specified API version.
                                   type: string
                               required:
-                              - fieldPath
+                                - fieldPath
                               type: object
                             resourceFieldRef:
                               description: 'Selects a resource of the container: only
@@ -2284,7 +2281,7 @@ spec:
                                   description: 'Required: resource to select'
                                   type: string
                               required:
-                              - resource
+                                - resource
                               type: object
                             secretKeyRef:
                               description: Selects a key of a secret in the pod's
@@ -2304,11 +2301,11 @@ spec:
                                     must be defined
                                   type: boolean
                               required:
-                              - key
+                                - key
                               type: object
                           type: object
                       required:
-                      - name
+                        - name
                       type: object
                     type: array
                   envFrom:
@@ -2412,8 +2409,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -2421,8 +2418,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2432,7 +2429,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           tcpSocket:
                             description: 'TCPSocket specifies an action involving
@@ -2445,14 +2442,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                         type: object
                       preStop:
@@ -2508,8 +2505,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -2517,8 +2514,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2528,7 +2525,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           tcpSocket:
                             description: 'TCPSocket specifies an action involving
@@ -2541,14 +2538,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                         type: object
                     type: object
@@ -2602,8 +2599,8 @@ spec:
                                   description: The header field value
                                   type: string
                               required:
-                              - name
-                              - value
+                                - name
+                                - value
                               type: object
                             type: array
                           path:
@@ -2611,8 +2608,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2622,7 +2619,7 @@ spec:
                               Defaults to HTTP.
                             type: string
                         required:
-                        - port
+                          - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -2652,14 +2649,14 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
-                        - port
+                          - port
                         type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
@@ -2711,7 +2708,7 @@ spec:
                             Defaults to "TCP".
                           type: string
                       required:
-                      - containerPort
+                        - containerPort
                       type: object
                     type: array
                   readinessProbe:
@@ -2764,8 +2761,8 @@ spec:
                                   description: The header field value
                                   type: string
                               required:
-                              - name
-                              - value
+                                - name
+                                - value
                               type: object
                             type: array
                           path:
@@ -2773,8 +2770,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2784,7 +2781,7 @@ spec:
                               Defaults to HTTP.
                             type: string
                         required:
-                        - port
+                          - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -2814,14 +2811,14 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
-                        - port
+                          - port
                         type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
@@ -3036,8 +3033,8 @@ spec:
                                   description: The header field value
                                   type: string
                               required:
-                              - name
-                              - value
+                                - name
+                                - value
                               type: object
                             type: array
                           path:
@@ -3045,8 +3042,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -3056,7 +3053,7 @@ spec:
                               Defaults to HTTP.
                             type: string
                         required:
-                        - port
+                          - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -3086,14 +3083,14 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
-                        - port
+                          - port
                         type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
@@ -3157,8 +3154,8 @@ spec:
                             in the pod
                           type: string
                       required:
-                      - devicePath
-                      - name
+                        - devicePath
+                        - name
                       type: object
                     type: array
                   volumeMounts:
@@ -3198,8 +3195,8 @@ spec:
                             exclusive. This field is beta in 1.15.
                           type: string
                       required:
-                      - mountPath
-                      - name
+                        - mountPath
+                        - name
                       type: object
                     type: array
                   workingDir:
@@ -3208,7 +3205,7 @@ spec:
                       configured in the container image. Cannot be updated.
                     type: string
                 required:
-                - name
+                  - name
                 type: object
               type: array
             listenLocal:
@@ -3274,8 +3271,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -3317,8 +3314,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -3393,7 +3390,7 @@ spec:
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                       username:
                         description: The secret in the service monitor namespace that
@@ -3412,7 +3409,7 @@ spec:
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                     type: object
                   bearerToken:
@@ -3460,7 +3457,7 @@ spec:
                                   key must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                           secret:
                             description: Secret containing data to use for the targets.
@@ -3479,7 +3476,7 @@ spec:
                                   must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                         type: object
                       caFile:
@@ -3507,7 +3504,7 @@ spec:
                                   key must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                           secret:
                             description: Secret containing data to use for the targets.
@@ -3526,7 +3523,7 @@ spec:
                                   must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                         type: object
                       certFile:
@@ -3557,7 +3554,7 @@ spec:
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                       serverName:
                         description: Used to verify the hostname for the targets.
@@ -3567,7 +3564,7 @@ spec:
                     description: The URL of the endpoint to send samples to.
                     type: string
                 required:
-                - url
+                  - url
                 type: object
               type: array
             remoteWrite:
@@ -3597,7 +3594,7 @@ spec:
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                       username:
                         description: The secret in the service monitor namespace that
@@ -3616,7 +3613,7 @@ spec:
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                     type: object
                   bearerToken:
@@ -3690,7 +3687,7 @@ spec:
                                   key must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                           secret:
                             description: Secret containing data to use for the targets.
@@ -3709,7 +3706,7 @@ spec:
                                   must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                         type: object
                       caFile:
@@ -3737,7 +3734,7 @@ spec:
                                   key must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                           secret:
                             description: Secret containing data to use for the targets.
@@ -3756,7 +3753,7 @@ spec:
                                   must be defined
                                 type: boolean
                             required:
-                            - key
+                              - key
                             type: object
                         type: object
                       certFile:
@@ -3787,7 +3784,7 @@ spec:
                               be defined
                             type: boolean
                         required:
-                        - key
+                          - key
                         type: object
                       serverName:
                         description: Used to verify the hostname for the targets.
@@ -3842,7 +3839,7 @@ spec:
                       type: object
                     type: array
                 required:
-                - url
+                  - url
                 type: object
               type: array
             replicaExternalLabelName:
@@ -3918,8 +3915,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -3966,8 +3963,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -4016,13 +4013,13 @@ spec:
                 common container settings. This defaults to the default PodSecurityContext.
               properties:
                 fsGroup:
-                  description: "A special supplemental group that applies to all containers
-                    in a pod. Some volume types allow the Kubelet to change the ownership
-                    of that volume to be owned by the pod: \n 1. The owning GID will
-                    be the FSGroup 2. The setgid bit is set (new files created in
-                    the volume will be owned by FSGroup) 3. The permission bits are
-                    OR'd with rw-rw---- \n If unset, the Kubelet will not modify the
-                    ownership and permissions of any volume."
+                  description: "A special supplemental group that applies to all containers\
+                    \ in a pod. Some volume types allow the Kubelet to change the\
+                    \ ownership of that volume to be owned by the pod: \n 1. The owning\
+                    \ GID will be the FSGroup 2. The setgid bit is set (new files\
+                    \ created in the volume will be owned by FSGroup) 3. The permission\
+                    \ bits are OR'd with rw-rw---- \n If unset, the Kubelet will not\
+                    \ modify the ownership and permissions of any volume."
                   format: int64
                   type: integer
                 runAsGroup:
@@ -4095,8 +4092,8 @@ spec:
                         description: Value of a property to set
                         type: string
                     required:
-                    - name
-                    - value
+                      - name
+                      - value
                     type: object
                   type: array
                 windowsOptions:
@@ -4163,8 +4160,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -4206,8 +4203,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -4267,6 +4264,10 @@ spec:
                     metadata:
                       description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                       type: object
+                      properties:
+                        name:
+                          description: Name is the name used in the PVC claim
+                          type: string
                     spec:
                       description: 'Spec defines the desired characteristics of a
                         volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -4302,8 +4303,8 @@ spec:
                               description: Name is the name of resource being referenced
                               type: string
                           required:
-                          - kind
-                          - name
+                            - kind
+                            - name
                           type: object
                         resources:
                           description: 'Resources represents the minimum resources
@@ -4357,8 +4358,8 @@ spec:
                                       type: string
                                     type: array
                                 required:
-                                - key
-                                - operator
+                                  - key
+                                  - operator
                                 type: object
                               type: array
                             matchLabels:
@@ -4436,8 +4437,8 @@ spec:
                                   a valid value of PersistentVolumeClaimCondition.Type
                                 type: string
                             required:
-                            - status
-                            - type
+                              - status
+                              - type
                             type: object
                           type: array
                         phase:
@@ -4451,11 +4452,11 @@ spec:
                 to the value of `version`. Version is ignored if Tag is set.
               type: string
             thanos:
-              description: "Thanos configuration allows configuring various aspects
-                of a Prometheus server in a Thanos environment. \n This section is
-                experimental, it may change significantly without deprecation notice
-                in any release. \n This is experimental and may change significantly
-                without backward compatibility in any release."
+              description: "Thanos configuration allows configuring various aspects\
+                \ of a Prometheus server in a Thanos environment. \n This section\
+                \ is experimental, it may change significantly without deprecation\
+                \ notice in any release. \n This is experimental and may change significantly\
+                \ without backward compatibility in any release."
               properties:
                 baseImage:
                   description: Thanos base image if other than default.
@@ -4485,7 +4486,7 @@ spec:
                       description: Specify whether the Secret or its key must be defined
                       type: boolean
                   required:
-                  - key
+                    - key
                   type: object
                 resources:
                   description: Resources defines the resource requirements for the
@@ -4604,7 +4605,7 @@ spec:
                           AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
                     required:
-                    - volumeID
+                      - volumeID
                     type: object
                   azureDisk:
                     description: AzureDisk represents an Azure Data Disk mount on
@@ -4635,8 +4636,8 @@ spec:
                           will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                     required:
-                    - diskName
-                    - diskURI
+                      - diskName
+                      - diskURI
                     type: object
                   azureFile:
                     description: AzureFile represents an Azure File Service mount
@@ -4654,8 +4655,8 @@ spec:
                         description: Share Name
                         type: string
                     required:
-                    - secretName
-                    - shareName
+                      - secretName
+                      - shareName
                     type: object
                   cephfs:
                     description: CephFS represents a Ceph FS mount on the host that
@@ -4694,7 +4695,7 @@ spec:
                           is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         type: string
                     required:
-                    - monitors
+                      - monitors
                     type: object
                   cinder:
                     description: 'Cinder represents a cinder volume attached and mounted
@@ -4725,7 +4726,7 @@ spec:
                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                         type: string
                     required:
-                    - volumeID
+                      - volumeID
                     type: object
                   configMap:
                     description: ConfigMap represents a configMap that should populate
@@ -4772,8 +4773,8 @@ spec:
                                 '..'.
                               type: string
                           required:
-                          - key
-                          - path
+                            - key
+                            - path
                           type: object
                         type: array
                       name:
@@ -4825,7 +4826,7 @@ spec:
                           documentation for supported values.
                         type: object
                     required:
-                    - driver
+                      - driver
                     type: object
                   downwardAPI:
                     description: DownwardAPI represents downward API about the pod
@@ -4859,7 +4860,7 @@ spec:
                                     specified API version.
                                   type: string
                               required:
-                              - fieldPath
+                                - fieldPath
                               type: object
                             mode:
                               description: 'Optional: mode bits to use on this file,
@@ -4894,10 +4895,10 @@ spec:
                                   description: 'Required: resource to select'
                                   type: string
                               required:
-                              - resource
+                                - resource
                               type: object
                           required:
-                          - path
+                            - path
                           type: object
                         type: array
                     type: object
@@ -4989,7 +4990,7 @@ spec:
                             type: string
                         type: object
                     required:
-                    - driver
+                      - driver
                     type: object
                   flocker:
                     description: Flocker represents a Flocker volume attached to a
@@ -5036,7 +5037,7 @@ spec:
                           in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                         type: boolean
                     required:
-                    - pdName
+                      - pdName
                     type: object
                   gitRepo:
                     description: 'GitRepo represents a git repository at a particular
@@ -5059,7 +5060,7 @@ spec:
                         description: Commit hash for the specified revision.
                         type: string
                     required:
-                    - repository
+                      - repository
                     type: object
                   glusterfs:
                     description: 'Glusterfs represents a Glusterfs mount on the host
@@ -5079,8 +5080,8 @@ spec:
                           More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                         type: boolean
                     required:
-                    - endpoints
-                    - path
+                      - endpoints
+                      - path
                     type: object
                   hostPath:
                     description: 'HostPath represents a pre-existing file or directory
@@ -5101,7 +5102,7 @@ spec:
                           info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                         type: string
                     required:
-                    - path
+                      - path
                     type: object
                   iscsi:
                     description: 'ISCSI represents an ISCSI Disk resource that is
@@ -5165,9 +5166,9 @@ spec:
                           TCP ports 860 and 3260).
                         type: string
                     required:
-                    - iqn
-                    - lun
-                    - targetPortal
+                      - iqn
+                      - lun
+                      - targetPortal
                     type: object
                   name:
                     description: 'Volume''s name. Must be a DNS_LABEL and unique within
@@ -5191,8 +5192,8 @@ spec:
                           NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                         type: string
                     required:
-                    - path
-                    - server
+                      - path
+                      - server
                     type: object
                   persistentVolumeClaim:
                     description: 'PersistentVolumeClaimVolumeSource represents a reference
@@ -5209,7 +5210,7 @@ spec:
                           Default false.
                         type: boolean
                     required:
-                    - claimName
+                      - claimName
                     type: object
                   photonPersistentDisk:
                     description: PhotonPersistentDisk represents a PhotonController
@@ -5225,7 +5226,7 @@ spec:
                           disk
                         type: string
                     required:
-                    - pdID
+                      - pdID
                     type: object
                   portworxVolume:
                     description: PortworxVolume represents a portworx volume attached
@@ -5245,7 +5246,7 @@ spec:
                         description: VolumeID uniquely identifies a Portworx volume
                         type: string
                     required:
-                    - volumeID
+                      - volumeID
                     type: object
                   projected:
                     description: Items for all in one resources secrets, configmaps,
@@ -5305,8 +5306,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                    - key
-                                    - path
+                                      - key
+                                      - path
                                     type: object
                                   type: array
                                 name:
@@ -5346,7 +5347,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                        - fieldPath
+                                          - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -5384,10 +5385,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                        - resource
+                                          - resource
                                         type: object
                                     required:
-                                    - path
+                                      - path
                                     type: object
                                   type: array
                               type: object
@@ -5430,8 +5431,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                    - key
-                                    - path
+                                      - key
+                                      - path
                                     type: object
                                   type: array
                                 name:
@@ -5473,12 +5474,12 @@ spec:
                                     point of the file to project the token into.
                                   type: string
                               required:
-                              - path
+                                - path
                               type: object
                           type: object
                         type: array
                     required:
-                    - sources
+                      - sources
                     type: object
                   quobyte:
                     description: Quobyte represents a Quobyte mount on the host that
@@ -5511,8 +5512,8 @@ spec:
                           created Quobyte volume by name.
                         type: string
                     required:
-                    - registry
-                    - volume
+                      - registry
+                      - volume
                     type: object
                   rbd:
                     description: 'RBD represents a Rados Block Device mount on the
@@ -5562,8 +5563,8 @@ spec:
                           info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                     required:
-                    - image
-                    - monitors
+                      - image
+                      - monitors
                     type: object
                   scaleIO:
                     description: ScaleIO represents a ScaleIO persistent volume attached
@@ -5616,9 +5617,9 @@ spec:
                           system that is associated with this volume source.
                         type: string
                     required:
-                    - gateway
-                    - secretRef
-                    - system
+                      - gateway
+                      - secretRef
+                      - system
                     type: object
                   secret:
                     description: 'Secret represents a secret that should populate
@@ -5665,8 +5666,8 @@ spec:
                                 '..'.
                               type: string
                           required:
-                          - key
-                          - path
+                            - key
+                            - path
                           type: object
                         type: array
                       optional:
@@ -5738,10 +5739,10 @@ spec:
                         description: Path that identifies vSphere volume vmdk
                         type: string
                     required:
-                    - volumePath
+                      - volumePath
                     type: object
                 required:
-                - name
+                  - name
                 type: object
               type: array
             walCompression:
@@ -5779,23 +5780,23 @@ spec:
               format: int32
               type: integer
           required:
-          - availableReplicas
-          - paused
-          - replicas
-          - unavailableReplicas
-          - updatedReplicas
+            - availableReplicas
+            - paused
+            - replicas
+            - unavailableReplicas
+            - updatedReplicas
           type: object
       required:
-      - spec
+        - spec
       type: object
   version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
 status:
   acceptedNames:
-    kind: ""
-    plural: ""
+    kind: ''
+    plural: ''
   conditions: []
   storedVersions: []

--- a/staging/prometheus-operator/patch/README.md
+++ b/staging/prometheus-operator/patch/README.md
@@ -1,0 +1,9 @@
+# Fork Patches
+
+This directory contains patches to be applied to the upstream source in order to satisfy the needs of our fork.
+
+## Usage
+
+```
+patch/patch.sh
+```

--- a/staging/prometheus-operator/patch/patch.sh
+++ b/staging/prometheus-operator/patch/patch.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for p in patch/patch_*.sh; do
+    $p
+done

--- a/staging/prometheus-operator/patch/patch_50_prometheus_crd.sh
+++ b/staging/prometheus-operator/patch/patch_50_prometheus_crd.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -z $(command -v yq) ]]; then
+    echo "$0 requires the 'yq' command line tool which is not installed. Please install this and start again."
+    exit 1
+fi
+
 SRCFILE="crds/crd-prometheus.yaml"
 TMPFILE=$(mktemp)
 yq -y '.spec.validation.openAPIV3Schema.properties.spec.properties.storage.properties.volumeClaimTemplate.properties.metadata.properties.name = {"description": "Name is the name used in the PVC claim", "type": "string"}' ${SRCFILE} >> ${TMPFILE}

--- a/staging/prometheus-operator/patch/patch_prometheus_crd.sh
+++ b/staging/prometheus-operator/patch/patch_prometheus_crd.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SRCFILE="crds/crd-prometheus.yaml"
+TMPFILE=$(mktemp)
+yq -y '.spec.validation.openAPIV3Schema.properties.spec.properties.storage.properties.volumeClaimTemplate.properties.metadata.properties.name = {"description": "Name is the name used in the PVC claim", "type": "string"}' ${SRCFILE} >> ${TMPFILE}
+mv ${TMPFILE} ${SRCFILE}
+


### PR DESCRIPTION
This is a hack to work around a deficiency in controller-gen with
sub-components.

With subcomponents, the only option controller-gen gives
is for top-level api types, to mark them with
kubebuilder:validation:EmbeddedResource which creates a
x-kubernetes-embedded-resource marker causing the validator to reject
the resource if it's missing the ApiType and Kind for the subresource.

Since volumeClaimTemplate doesn't actually _require_ those, this causes
the templated resource to fail validation.

This hack is a workaround pending a fix of https://github.com/coreos/prometheus-operator/issues/3093