### PR TITLE
fix: azuredisk-csi-driver

### DIFF
--- a/stable/azuredisk-csi-driver/Chart.yaml
+++ b/stable/azuredisk-csi-driver/Chart.yaml
@@ -5,7 +5,7 @@ name: azuredisk-csi-driver
 maintainers:
   - name: sebbrandt87
   - name: hectorj2f
-version: 0.7.0
+version: 0.7.1
 kubeVersion: ">=1.15.0"
 home: https://github.com/kubernetes-sigs/azuredisk-csi-driver
 sources:

--- a/stable/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/stable/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -106,7 +106,7 @@ spec:
             - mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
               name: msi
-            - mountPath: /devhost #use /devhost to avoid conflict
+            - mountPath: /dev
               name: device-dir
             - mountPath: /sys/bus/scsi/devices
               name: sys-devices-dir

--- a/stable/azuredisk-csi-driver/templates/rbac-csi-azuredisk-controller.yaml
+++ b/stable/azuredisk-csi-driver/templates/rbac-csi-azuredisk-controller.yaml
@@ -69,7 +69,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]


### PR DESCRIPTION
- they changed to check only /dev insteaf of /devhost
(which was what the driver did before)
- added needed permissions csi-attacher

```
I0529 13:34:18.236308       1 utils.go:119] GRPC response: capabilities:<rpc:<type:STAGE_UNSTAGE_VOLUME > > capabilities:<rpc:<type:EXPAND_VOLUME > > capabilities:<rpc:<type:GET_VOLUME_STATS > >
I0529 13:34:18.241424       1 utils.go:112] GRPC call: /csi.v1.Node/NodePublishVolume
I0529 13:34:18.241489       1 utils.go:113] GRPC request: volume_id:"/subscriptions/b1ed8f2f-ceda-41d5-a0a8-95960b5340c2/resourceGroups/sbrandt-konvoy-93fa-rg/providers/Microsoft.Compute/disks/pvc-58b1803c-96cb-475a-8501-791832a002dc" publish_context:<key:"LUN" value:"1" > staging_target_path:"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-58b1803c-96cb-475a-8501-791832a002dc/globalmount" target_path:"/var/lib/kubelet/pods/458f6b1f-c3c0-4a6a-b424-3f620d081bcf/volumes/kubernetes.io~csi/pvc-58b1803c-96cb-475a-8501-791832a002dc/mount" volume_capability:<mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > > volume_context:<key:"cachingMode" value:"ReadOnly" > volume_context:<key:"csi.storage.k8s.io/ephemeral" value:"false" > volume_context:<key:"csi.storage.k8s.io/pod.name" value:"prometheus-prometheus-kubeaddons-prom-prometheus-0" > volume_context:<key:"csi.storage.k8s.io/pod.namespace" value:"kubeaddons" > volume_context:<key:"csi.storage.k8s.io/pod.uid" value:"458f6b1f-c3c0-4a6a-b424-3f620d081bcf" > volume_context:<key:"csi.storage.k8s.io/serviceAccount.name" value:"prometheus-kubeaddons-prom-prometheus" > volume_context:<key:"kind" value:"Managed" > volume_context:<key:"skuname" value:"" > volume_context:<key:"storage.kubernetes.io/csiProvisionerIdentity" value:"1590759075417-8081-disk.csi.azure.com" >
I0529 13:34:18.241519       1 nodeserver.go:157] NodePublishVolume: called with args {VolumeId:/subscriptions/b1ed8f2f-ceda-41d5-a0a8-95960b5340c2/resourceGroups/sbrandt-konvoy-93fa-rg/providers/Microsoft.Compute/disks/pvc-58b1803c-96cb-475a-8501-791832a002dc PublishContext:map[LUN:1] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-58b1803c-96cb-475a-8501-791832a002dc/globalmount TargetPath:/var/lib/kubelet/pods/458f6b1f-c3c0-4a6a-b424-3f620d081bcf/volumes/kubernetes.io~csi/pvc-58b1803c-96cb-475a-8501-791832a002dc/mount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[cachingMode:ReadOnly csi.storage.k8s.io/ephemeral:false csi.storage.k8s.io/pod.name:prometheus-prometheus-kubeaddons-prom-prometheus-0 csi.storage.k8s.io/pod.namespace:kubeaddons csi.storage.k8s.io/pod.uid:458f6b1f-c3c0-4a6a-b424-3f620d081bcf csi.storage.k8s.io/serviceAccount.name:prometheus-kubeaddons-prom-prometheus kind:Managed skuname: storage.kubernetes.io/csiProvisionerIdentity:1590759075417-8081-disk.csi.azure.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0529 13:34:18.241605       1 nodeserver.go:207] NodePublishVolume: mounting /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-58b1803c-96cb-475a-8501-791832a002dc/globalmount at /var/lib/kubelet/pods/458f6b1f-c3c0-4a6a-b424-3f620d081bcf/volumes/kubernetes.io~csi/pvc-58b1803c-96cb-475a-8501-791832a002dc/mount
I0529 13:34:18.241657       1 mount_linux.go:142] Mounting cmd (mount) with arguments ([-o bind /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-58b1803c-96cb-475a-8501-791832a002dc/globalmount /var/lib/kubelet/pods/458f6b1f-c3c0-4a6a-b424-3f620d081bcf/volumes/kubernetes.io~csi/pvc-58b1803c-96cb-475a-8501-791832a002dc/mount])
I0529 13:34:18.243525       1 mount_linux.go:142] Mounting cmd (mount) with arguments ([-o bind,remount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-58b1803c-96cb-475a-8501-791832a002dc/globalmount /var/lib/kubelet/pods/458f6b1f-c3c0-4a6a-b424-3f620d081bcf/volumes/kubernetes.io~csi/pvc-58b1803c-96cb-475a-8501-791832a002dc/mount])
I0529 13:34:18.245539       1 nodeserver.go:211] NodePublishVolume: mount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-58b1803c-96cb-475a-8501-791832a002dc/globalmount at /var/lib/kubelet/pods/458f6b1f-c3c0-4a6a-b424-3f620d081bcf/volumes/kubernetes.io~csi/pvc-58b1803c-96cb-475a-8501-791832a002dc/mount successfully
```

