### PR TITLE
fix: gcpdisk-csi-driver old snapshotter

### DIFF
--- a/stable/gcpdisk-csi-driver/Chart.yaml
+++ b/stable/gcpdisk-csi-driver/Chart.yaml
@@ -4,7 +4,7 @@ description: Google Compute Engine Persistent Disk (GCE PD) Container Storage In
 name: gcpdisk-csi-driver
 maintainers:
   - name: sebbrandt87
-version: 0.7.0
+version: 0.7.1
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
 sources:

--- a/stable/gcpdisk-csi-driver/templates/csi-gcpdisk-controller.yaml
+++ b/stable/gcpdisk-csi-driver/templates/csi-gcpdisk-controller.yaml
@@ -53,7 +53,9 @@ spec:
           args:
             - --v=5
             - --csi-address=$(ADDRESS)
+            {{- if or (gt (.Capabilities.KubeVersion.Minor | int) 17) (eq (.Capabilities.KubeVersion.Minor | int) 17) }}
             - --metrics-address=:22014
+            {{- end }}
             {{- if (gt (.Values.replicas | int) 1) }}
             - --leader-election=true
             {{- end }}

--- a/stable/gcpdisk-csi-driver/templates/rbac-csi-gcpdisk-controller.yaml
+++ b/stable/gcpdisk-csi-driver/templates/rbac-csi-gcpdisk-controller.yaml
@@ -107,6 +107,18 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
+  # This is just for the older snapshotter version needed
+  {{- if or (lt (.Capabilities.KubeVersion.Minor | int) 16) (eq (.Capabilities.KubeVersion.Minor | int) 16) }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  {{- end }}
 
 ---
 


### PR DESCRIPTION
- accidently we lost old snapshotter 
functionality
- set metrics address not for old snapshotter
version
- readded back needed permissions for old 
snapshotter version

```
STAGE [Deploying Enabled Addons]
gatekeeper                                                             [OK]
velero                                                                 [OK]
defaultstorageclass-protection                                         [OK]
kube-oidc-proxy                                                        [OK]
traefik-forward-auth                                                   [OK]
konvoyconfig                                                           [OK]
dashboard                                                              [OK]
prometheus                                                             [OK]
dex                                                                    [OK]
kibana                                                                 [OK]
opsportal                                                              [OK]
elasticsearch                                                          [OK]
prometheusadapter                                                      [OK]
dex-k8s-authenticator                                                  [OK]
elasticsearch-curator                                                  [OK]
cert-manager                                                           [OK]
gcpdisk-csi-driver                                                     [OK]
fluentbit                                                              [OK]
reloader                                                               [OK]
traefik                                                                [OK]
elasticsearchexporter                                                  [OK]
gcpdiskprovisioner                                                     [OK]
```

```
NAMESPACE    NAME                                                                                                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
kommander    kommander-kubeaddons-cost-analyzer                                                                       Bound    pvc-47116c96-b83d-475f-95b6-5a738544d5db   1Gi        RWO            gcpdiskprovisioner   3m31s
kommander    kommander-kubeaddons-prometheus-alertmanager                                                             Bound    pvc-2be6ebc3-90eb-45fd-a400-40e11ef0e264   2Gi        RWO            gcpdiskprovisioner   3m31s
kommander    kommander-kubeaddons-prometheus-server                                                                   Bound    pvc-065dd9f2-9e6b-4f20-acd5-4a4f322cf46a   32Gi       RWO            gcpdiskprovisioner   3m31s
kubeaddons   data-elasticsearch-kubeaddons-data-0                                                                     Bound    pvc-5cd83a5b-9d8f-4db5-9aad-b06bdbcbfd02   30Gi       RWO            gcpdiskprovisioner   38m
kubeaddons   data-elasticsearch-kubeaddons-data-1                                                                     Bound    pvc-a27a02cc-6adc-4820-9ae9-94ddd20b69e7   30Gi       RWO            gcpdiskprovisioner   35m
kubeaddons   data-elasticsearch-kubeaddons-master-0                                                                   Bound    pvc-78c78cf2-5ac6-45ba-99e8-f52ea067e840   4Gi        RWO            gcpdiskprovisioner   38m
kubeaddons   data-elasticsearch-kubeaddons-master-1                                                                   Bound    pvc-8e204a76-c890-4779-b023-aebb9bdca804   4Gi        RWO            gcpdiskprovisioner   37m
kubeaddons   data-elasticsearch-kubeaddons-master-2                                                                   Bound    pvc-6df51f04-a9d0-46c7-b025-32b0c17b6813   4Gi        RWO            gcpdiskprovisioner   36m
kubeaddons   prometheus-prometheus-kubeaddons-prom-prometheus-db-prometheus-prometheus-kubeaddons-prom-prometheus-0   Bound    pvc-5872fc64-5ad5-42e9-942d-1fceba43d022   50Gi       RWO            gcpdiskprovisioner   37m
velero       data-minio-0                                                                                             Bound    pvc-7d507b9f-a4e9-47e6-8b4f-0d3693f13225   10Gi       RWO            gcpdiskprovisioner   37m
velero       data-minio-1                                                                                             Bound    pvc-0badfaa6-3997-4204-951e-03826b2346e5   10Gi       RWO            gcpdiskprovisioner   37m
velero       data-minio-2                                                                                             Bound    pvc-8dc94681-b162-4166-bb9e-cf5f19cf214c   10Gi       RWO            gcpdiskprovisioner   37m
velero       data-minio-3                                                                                             Bound    pvc-49ba5d03-a85c-44b9-aa5f-113f66179d51   10Gi       RWO            gcpdiskprovisioner   37m
```

```
I0529 08:30:12.345178       1 main.go:89] Version: v1.2.2-0-gd5da3c1e
I0529 08:30:12.364419       1 connection.go:151] Connecting to unix:///csi/csi.sock
I0529 08:30:14.220418       1 connection.go:180] GRPC call: /csi.v1.Identity/GetPluginInfo
I0529 08:30:14.220435       1 connection.go:181] GRPC request: {}
I0529 08:30:14.222027       1 connection.go:183] GRPC response: {"name":"pd.csi.storage.gke.io","vendor_version":"v0.7.0-gke.0"}
I0529 08:30:14.222544       1 connection.go:184] GRPC error: <nil>
I0529 08:30:14.222553       1 main.go:156] CSI driver name: "pd.csi.storage.gke.io"
I0529 08:30:14.222562       1 common.go:111] Probing CSI driver for readiness
I0529 08:30:14.222569       1 connection.go:180] GRPC call: /csi.v1.Identity/Probe
I0529 08:30:14.222573       1 connection.go:181] GRPC request: {}
I0529 08:30:14.223223       1 connection.go:183] GRPC response: {}
I0529 08:30:14.223643       1 connection.go:184] GRPC error: <nil>
I0529 08:30:14.223652       1 connection.go:180] GRPC call: /csi.v1.Controller/ControllerGetCapabilities
I0529 08:30:14.223657       1 connection.go:181] GRPC request: {}
I0529 08:30:14.224486       1 connection.go:183] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":2}}},{"Type":{"Rpc":{"type":5}}},{"Type":{"Rpc":{"type":6}}},{"Type":{"Rpc":{"type":8}}},{"Type":{"Rpc":{"
type":9}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":10}}}]}
I0529 08:30:14.228615       1 connection.go:184] GRPC error: <nil>
I0529 08:30:14.228628       1 main.go:180] Start NewCSISnapshotController with snapshotter [pd.csi.storage.gke.io] kubeconfig [] connectionTimeout [0s] csiAddress [/csi/csi.sock] createSnapshotContentRetryCount [824634013504] createSnapsh
otContentInterval [10s] resyncPeriod [1m0s] snapshotNamePrefix [snapshot] snapshotNameUUIDLength [824634013544]
I0529 08:30:14.228998       1 snapshot_controller_base.go:148] Starting CSI snapshotter
I0529 08:30:14.229154       1 reflector.go:123] Starting reflector *v1alpha1.VolumeSnapshotContent (1m0s) from github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions/factory.go:117
I0529 08:30:14.229184       1 reflector.go:161] Listing and watching *v1alpha1.VolumeSnapshotContent from github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions/factory.go:117
I0529 08:30:14.229186       1 reflector.go:123] Starting reflector *v1.PersistentVolumeClaim (1m0s) from k8s.io/client-go/informers/factory.go:133
I0529 08:30:14.229213       1 reflector.go:161] Listing and watching *v1.PersistentVolumeClaim from k8s.io/client-go/informers/factory.go:133
I0529 08:30:14.229231       1 reflector.go:123] Starting reflector *v1alpha1.VolumeSnapshotClass (1m0s) from github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions/factory.go:117
I0529 08:30:14.229249       1 reflector.go:161] Listing and watching *v1alpha1.VolumeSnapshotClass from github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions/factory.go:117
I0529 08:30:14.229261       1 reflector.go:123] Starting reflector *v1alpha1.VolumeSnapshot (1m0s) from github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions/factory.go:117
I0529 08:30:14.229278       1 reflector.go:161] Listing and watching *v1alpha1.VolumeSnapshot from github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions/factory.go:117
I0529 08:30:14.329234       1 shared_informer.go:123] caches populated
I0529 08:30:14.329277       1 snapshot_controller_base.go:492] controller initialized
```