### PR TITLE
feat(gcpdisk-csi-driver): update images

### DIFF
--- a/stable/gcpdisk-csi-driver/Chart.yaml
+++ b/stable/gcpdisk-csi-driver/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-appVersion: 0.6.0
+appVersion: 0.7.0
 description: Google Compute Engine Persistent Disk (GCE PD) Container Storage Interface (CSI) Storage Plugin
 name: gcpdisk-csi-driver
 maintainers:
   - name: sebbrandt87
-version: 0.6.0
+version: 0.7.0
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
 sources:

--- a/stable/gcpdisk-csi-driver/files/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+++ b/stable/gcpdisk-csi-driver/files/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -1,0 +1,85 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+  creationTimestamp: null
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .driver
+    name: Driver
+    type: string
+  - JSONPath: .deletionPolicy
+    description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass
+      should be deleted when its bound VolumeSnapshot is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    singular: volumesnapshotclass
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotClass specifies parameters that a underlying storage
+        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+        are non-namespaced
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        deletionPolicy:
+          description: deletionPolicy determines whether a VolumeSnapshotContent created
+            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
+            is deleted. Supported values are "Retain" and "Delete". "Retain" means
+            that the VolumeSnapshotContent and its physical snapshot on underlying
+            storage system are kept. "Delete" means that the VolumeSnapshotContent
+            and its physical snapshot on underlying storage system are deleted. Required.
+          enum:
+          - Delete
+          - Retain
+          type: string
+        driver:
+          description: driver is the name of the storage driver that handles this
+            VolumeSnapshotClass. Required.
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        parameters:
+          additionalProperties:
+            type: string
+          description: parameters is a key-value map with storage driver specific
+            parameters for creating snapshots. These values are opaque to Kubernetes.
+          type: object
+      required:
+      - deletionPolicy
+      - driver
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/stable/gcpdisk-csi-driver/files/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/stable/gcpdisk-csi-driver/files/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -1,0 +1,233 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+  creationTimestamp: null
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot in bytes
+    name: RestoreSize
+    type: integer
+  - JSONPath: .spec.deletionPolicy
+    description: Determines whether this VolumeSnapshotContent and its physical snapshot
+      on the underlying storage system should be deleted when its bound VolumeSnapshot
+      is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .spec.driver
+    description: Name of the CSI driver used to create the physical snapshot on the
+      underlying storage system.
+    name: Driver
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+    name: VolumeSnapshotClass
+    type: string
+  - JSONPath: .spec.volumeSnapshotRef.name
+    description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+      object is bound.
+    name: VolumeSnapshot
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    singular: volumesnapshotcontent
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+        object in the underlying storage system
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: spec defines properties of a VolumeSnapshotContent created
+            by the underlying storage system. Required.
+          properties:
+            deletionPolicy:
+              description: deletionPolicy determines whether this VolumeSnapshotContent
+                and its physical snapshot on the underlying storage system should
+                be deleted when its bound VolumeSnapshot is deleted. Supported values
+                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are kept. "Delete"
+                means that the VolumeSnapshotContent and its physical snapshot on
+                underlying storage system are deleted. In dynamic snapshot creation
+                case, this field will be filled in with the "DeletionPolicy" field
+                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
+                pre-existing snapshots, users MUST specify this field when creating
+                the VolumeSnapshotContent object. Required.
+              enum:
+              - Delete
+              - Retain
+              type: string
+            driver:
+              description: driver is the name of the CSI driver used to create the
+                physical snapshot on the underlying storage system. This MUST be the
+                same as the name returned by the CSI GetPluginName() call for that
+                driver. Required.
+              type: string
+            source:
+              description: source specifies from where a snapshot will be created.
+                This field is immutable after creation. Required.
+              properties:
+                snapshotHandle:
+                  description: snapshotHandle specifies the CSI "snapshot_id" of a
+                    pre-existing snapshot on the underlying storage system. This field
+                    is immutable.
+                  type: string
+                volumeHandle:
+                  description: volumeHandle specifies the CSI "volume_id" of the volume
+                    from which a snapshot should be dynamically taken from. This field
+                    is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: name of the VolumeSnapshotClass to which this snapshot
+                belongs.
+              type: string
+            volumeSnapshotRef:
+              description: volumeSnapshotRef specifies the VolumeSnapshot object to
+                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                field must reference to this VolumeSnapshotContent's name for the
+                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                object, name and namespace of the VolumeSnapshot object MUST be provided
+                for binding to happen. This field is immutable after creation. Required.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+          required:
+          - deletionPolicy
+          - driver
+          - source
+          - volumeSnapshotRef
+          type: object
+        status:
+          description: status represents the current information of a snapshot.
+          properties:
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates the creation time is unknown. The
+                format of this field is a Unix nanoseconds time encoded as an int64.
+                On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                since 1970-01-01 00:00:00 UTC.
+              format: int64
+              type: integer
+            error:
+              description: error is the latest observed error during snapshot creation,
+                if any.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              format: int64
+              minimum: 0
+              type: integer
+            snapshotHandle:
+              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
+                the underlying storage system. If not specified, it indicates that
+                dynamic snapshot creation has either failed or it is still in progress.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/stable/gcpdisk-csi-driver/files/snapshot.storage.k8s.io_volumesnapshots.yaml
+++ b/stable/gcpdisk-csi-driver/files/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -1,0 +1,188 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+  creationTimestamp: null
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .spec.source.persistentVolumeClaimName
+    description: Name of the source PVC from where a dynamically taken snapshot will
+      be created.
+    name: SourcePVC
+    type: string
+  - JSONPath: .spec.source.volumeSnapshotContentName
+    description: Name of the VolumeSnapshotContent which represents a pre-provisioned
+      snapshot.
+    name: SourceSnapshotContent
+    type: string
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot.
+    name: RestoreSize
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+    name: SnapshotClass
+    type: string
+  - JSONPath: .status.boundVolumeSnapshotContentName
+    description: The name of the VolumeSnapshotContent to which this VolumeSnapshot
+      is bound.
+    name: SnapshotContent
+    type: string
+  - JSONPath: .status.creationTime
+    description: Timestamp when the point-in-time snapshot is taken by the underlying
+      storage system.
+    name: CreationTime
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    singular: volumesnapshot
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshot is a user's request for either creating a point-in-time
+        snapshot of a persistent volume, or binding to a pre-existing snapshot.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'spec defines the desired characteristics of a snapshot requested
+            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+            Required.'
+          properties:
+            source:
+              description: source specifies where a snapshot will be created from.
+                This field is immutable after creation. Required.
+              properties:
+                persistentVolumeClaimName:
+                  description: persistentVolumeClaimName specifies the name of the
+                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
+                    object where the snapshot should be dynamically taken from. This
+                    field is immutable.
+                  type: string
+                volumeSnapshotContentName:
+                  description: volumeSnapshotContentName specifies the name of a pre-existing
+                    VolumeSnapshotContent object. This field is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
+                requested by the VolumeSnapshot. If not specified, the default snapshot
+                class will be used if one exists. If not specified, and there is no
+                default snapshot class, dynamic snapshot creation will fail. Empty
+                string is not allowed for this field. TODO(xiangqian): a webhook validation
+                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
+              type: string
+          required:
+          - source
+          type: object
+        status:
+          description: 'status represents the current information of a snapshot. NOTE:
+            status can be modified by sources other than system controllers, and must
+            not be depended upon for accuracy. Controllers should only use information
+            from the VolumeSnapshotContent object after verifying that the binding
+            is accurate and complete.'
+          properties:
+            boundVolumeSnapshotContentName:
+              description: 'boundVolumeSnapshotContentName represents the name of
+                the VolumeSnapshotContent object to which the VolumeSnapshot object
+                is bound. If not specified, it indicates that the VolumeSnapshot object
+                has not been successfully bound to a VolumeSnapshotContent object
+                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
+                mean binding       is valid. Controllers MUST always verify bidirectional
+                binding between       VolumeSnapshot and VolumeSnapshotContent to
+                avoid possible security issues.'
+              type: string
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates that the creation time of the snapshot
+                is unknown.
+              format: date-time
+              type: string
+            error:
+              description: error is the last observed error during snapshot creation,
+                if any. This field could be helpful to upper level controllers(i.e.,
+                application controller) to decide whether they should continue on
+                waiting for the snapshot to be created based on the type of error
+                reported.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              anyOf:
+              - type: integer
+              - type: string
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/stable/gcpdisk-csi-driver/templates/_helper.tpl
+++ b/stable/gcpdisk-csi-driver/templates/_helper.tpl
@@ -9,3 +9,27 @@ labels:
   chart: "{{ .Chart.Name }}"
   chartVersion: "{{ .Chart.Version }}"
 {{- end -}}