```
I0529 13:32:29.789120       1 csi_handler.go:219] Error processing "csi-76166479a4fc0ba0a34e283a43c891f6f7729b002e153daf45d785952662e238": failed to attach: could not save VolumeAttachment: volumeattachments.storage.k8s.io "csi-76166479a4
fc0ba0a34e283a43c891f6f7729b002e153daf45d785952662e238" is forbidden: User "system:serviceaccount:kube-system:csi-azuredisk-controller-sa" cannot patch resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
I0529 13:32:34.793492       1 leaderelection.go:283] successfully renewed lease kube-system/external-attacher-leader-disk-csi-azure-com                                                                                                       I0529 13:32:39.799456       1 leaderelection.go:283] successfully renewed lease kube-system/external-attacher-leader-disk-csi-azure-com                                                                                                       I0529 13:32:44.530244       1 controller.go:198] Started VA processing "csi-b09b36c9f956fa1882bb1555e2fdf15684f844816d1624e41b6c2db438cff0c5"
I0529 13:32:44.530272       1 csi_handler.go:209] CSIHandler: processing VA "csi-b09b36c9f956fa1882bb1555e2fdf15684f844816d1624e41b6c2db438cff0c5"
I0529 13:32:44.530282       1 csi_handler.go:236] Attaching "csi-b09b36c9f956fa1882bb1555e2fdf15684f844816d1624e41b6c2db438cff0c5"
I0529 13:32:44.530292       1 csi_handler.go:396] Starting attach operation for "csi-b09b36c9f956fa1882bb1555e2fdf15684f844816d1624e41b6c2db438cff0c5"
I0529 13:32:44.530363       1 csi_handler.go:335] Adding finalizer to PV "pvc-58b1803c-96cb-475a-8501-791832a002dc"
I0529 13:32:44.533776       1 csi_handler.go:344] PV finalizer added to "pvc-58b1803c-96cb-475a-8501-791832a002dc"
I0529 13:32:44.533801       1 csi_handler.go:689] Found NodeID worker-5-sbrandt-konvoy-93fa in CSINode worker-5-sbrandt-konvoy-93fa
I0529 13:32:44.533830       1 csi_handler.go:297] VA finalizer added to "csi-b09b36c9f956fa1882bb1555e2fdf15684f844816d1624e41b6c2db438cff0c5"
I0529 13:32:44.533842       1 csi_handler.go:311] NodeID annotation added to "csi-b09b36c9f956fa1882bb1555e2fdf15684f844816d1624e41b6c2db438cff0c5"
I0529 13:32:44.539725       1 connection.go:182] GRPC call: /csi.v1.Controller/ControllerPublishVolume
I0529 13:32:44.539741       1 connection.go:183] GRPC request: {"node_id":"worker-5-sbrandt-konvoy-93fa","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}},"volume_context":{"cachingMode":"ReadOnly","
kind":"Managed","skuname":"","storage.kubernetes.io/csiProvisionerIdentity":"1590759075417-8081-disk.csi.azure.com"},"volume_id":"/subscriptions/b1ed8f2f-ceda-41d5-a0a8-95960b5340c2/resourceGroups/sbrandt-konvoy-93fa-rg/providers/Microsof
t.Compute/disks/pvc-58b1803c-96cb-475a-8501-791832a002dc"}
```

```
STAGE [Deploying Enabled Addons]
konvoyconfig                                                           [OK]
azurediskprovisioner                                                   [OK]
reloader                                                               [OK]
dashboard                                                              [OK]
azuredisk-csi-driver                                                   [OK]
opsportal                                                              [OK]
cert-manager                                                           [OK]
defaultstorageclass-protection                                         [OK]
gatekeeper                                                             [OK]
traefik                                                                [OK]
prometheus                                                             [OK]
dex                                                                    [OK]
prometheusadapter                                                      [OK]
kube-oidc-proxy                                                        [OK]
traefik-forward-auth                                                   [OK]
dex-k8s-authenticator                                                  [OK]
velero                                                                 [OK]
kommander                                                              [OK]
elasticsearch                                                          [OK]
elasticsearch-curator                                                  [OK]
elasticsearchexporter                                                  [OK]
fluentbit                                                              [OK]
kibana                                                                 [OK]
```