### PR TITLE
[kommander] Rewrite Kubecost URL to include trailing slash

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.8.15
+version: 0.8.16

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -214,7 +214,10 @@ kubecost:
       annotations:
         kubernetes.io/ingress.class: traefik
         ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
-        traefik.frontend.rule.type: PathPrefixStrip
+        traefik.frontend.rule.type: "PathPrefix"
+        traefik.frontend.redirect.regex: "^(.*)/ops/portal/kommander/kubecost$"
+        traefik.frontend.redirect.replacement: "$1/ops/portal/kommander/kubecost/"
+        traefik.ingress.kubernetes.io/request-modifier: 'ReplacePathRegex: ^/ops/portal/kommander/kubecost/(.*) /$1'
         traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
         traefik.ingress.kubernetes.io/auth-type: forward
         traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-68100

Kubecost assumes its URL has a trailing slash. If served without a trailing slash, the web app doesn't work. This PR causes Traefik to redirect `/ops/portal/kommander/kubecost` to `/ops/portal/kommander/kubecost/` so that Kubecost's URL always has a trailing slash.

## Testing

I tested this PR by deploying a Konvoy cluster with the kommander addon disabled, then installing a local copy of this branch's kommander chart with the chart values defined in the kommander addon. Then I browsed to `/ops/portal/kommander/kubecost`, saw that I was redirected to `/ops/portal/kommander/kubecost/`, and saw that the resulting Kubecost page listed this cluster and its projected cost.