+
+{{/*
+As the official docs say 0.7.0 is compatible up from kubernetes versions >= Minor 16
+so we define it here to use the higher version only then.
+*/}}
+{{- define "gcpdisk.image.tag" -}}
+{{- if or (gt (.Capabilities.KubeVersion.Minor | int) 16) (eq (.Capabilities.KubeVersion.Minor | int) 16) }}
+{{- .Values.image.tagK8sMinor16 -}}
+{{- else -}}
+{{- .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+To keep compability we need to set snapshotter tag to the same tag as snapshot-controller.
+They are released in combination and depend on each other on newer kubernetes versions >= Minor 17
+*/}}
+{{- define "gcpdisk.snapshotter.image.tag" -}}
+{{- if or (gt (.Capabilities.KubeVersion.Minor | int) 17) (eq (.Capabilities.KubeVersion.Minor | int) 17) }}
+{{- .Values.snapshotController.image.tag -}}
+{{- else -}}
+{{- .Values.snapshotter.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/stable/gcpdisk-csi-driver/templates/csi-gcpdisk-controller.yaml
+++ b/stable/gcpdisk-csi-driver/templates/csi-gcpdisk-controller.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "gcpdisk.labels" . | indent 2 }}
 spec:
   serviceName: "csi-gce-pd"
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: gcp-compute-persistent-disk-csi-driver
@@ -15,20 +15,21 @@ spec:
 {{ include "gcpdisk.labels" . | indent 6 }}
         app: gcp-compute-persistent-disk-csi-driver
     spec:
