### PR TITLE
fix: add permissions to handle konvoycluster resources

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 7.1.0
+version: 7.1.1
 appVersion: 1.17.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -123,6 +123,9 @@ rules:
     - leases
     verbs:
     - create
+  - apiGroups: ["kommander.mesosphere.io"]
+    resources: ["konvoyclusters"]
+    verbs: ["watch", "list", "get", "update"]    
   - apiGroups:
     - coordination.k8s.io
     resourceNames:


### PR DESCRIPTION
The cluster-autoscaler cannot handle konvoyclusters.