### PR TITLE
chore: Modify kommander codeowners, add kubecost codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,12 +18,11 @@
 /stable/dispatch @mesosphere/devx
 /stable/gcpdisk-csi-driver @mesosphere/sig-ksphere-cluster
 /stable/gcpdiskprovisioner @mesosphere/sig-ksphere-cluster
-/stable/kommander @mesosphere/sig-ksphere-ui @mesosphere/sig-ksphere-multi-cluster
-/stable/kommander-karma @mesosphere/sig-ksphere-observability
-/stable/kommander-thanos @mesosphere/sig-ksphere-observability
+/stable/kommander @mesosphere/sig-ksphere-ui @mesosphere/sig-ksphere-multi-cluster @mesosphere/sig-ksphere-observability
+/stable/kubecost @mesosphere/sig-ksphere-observability
 /stable/localvolumeprovisioner @mesosphere/sig-ksphere-cluster
 /stable/mtls-proxy @mesosphere/sig-ksphere-observability
-/stable/opsportal @mesosphere/sig-ksphere-ui @mesosphere/sig-ksphere-security 
+/stable/opsportal @mesosphere/sig-ksphere-ui @mesosphere/sig-ksphere-security
 /stable/tekton @mesosphere/devx
 
 /staging/prometheus-operator @mesosphere/sig-ksphere-observability


### PR DESCRIPTION
- Removed `/stable/kommander-karma` and `/stable/kommander-thanos` because those charts 
were moved directly into kommander chart
- Add @mesosphere/sig-ksphere-observability to `/stable/kommander` chart
- Add @mesosphere/sig-ksphere-observability to `/stable/kubecost` chart