### PR TITLE
kubeaddons-catalog: add env support

### DIFF
--- a/staging/kubeaddons-catalog/Chart.yaml
+++ b/staging/kubeaddons-catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.8.3"
 description: "A Catalog service for Kubeaddons"
 name: kubeaddons-catalog
-version: 0.1.8
+version: 0.1.9
 home: https://github.com/mesosphere/kommander-catalog-api
 sources:
 - https://github.com/mesosphere/kommander-catalog-api

--- a/staging/kubeaddons-catalog/templates/deployment.yaml
+++ b/staging/kubeaddons-catalog/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ tpl $value $ | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/staging/kubeaddons-catalog/values.yaml
+++ b/staging/kubeaddons-catalog/values.yaml
@@ -31,3 +31,5 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+env: {}


### PR DESCRIPTION
Allow users to specify environment variables for the container (e.g.,
setting up proxy related environment variables).

Tested with this values file:

```yaml
env:
  foo: bar
  zoo: now
```

Result:

```yaml
env:
  - name: "foo"
    value: "bar"
  - name: "zoo"
    value: "now"
```