### PR TITLE
[D2IQ-66836] opsportal-kommander-view ClusterRole 401 viewing Kommander UI

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.6.13
+version: 0.6.14

--- a/stable/kommander/templates/kommander-ui/ingress-roles.yaml
+++ b/stable/kommander/templates/kommander-ui/ingress-roles.yaml
@@ -30,6 +30,13 @@ rules:
   verbs:
   - get
   - head
+- nonResourceURLs:
+  - /ops/portal/kommander/ui/graphql
+  - {{ index .Values "kommander-ui" "ingress" "graphqlPath" | trimSuffix "/" }}
+  verbs:
+  - get
+  - head
+  - post
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/kommander/templates/kommander-ui/ingress-roles.yaml
+++ b/stable/kommander/templates/kommander-ui/ingress-roles.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - nonResourceURLs:
   - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}
@@ -23,6 +24,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - nonResourceURLs:
   - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}
@@ -31,7 +33,6 @@ rules:
   - get
   - head
 - nonResourceURLs:
-  - /ops/portal/kommander/ui/graphql
   - {{ index .Values "kommander-ui" "ingress" "graphqlPath" | trimSuffix "/" }}
   verbs:
   - get
@@ -46,6 +47,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - nonResourceURLs:
   - {{ index .Values "kommander-ui" "ingress" "path" | trimSuffix "/" }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -174,6 +174,7 @@ kommander-ui:
       traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
       traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Impersonate-User,Impersonate-Group
     path: /ops/portal/kommander/ui
+    graphqlPath: /ops/portal/kommander/ui/graphql
 
 portalRBAC:
   grafana:

--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.0
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.3.8
+version: 0.3.9
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc


### PR DESCRIPTION
Currently the opsportal-kommander-view ClusterRole results in a 401 when trying to reach the Kommander UI with the following error due to not being allowed to POST to:

`/ops/portal/kommander/ui/graphql`

This is similar to the opsportal-view ClusterRole where the user needs to be able to POST to graphql. 

[D2IQ-66861]

[D2IQ-66861]: https://jira.d2iq.com/browse/D2IQ-66861