### PR TITLE
[D2IQ-66835] Prom Operator v0.35.1

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,8 +12,8 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.8.4
-appVersion: 0.35.0
+version: 8.8.5
+appVersion: 0.35.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -1215,7 +1215,7 @@ prometheusOperator:
   ##
   image:
     repository: quay.io/coreos/prometheus-operator
-    tag: v0.35.0
+    tag: v0.35.1
     pullPolicy: IfNotPresent
 
   ## Configmap-reload image to use for reloading configmaps


### PR DESCRIPTION
The purpose of this task is to update our prometheus operator to v0.35.1 as per D2IQ-66835.
