### PR TITLE
kommander: do not recreate the kubecost-query-stores configmap on upgrade

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.8.22
+version: 0.8.23

--- a/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
+++ b/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
 {{ $labels }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
 data:
   stores.yaml: |-


### PR DESCRIPTION
Fixes https://jira.d2iq.com/browse/D2IQ-69505

Note: If the configmap already exists and has the `pre-upgrade` hook annotation, the annotation will remain, because the configmap will not be deleted/re-created during the upgrade. This seems correct, but also non-intuitive, and I'm still trying to understand it.