### PR TITLE
Additional nonResourceURLS to opsportal-kibana-view ClusterRole

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.0
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.3.9
+version: 0.3.10
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/templates/kibana-roles.yaml
+++ b/stable/opsportal/templates/kibana-roles.yaml
@@ -57,7 +57,11 @@ rules:
 - nonResourceURLs:
   - {{ .Values.kibanaRBAC.path | trimSuffix "/"}}
   - {{ .Values.kibanaRBAC.path | trimSuffix "/" }}/*
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/" }}/api/saved_objects/*
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/" }}/elasticsearch/*
+  - {{ .Values.kibanaRBAC.path | trimSuffix "/" }}/api/timelion/run
   verbs:
   - get
   - head
+  - post
 {{- end }}


### PR DESCRIPTION
Per D2IQ-66863, Adding additional nonResourceURLs to the opsportal-kibana that will allow a user "view" type of permissions within Kibana addon.

Currently a user is not able:
 - To use the Discover tab which is a requirement in our Product for viewing logs for Kubernetes, Konvoy and Kommander by default.
 - Use the Timelion app which comes preinstalled in our Kibana. 

The following nonResourceURLs have been inspected to ensure that users with the ClusterRole are not able create/delete Indexes or use the Dev Tools tool to do anything that would be considered destructive in Elasticsearch. 