### PR TITLE
bug: fix misplaced quotes

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.8.2
+version: 8.8.3
 appVersion: 0.35.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/mesosphere-hooks/grafana-default-dashboard-hook.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/grafana-default-dashboard-hook.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.mesosphereResources.hooks.grafana.jobName | quote }}
+  name: {{ .Release.Name }}-{{ .Values.mesosphereResources.hooks.grafana.jobName }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "-5"
@@ -11,7 +11,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}-{{ .Values.mesosphereResources.hooks.grafana.jobName | quote }}
+      name: {{ .Release.Name }}-{{ .Values.mesosphereResources.hooks.grafana.jobName }}
     spec:
       restartPolicy: Never
       containers:


### PR DESCRIPTION
This fixes the error:

```
warning: Release prometheus-kubeaddons post-upgrade prometheus-operator/templates/mesosphere-hooks/grafana-default-dashboard-hook.yaml failed: Job.batch "prometheus-kubeaddons-\"grafana-default-dashboard\"" is invalid: [metadata.name: Invalid value: "prometheus-kubeaddons-\"grafana-default-dashboard\"": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.labels: Invalid value: "prometheus-kubeaddons-\"grafana-default-dashboard\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]
```