### PR TITLE
kommander: Override kubecost component names

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -65,3 +65,4 @@ dindTask("test", inputs=[git], deps=["lint"], steps=[
 
 action(tasks=["test"], on=pullRequest(branches=["*"]))
 action(tasks=["publish"], on=push(branches=["master"]))
+action(tasks = ["test"], on = pullRequest(chatops = ["test"]))

--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.8.12
+version: 0.8.13

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -193,6 +193,7 @@ kubecost:
 
   cost-analyzer:
     enabled: true
+    fullnameOverride: "kommander-kubecost-cost-analyzer"
     global:
       prometheus:
         # If false, Prometheus will not be installed -- only actively supported on paid Kubecost plans
@@ -236,6 +237,15 @@ kubecost:
           defaultDatasourceEnabled: false
           # dataSourceName: KubecostPrometheus
           label: grafana_datasource_kommander
+
+    prometheus:
+      fullnameOverride: "kommander-kubecost-prometheus"
+      server:
+        fullnameOverride: "kommander-kubecost-prometheus-server"
+      alertmanager:
+        fullnameOverride: "kommander-kubecost-prometheus-alertmanager"
+      kube-state-metrics:
+        fullnameOverride: "kommander-kubecost-prometheus-kube-state-metrics"
 
     thanos:
       fullnameOverride: "kommander-kubecost-thanos"


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-68887
We should override kommander kubecost component names to include "kubecost" in the name to make it clear which components are deployed as part of kubecost.

## Testing
Tested by hosting the chart and deploying it.
```
$ k get deployments -nkommander | grep kommander-
kommander-kubeaddons-grafana                       1/1     1            1           69s
kommander-kubeaddons-karma                         0/1     1            0           69s
kommander-kubeaddons-kommander-ui                  0/1     1            0           69s
kommander-kubeaddons-kubeaddons-catalog            1/1     1            1           69s
kommander-kubeaddons-thanos-query                  0/1     1            0           69s
kommander-kubecost-cost-analyzer                   0/1     1            0           69s
kommander-kubecost-prometheus-alertmanager         0/1     1            0           69s
kommander-kubecost-prometheus-kube-state-metrics   1/1     1            1           69s
kommander-kubecost-prometheus-server               1/1     1            1           69s
kommander-kubecost-thanos-query                    1/1     1            1           69s
```
All kubecost components are prefixed with `kommander-kubecost` instead of `kommander-kubeaddons`