-      # Host network must be used for interaction with Workload Identity in GKE
-      # since it replaces GCE Metadata Server with GKE Metadata Server. Remove
-      # this requirement when issue is resolved and before any exposure of
-      # metrics ports
-      hostNetwork: true
       serviceAccountName: csi-gce-pd-controller-sa
       nodeSelector:
         beta.kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
       containers:
         - name: csi-provisioner
           image: {{ .Values.provisioner.image.repository }}:{{ .Values.provisioner.image.tag }}
           args:
+            - --v=5
             - --csi-address=$(ADDRESS)
+            - --metrics-address=:22011
             - --timeout={{ .Values.provisioner.timeout }}
             - --retry-interval-start={{ .Values.provisioner.retryIntervalStart }}
             - --retry-interval-max={{ .Values.provisioner.retryIntervalMax }}
@@ -36,8 +37,10 @@ spec:
             {{- if .Values.enableTopologyZone }}
             - --feature-gates=Topology=true
             {{- end}}
+            {{- if (gt (.Values.replicas | int) 1) }}
             - --enable-leader-election
             - --leader-election-type=leases
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -45,22 +48,15 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-        - name: cluster-driver-registrar
-          image: {{ .Values.registrar.cluster.image.repository }}:{{ .Values.registrar.cluster.image.tag }}
-          args:
-            - --csi-address=$(ADDRESS)
-            - --driver-requires-attachment=true
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
         - name: csi-snapshotter
-          image: {{ .Values.snapshotter.image.repository }}:{{ .Values.snapshotter.image.tag }}
+          image: "{{ .Values.snapshotter.image.repository }}:{{ include "gcpdisk.snapshotter.image.tag" . }}"
           args:
+            - --v=5
             - --csi-address=$(ADDRESS)
+            - --metrics-address=:22014
+            {{- if (gt (.Values.replicas | int) 1) }}
+            - --leader-election=true
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -72,10 +68,14 @@ spec:
           args:
             - --v=5
             - --csi-address=$(ADDRESS)
+            - --metrics-address=:22012
             - --timeout={{ .Values.attacher.timeout }}
             - --retry-interval-start={{ .Values.attacher.retryIntervalStart }}
             - --retry-interval-max={{ .Values.attacher.retryIntervalMax }}
             - --worker-threads={{ .Values.attacher.workerThreads }}
+            {{- if (gt (.Values.replicas | int) 1) }}
+            - --leader-election=true
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -88,6 +88,10 @@ spec:
           args:
             - --v=5
             - --csi-address=$(ADDRESS)
