### PR TITLE
kommander: update ingress priority for Grafana

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.8.18
+version: 0.8.19

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -83,7 +83,7 @@ grafana:
       traefik.ingress.kubernetes.io/auth-response-headers: "X-Forwarded-User"
       traefik.ingress.kubernetes.io/auth-type: "forward"
       traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
-      traefik.ingress.kubernetes.io/priority: "2"
+      traefik.ingress.kubernetes.io/priority: "4"
 
     ## Labels to be added to the Ingress
     ##


### PR DESCRIPTION
This is now set at the same value as for karma, `4`.
This resolves the bug https://jira.d2iq.com/browse/D2IQ-68570
which was making Grafana inacessible from the Kommander UI
after self-attaching a Konvoy cluster.

This change was tested manually by updating the ingress
kommander-kubeaddons-grafana on a running Konvoy
cluster after self-attachment.