### PR TITLE
kubecost: Fix sa hook delete-policy

### DIFF
--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.58.0
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: gracedo

--- a/stable/kubecost/templates/hooks-clusterid.yaml
+++ b/stable/kubecost/templates/hooks-clusterid.yaml
@@ -11,9 +11,9 @@ metadata:
     app: {{ template "kubecost.name" . }}-kubecost
 {{ include "kubecost.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade,post-delete
+    helm.sh/hook: pre-install,pre-upgrade,post-delete
     helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Was seeing that there was something wonky going on with the service accounts when kubecost was getting deployed on managed clusters - occasionally the sa token secret couldn't be found which caused other required hook jobs to fail which depended on the sa/roles, which in turn caused kubecost deployment to fail. Removed `hook-succeeded` from the sa hook deletion policy and thus the post- hooks. This seemed to stop kubecost deployments from failing.

```
3m32s       Warning   Failed                   pod/kubecost-kubeaddons-cluster-i
d-configmap-tr88l             Error: cannot find volume "kubecost-kubeaddons-hoo
k-token-7mdbp" to mount into container "kubectl"
<unknown>   Normal    Scheduled                pod/kubecost-kubeaddons-cluster-i
d-configmap-wjrg2             Successfully assigned kubecost/kubecost-kubeaddons
-cluster-id-configmap-wjrg2 to ip-10-0-130-204.us-west-2.compute.internal
3m42s       Normal    Pulling                  pod/kubecost-kubeaddons-cluster-i
d-configmap-wjrg2             Pulling image "bitnami/kubectl:1.16.2"
3m41s       Normal    Pulled                   pod/kubecost-kubeaddons-cluster-i
d-configmap-wjrg2             Successfully pulled image "bitnami/kubectl:1.16.2"
3m41s       Normal    Created                  pod/kubecost-kubeaddons-cluster-i
d-configmap-wjrg2             Created container kubectl
3m41s       Normal    Started                  pod/kubecost-kubeaddons-cluster-i
d-configmap-wjrg2             Started container kubectl
3m38s       Warning   FailedMount              pod/kubecost-kubeaddons-cluster-i
d-configmap-wjrg2             MountVolume.SetUp failed for volume "kubecost-kube
addons-hook-token-gqhf2" : secret "kubecost-kubeaddons-hook-token-gqhf2" not found
```