+            - --metrics-address=:22013
+            {{- if (gt (.Values.replicas | int) 1) }}
+            - --leader-election=true
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -98,7 +102,7 @@ spec:
         - name: gce-pd-driver
           # Don't change base image without changing pdImagePlaceholder in
           # test/k8s-integration/main.go
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ .Values.image.repository }}:{{ include "gcpdisk.image.tag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--v=5"

--- a/stable/gcpdisk-csi-driver/templates/csi-gcpdisk-snapshot-controller.yaml
+++ b/stable/gcpdisk-csi-driver/templates/csi-gcpdisk-snapshot-controller.yaml
@@ -1,0 +1,35 @@
+{{- if or (gt (.Capabilities.KubeVersion.Minor | int) 17) (eq (.Capabilities.KubeVersion.Minor | int) 17) }}
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-snapshot-controller
+  namespace: {{ .Release.Namespace }}
+{{ include "gcpdisk.labels" . | indent 2 }}
+spec:
+  serviceName: csi-gce-pd-snapshot-controller
+  replicas: {{ .Values.replicasSnapshotController }}
+  selector:
+    matchLabels:
+      app: gcp-compute-persistent-disk-csi-driver
+  template:
+    metadata:
+{{ include "gcpdisk.labels" . | indent 6 }}
+        app: gcp-compute-persistent-disk-csi-driver
+    spec:
+      serviceAccount: csi-gce-pd-snapshot-controller-sa
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+      containers:
+        - name: csi-gce-pd-snapshot-controller
+          image: "{{ .Values.snapshotController.image.repository }}:{{ .Values.snapshotController.image.tag }}"
+          args:
+            - --v=5
+            {{- if (gt (.Values.replicasSnapshotController | int) 1) }}
+            - --leader-election=true
+            {{- end }}
+{{- end }}

--- a/stable/gcpdisk-csi-driver/templates/install-crds.yaml
+++ b/stable/gcpdisk-csi-driver/templates/install-crds.yaml
@@ -1,0 +1,87 @@
+{{- if or (gt (.Capabilities.KubeVersion.Minor | int) 17) (eq (.Capabilities.KubeVersion.Minor | int) 17) }}
+{{- if not (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: gcpdisk-csi-driver-snapshot-crds
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+data:
+  crds.yaml: |-
+{{ range $path, $_ := .Files.Glob "files/snapshot*.yaml" }}
+    ---
+{{ $.Files.Get $path | printf "%s" | indent 4 }}
+{{ end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: gcpdisk-csi-driver-snapshot-crds
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    spec:
+      serviceAccountName: gcpdisk-csi-driver-snapshot-crds
+      containers:
+        - name: gcpdisk-csi-driver-snapshot-crds
+          image: "bitnami/kubectl:1.17"
+          volumeMounts:
+            - name: gcpdisk-csi-driver-snapshot-crds
+              mountPath: /etc/gcpdisk-csi-driver-snapshot-crds
+              readOnly: true
+          command: ["kubectl", "apply", "-f", "/etc/gcpdisk-csi-driver-snapshot-crds"]
+      volumes:
+        - name: gcpdisk-csi-driver-snapshot-crds
+          configMap:
+            name: gcpdisk-csi-driver-snapshot-crds
+      restartPolicy: OnFailure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcpdisk-csi-driver-snapshot-crds
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcpdisk-csi-driver-snapshot-crds
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcpdisk-csi-driver-snapshot-crds
+subjects:
+  - kind: ServiceAccount
+    name: gcpdisk-csi-driver-snapshot-crds
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcpdisk-csi-driver-snapshot-crds
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- end }}
+{{- end }}

--- a/stable/gcpdisk-csi-driver/templates/rbac-csi-gcpdisk-controller.yaml
+++ b/stable/gcpdisk-csi-driver/templates/rbac-csi-gcpdisk-controller.yaml
@@ -26,6 +26,12 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
 
 ---
 
@@ -33,7 +39,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-gce-pd-provisioner-binding
-  namespace: {{ .Release.Namespace }}
 {{ include "gcpdisk.labels" . | indent 2 }}
 subjects:
   - kind: ServiceAccount
@@ -71,7 +76,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-gce-pd-attacher-binding
-  namespace: {{ .Release.Namespace }}
 {{ include "gcpdisk.labels" . | indent 2 }}
 subjects:
   - kind: ServiceAccount
@@ -87,55 +91,13 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-gce-pd-cluster-driver-registrar-role
-rules:
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "delete"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-gce-pd-driver-registrar-binding
-  namespace: {{ .Release.Namespace }}
-{{ include "gcpdisk.labels" . | indent 2 }}
-subjects:
-  - kind: ServiceAccount
-    name: csi-gce-pd-controller-sa
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: csi-gce-pd-cluster-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
   name: csi-gce-pd-external-snapshotter-role
 {{ include "gcpdisk.labels" . | indent 2 }}
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
+  # Secrets resource omitted since GCE PD snapshots does not require them
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -143,11 +105,8 @@ rules:
     resources: ["volumesnapshotcontents"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
 
 ---
 
@@ -155,7 +114,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-gce-pd-snapshotter-binding
-  namespace: {{ .Release.Namespace }}
 {{ include "gcpdisk.labels" . | indent 2 }}
 subjects:
   - kind: ServiceAccount
@@ -193,7 +151,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-gce-pd-resizer-binding
-  namespace: {{ .Release.Namespace }}
 {{ include "gcpdisk.labels" . | indent 2 }}
 subjects:
   - kind: ServiceAccount

--- a/stable/gcpdisk-csi-driver/templates/rbac-csi-gcpdisk-snapshot-controller.yaml
+++ b/stable/gcpdisk-csi-driver/templates/rbac-csi-gcpdisk-snapshot-controller.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-gce-pd-snapshot-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-gce-pd-snapshot-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-gce-pd-snapshot-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: csi-gce-pd-snapshot-controller-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-gce-pd-snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-gce-pd-snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-gce-pd-snapshot-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: csi-gce-pd-snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/stable/gcpdisk-csi-driver/templates/serviceaccount-csi-gcpdisk-snapshot-controller.yaml
+++ b/stable/gcpdisk-csi-driver/templates/serviceaccount-csi-gcpdisk-snapshot-controller.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-gce-pd-snapshot-controller-sa
+  namespace: {{ .Release.Namespace }}
+{{ include "gcpdisk.labels" . | indent 2 }}
+{{- end -}}

--- a/stable/gcpdisk-csi-driver/values.yaml
+++ b/stable/gcpdisk-csi-driver/values.yaml
@@ -1,6 +1,13 @@
+# replicas of the CSI-Controller
+replicas: 1
+
+# replicas of the CSI-Snapshot-Controller
+replicasSnapshotController: 1
+
 image:
   repository: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
-  tag: v0.6.0-gke.0
+  tag: v0.6.2-gke.0
+  tagK8sMinor16: v0.7.0-gke.0
   pullPolicy: Always
 
 serviceAccount:
@@ -12,25 +19,25 @@ rbac:
 # True if enable volume Topology Zone
 enableTopologyZone: true
 
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+
 liveness:
   image:
     repository: quay.io/k8scsi/livenessprobe
     tag: v1.1.0
 
 registrar:
-  cluster:
-    image:
-      repository: quay.io/k8scsi/csi-cluster-driver-registrar
-      tag: v1.0.1
   node:
     image:
       repository: quay.io/k8scsi/csi-node-driver-registrar
-      tag: v1.2.0
+      tag: v1.3.0
 
 provisioner:
   image:
     repository: quay.io/k8scsi/csi-provisioner
-    tag: v1.4.0
+    tag: v1.6.0
   timeout: 30s
   retryIntervalStart: 1s
   retryIntervalMax: 5m
@@ -39,7 +46,7 @@ provisioner:
 attacher:
   image:
     repository: quay.io/k8scsi/csi-attacher
-    tag: v2.0.0
+    tag: v2.2.0
   timeout: 120s
   retryIntervalStart: 1s
   retryIntervalMax: 5m
@@ -53,6 +60,11 @@ snapshotter:
 resizer:
   image:
     repository: quay.io/k8scsi/csi-resizer
-    tag: v0.3.0
+    tag: v0.5.0
+
+snapshotController:
+  image:
+    repository: "quay.io/k8scsi/snapshot-controller"
+    tag: v2.1.1
 
 cloudConfig: /etc/kubernetes/cloud-config/cloud.conf


### PR DESCRIPTION
- logic for same image tag being used for snapshotter as
snapshot-controller
- updated images to compatible latest
- added replicas for SnapshotController
- only leader-election enabled if replicas > 1
- added CRD install for v1beta1
- added tolerations

Notes:
atm with this an "upgrade" would fail, and there would be the need to
manual remove the v1alpha1 snapshot CRDs. Which would also purge
snapshots. This must be documented.

changes as for #580 #581

[D2IQ-68177] #comment See GitHub

[D2IQ-68177]: https://jira.d2iq.com/browse/D2IQ-68177