### PR TITLE
kommander: Grafana updates to cluster label

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.6.16
+version: 0.6.17

--- a/stable/kommander/templates/grafana/dashboards/apiserver.yaml
+++ b/stable/kommander/templates/grafana/dashboards/apiserver.yaml
@@ -1235,7 +1235,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/cluster-total.yaml
+++ b/stable/kommander/templates/grafana/dashboards/cluster-total.yaml
@@ -1278,7 +1278,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/controller-manager.yaml
+++ b/stable/kommander/templates/grafana/dashboards/controller-manager.yaml
@@ -1035,7 +1035,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/etcd.yaml
+++ b/stable/kommander/templates/grafana/dashboards/etcd.yaml
@@ -1275,7 +1275,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/k8s-coredns.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-coredns.yaml
@@ -1178,7 +1178,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-cluster.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-cluster.yaml
@@ -61,7 +61,7 @@ data:
       "gnetId": null,
       "graphTooltip": 0,
       "id": null,
-      "iteration": 1582323837127,
+      "iteration": 1588637701877,
       "links": [],
       "panels": [
         {
@@ -186,6 +186,23 @@ data:
               "pattern": "Time",
               "thresholds": [],
               "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "Cluster",
+              "align": "auto",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "cluster",
+              "thresholds": [],
+              "type": "string",
               "unit": "short"
             }
           ],
@@ -896,6 +913,23 @@ data:
               "unit": "short"
             },
             {
+              "alias": "Cluster",
+              "align": "auto",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "cluster",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
               "alias": "",
               "align": "auto",
               "colorMode": null,
@@ -1306,6 +1340,23 @@ data:
               "unit": "short"
             },
             {
+              "alias": "Cluster",
+              "align": "auto",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "cluster",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
               "alias": "",
               "align": "auto",
               "colorMode": null,
@@ -1589,6 +1640,23 @@ data:
               "linkTooltip": "Drill down to pods",
               "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
               "pattern": "namespace",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Cluster",
+              "align": "auto",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "cluster",
               "thresholds": [],
               "type": "number",
               "unit": "short"
@@ -2565,6 +2633,7 @@ data:
         "list": [
           {
             "current": {
+              "selected": true,
               "text": "ThanosQuery",
               "value": "ThanosQuery"
             },

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-cluster.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-cluster.yaml
@@ -2587,7 +2587,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": true,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-namespace.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-namespace.yaml
@@ -1806,7 +1806,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-node.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-node.yaml
@@ -886,7 +886,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-pod.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-pod.yaml
@@ -1546,7 +1546,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-workload.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-workload.yaml
@@ -1939,7 +1939,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
+++ b/stable/kommander/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
@@ -2041,7 +2041,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/kubelet.yaml
+++ b/stable/kommander/templates/grafana/dashboards/kubelet.yaml
@@ -2318,7 +2318,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/namespace-by-pod.yaml
+++ b/stable/kommander/templates/grafana/dashboards/namespace-by-pod.yaml
@@ -1272,7 +1272,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/namespace-by-workload.yaml
+++ b/stable/kommander/templates/grafana/dashboards/namespace-by-workload.yaml
@@ -1232,7 +1232,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/node-cluster-rsrc-use.yaml
+++ b/stable/kommander/templates/grafana/dashboards/node-cluster-rsrc-use.yaml
@@ -1025,7 +1025,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/node-rsrc-use.yaml
+++ b/stable/kommander/templates/grafana/dashboards/node-rsrc-use.yaml
@@ -1025,7 +1025,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/nodes.yaml
+++ b/stable/kommander/templates/grafana/dashboards/nodes.yaml
@@ -913,7 +913,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/pod-total.yaml
+++ b/stable/kommander/templates/grafana/dashboards/pod-total.yaml
@@ -1064,7 +1064,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/pods.yaml
+++ b/stable/kommander/templates/grafana/dashboards/pods.yaml
@@ -504,7 +504,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/prometheus-remote-write.yaml
+++ b/stable/kommander/templates/grafana/dashboards/prometheus-remote-write.yaml
@@ -1316,7 +1316,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": true,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/prometheus.yaml
+++ b/stable/kommander/templates/grafana/dashboards/prometheus.yaml
@@ -1217,7 +1217,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/proxy.yaml
+++ b/stable/kommander/templates/grafana/dashboards/proxy.yaml
@@ -1128,7 +1128,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/scheduler.yaml
+++ b/stable/kommander/templates/grafana/dashboards/scheduler.yaml
@@ -984,7 +984,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/statefulset.yaml
+++ b/stable/kommander/templates/grafana/dashboards/statefulset.yaml
@@ -805,7 +805,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],

--- a/stable/kommander/templates/grafana/dashboards/workload-total.yaml
+++ b/stable/kommander/templates/grafana/dashboards/workload-total.yaml
@@ -977,7 +977,7 @@ data:
             "definition": "",
             "hide": 0,
             "includeAll": false,
-            "label": "cluster",
+            "label": "Cluster (Monitoring ID/clusterId)",
             "multi": false,
             "name": "cluster",
             "options": [],


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-65414
To match the language in the kommander ui wrt monitoring id exposed there used to correlate cluster to its metrics in the centralized grafana, made some changes to the grafana dashboards. Renamed the `cluster` filter display name to `Cluster (Monitoring ID/clusterId)` and also fixed some inconsistencies with capitalization of `Cluster`.

kommander ui:
![image](https://user-images.githubusercontent.com/5897740/81120430-8ba73b80-8ee1-11ea-9417-aab7e9e40c33.png)

![image](https://user-images.githubusercontent.com/5897740/81120598-ec367880-8ee1-11ea-87a1-b85b8b0932e1.png)

