### PR TITLE
fix: Fix consistent sort ordering for publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ stagingrepo: $(STAGING_TARGETS) | gh-pages/staging/index.yaml
 stablerepo: $(STABLE_TARGETS) | gh-pages/stable/index.yaml
 
 .PHONY: publish
+publish: export LC_COLLATE := C
 publish:
 	-git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1
 	rm -rf gh-pages


### PR DESCRIPTION
Now that Dispatch is publishing helm repo, I noticed that the sort
order is different when I run builds locally due to different
LC_COLLATE. Setting this to LC_COLLATE=C to be consistent on all hosts
regardless of local environment ensures reproducible builds on all
hosts.