### PR TITLE
velero: backport of extraArgs fix: #20091

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -16,4 +16,4 @@ name: velero
 sources:
 - https://github.com/heptio/velero
 tillerVersion: '>=2.10.0'
-version: 3.0.3
+version: 3.0.4

--- a/staging/velero/charts/minio/Chart.yaml
+++ b/staging/velero/charts/minio/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/minio/minio
-version: 5.0.15
+version: 5.0.16

--- a/staging/velero/charts/minio/templates/_helpers.tpl
+++ b/staging/velero/charts/minio/templates/_helpers.tpl
@@ -102,6 +102,6 @@ Properly format optional additional arguments to Minio binary
 */}}
 {{- define "minio.extraArgs" -}}
 {{- range .Values.extraArgs -}}
-,{{ . | quote }}
+{{ " " }}{{ .  }}
 {{- end -}}
 {{- end -}}

--- a/staging/velero/charts/minio/templates/deployment.yaml
+++ b/staging/velero/charts/minio/templates/deployment.yaml
@@ -73,43 +73,36 @@ spec:
           {{- if .Values.s3gateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }}"
-          {{- template "minio.extraArgs" . }} ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }} {{- template `minio.extraArgs` . }}" ]
           {{- else }}
           {{- if .Values.azuregateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure"
-          {{- template "minio.extraArgs" . }} ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure {{- template `minio.extraArgs` . }}" ]
           {{- else }}
           {{- if .Values.gcsgateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId }}"
-          {{- template "minio.extraArgs" . }} ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId  }} {{- template `minio.extraArgs` . }}" ]
           {{- else }}
           {{- if .Values.ossgateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway oss {{ .Values.ossgateway.endpointURL }}"
-          {{- template "minio.extraArgs" . }} ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway oss {{ .Values.ossgateway.endpointURL }} {{- template `minio.extraArgs` . }}" ]
           {{- else }}
           {{- if .Values.nasgateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }}"
-          {{- template "minio.extraArgs" . }} ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }} {{- template `minio.extraArgs` . }}" ]
           {{- else }}
           {{- if .Values.b2gateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway b2"
-          {{- template "minio.extraArgs" . }} ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway b2 {{- template `minio.extraArgs` . }}" ]
           {{- else }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }}"
-          {{- template "minio.extraArgs" . }} ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }} {{- template `minio.extraArgs` . }}" ]
           {{- end }}
           {{- end }}
           {{- end }}

--- a/staging/velero/charts/minio/templates/statefulset.yaml
+++ b/staging/velero/charts/minio/templates/statefulset.yaml
@@ -90,8 +90,7 @@ spec:
 
           command: [ "/bin/sh",
             "-ce",
-            "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{- range $i := until $zoneCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.statefulset.name` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{else}}{{ $bucketRoot }}{{end}}{{- end}}"
-          {{- template "minio.extraArgs" . }} ]
+            "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{- range $i := until $zoneCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.statefulset.name` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{else}}{{ $bucketRoot }}{{end}}{{- end}}{{- template `minio.extraArgs` . }}" ]
           volumeMounts:
             {{- if $penabled }}
             {{- if (gt $drivesPerNode 1) }}

--- a/staging/velero/requirements.lock
+++ b/staging/velero/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
   repository: ""
-  version: 5.0.15
-digest: sha256:66c5f09423e15b3949f65c583e691740420048330a9657dda06de10d73ed1e9e
-generated: "2020-04-10T11:24:42.229112-07:00"
+  version: 5.0.16
+digest: sha256:fb14297ca5905229d04cb1c1fcb313e5b47c5e95e72267ccf953c621828b51e4
+generated: "2020-04-14T13:53:13.485547527+02:00"

--- a/staging/velero/requirements.yaml
+++ b/staging/velero/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: minio
-  version: 5.0.15
+  version: 5.0.16
   condition: minioBackend


### PR DESCRIPTION
This is a backport of https://github.com/helm/charts/pull/20091/ In the currently used charts the `extraArgs` chart option does not work, hence we cannot pass the `--json` option to the minio server.

Having enabled the json logging, we will be able to properly correlate log eventsas described in [1]. 

[1] https://jira.d2iq.com/browse/D2IQ-66612