### PR TITLE
traefik: support extra SSL entrypoints [D2IQ-68705]

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.18
+version: 1.72.19
 appVersion: 1.7.23
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/configmap.yaml
+++ b/staging/traefik/templates/configmap.yaml
@@ -145,6 +145,51 @@ data:
         {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.extraSSLEntrypoints }}
+      {{- range $name, $e := .Values.extraSSLEntrypoints }}
+      [entryPoints.{{ $name }}]
+      {{- if $.Values.whiteListSourceRange }}
+      {{ template "traefik.whiteListSourceRange" $ }}
+      {{- end }}
+      address = {{ $e.address | quote }}
+      compress = {{ $.Values.gzip.enabled }}
+        {{- if $.Values.proxyProtocol.enabled }}
+        [entryPoints.{{ $name }}.proxyProtocol]
+        {{ template "traefik.trustedips" $ }}
+        {{- end }}
+        {{- if $.Values.forwardedHeaders.enabled }}
+        [entryPoints.{{ $name }}.forwardedHeaders]
+        {{ template "traefik.forwardedHeadersTrustedIPs" $ }}
+        {{- end }}
+        {{- if not $.Values.ssl.upstream }}
+        [entryPoints.{{ $name }}.tls]
+        [entryPoints.{{ $name }}.tls.defaultCertificate]
+        certFile = "/ssl/tls.crt"
+        keyFile = "/ssl/tls.key"
+        {{- if $.Values.ssl.tlsMinVersion }}
+        minVersion = {{ $.Values.ssl.tlsMinVersion | quote }}
+        {{- end }}
+        {{- if $.Values.ssl.cipherSuites }}
+        {{ template "traefik.ssl.cipherSuites" $ }}
+        {{- end }}
+        {{- if $.Values.ssl.sniStrict }}
+        sniStrict = true
+        {{- end }}
+          {{- if $.Values.ssl.caSecretName }}
+          [[entryPoints.{{ $name }}.tls.certificates]]
+          certFile = "/custom-ssl/tls.crt"
+          keyFile = "/custom-ssl/tls.key"
+          {{- end }}
+        {{- end }}
+        {{- if $.Values.ssl.auth }}
+        {{- if $.Values.ssl.auth.basic }}
+        [entryPoints.{{ $name }}.auth]
+          [entryPoints.{{ $name }}.auth.basic]
+            users = [{{ range $key, $value := $.Values.ssl.auth.basic }}"{{ $key }}:{{ $value }}",{{ end }}]
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.extraConfigEntrypoints }}
       {{- .Values.extraConfigEntrypoints | nindent 6 }}
       {{- end }}

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -492,6 +492,10 @@ initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.0.7
 dashboardRBAC:
   enabled: true
 
+# extraSSLEntrypoints:
+#   velero-minio:
+#     address: ":9000"
+
 # extraConfigEntrypoints: |
 # 	[entryPoints.velero]
 # 		address = ":9000"


### PR DESCRIPTION
This change improves the charts by allowing extra SSL entrypoints being
defined, and inherit SSL configurations from global SSL config. We
observed that in some customer environment, they are using advanced
configurations for their ingress, including turning on proxy protocol on
the ingress.

Previously, we use `extraConfigEntrypoints` to add the additional velero
minio entrypoints for the velero addon. This basically means if they
have any customization on the ingress entrypoint, we'll have to ask them
to manually specifying those configs `extraConfigEntrypoints` again for
the velero-minio entrypoint, which creates a very bad user experience.

This patch improves this experiecne by introducing `extraSSLEntrypoints`
that will inherit global configurations so that the user does not have
to do anything on the additional entrypoints.

This has been tested with the following cases:

1. Empty `extraSSLEntrypoints`.

myvalue.yaml:

```yaml
ssl:
  enabled: true
  enforced: true
  insecureSkipVerify: true
  useCertManager: true
  caSecretName: acme-certs
```

Resultant configmap:

```toml
[entryPoints]
  [entryPoints.http]
  address = ":80"
  compress = true
    [entryPoints.http.redirect]
      regex = "^http://(.*)"
      replacement = "https://$1"
  [entryPoints.https]
  address = ":443"
  compress = true
    [entryPoints.https.tls]
    [entryPoints.https.tls.defaultCertificate]
    certFile = "/ssl/tls.crt"
    keyFile = "/ssl/tls.key"
      [[entryPoints.https.tls.certificates]]
      certFile = "/custom-ssl/tls.crt"
      keyFile = "/custom-ssl/tls.key"
```

2. Add the velero-minio entrypoint.

myvalue.yaml:

```yaml
ssl:
  enabled: true
  enforced: true
  insecureSkipVerify: true
  useCertManager: true
  caSecretName: acme-certs
extraServicePorts:
  - name: velero-minio
    port: 9000
    protocol: TCP
    targetPort: 9000
proxyProtocol:
  enabled: true
  trustedIPs:
  - "10.0.0.0/8"
  - "192.168.0.0/16"
forwardedHeaders:
  enabled: true
  trustedIPs:
  - "10.0.0.0/8"
  - "192.168.0.0/16"
extraSSLEntrypoints:
  velero-minio:
    address: ":9000"
```

Resultant configmap:

```toml
[entryPoints]
  [entryPoints.http]
  address = ":80"
  compress = true
    [entryPoints.http.proxyProtocol]
    trustedIPs = ["10.0.0.0/8", "192.168.0.0/16"]
    [entryPoints.http.forwardedHeaders]
    trustedIPs = ["10.0.0.0/8", "192.168.0.0/16"]
    [entryPoints.http.redirect]
      regex = "^http://(.*)"
      replacement = "https://$1"
  [entryPoints.https]
  address = ":443"
  compress = true
    [entryPoints.https.proxyProtocol]
    trustedIPs = ["10.0.0.0/8", "192.168.0.0/16"]
    [entryPoints.https.forwardedHeaders]
    trustedIPs = ["10.0.0.0/8", "192.168.0.0/16"]
    [entryPoints.https.tls]
    [entryPoints.https.tls.defaultCertificate]
    certFile = "/ssl/tls.crt"
    keyFile = "/ssl/tls.key"
      [[entryPoints.https.tls.certificates]]
      certFile = "/custom-ssl/tls.crt"
      keyFile = "/custom-ssl/tls.key"
  [entryPoints.velero-minio]
  address = ":9000"
  compress = true
    [entryPoints.velero-minio.proxyProtocol]
    trustedIPs = ["10.0.0.0/8", "192.168.0.0/16"]
    [entryPoints.velero-minio.forwardedHeaders]
    trustedIPs = ["10.0.0.0/8", "192.168.0.0/16"]
    [entryPoints.velero-minio.tls]
    [entryPoints.velero-minio.tls.defaultCertificate]
    certFile = "/ssl/tls.crt"
    keyFile = "/ssl/tls.key"
      [[entryPoints.velero-minio.tls.certificates]]
      certFile = "/custom-ssl/tls.crt"
      keyFile = "/custom-ssl/tls.key"
```