### PR TITLE
fix: traefik job name must be unique for upgrades to succeed

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.19
+version: 1.72.20
 appVersion: 1.7.23
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/init-cert-job.yaml
+++ b/staging/traefik/templates/init-cert-job.yaml
@@ -7,9 +7,7 @@ metadata:
   # certificate object is a helm hook, and will be re-created during
   # an upgrade. See more details in:
   # https://github.com/helm/helm/issues/5482
-  name: {{ include "traefik.fullname" . }}-{{ .Chart.Version }}
-  annotations:
-    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+  name: {{ include "traefik.fullname" . }}-{{ .Chart.Version }}-{{ randAlphaNum 5 | lower }}
   labels:
     chart: {{ template "traefik.chart" . }}
     app: {{ template "traefik.name" . }}


### PR DESCRIPTION
Otherwise, Helm will try to patch the last job and K8s doesn't allow that for certain fields (e.g. the image field is immutable).

Upon an upgrade of the release comprised of this chart, the previous job will get removed. Thus, we won't be having old jobs hanging around on clusters.

This is how I tested this:

1. Spin up a Konvoy cluster with all Addons except cert-manager disabled
1. From the `staging/traefik` directory of the [mesosphere/charts](https://github.com/mesosphere/charts) repo, install the traefik chart:
   ```
   helm install --name traefik-kubeaddons --namespace kubeaddons -f values-override.yaml .
   ```
   The contents of the `values-override.yaml` file can be derived directly from the [traefik Addon](https://github.com/mesosphere/kubernetes-base-addons/tree/master/addons/traefik/1.7.x), with one change:
   ```
   initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.2.9
   ```
1. Wait for the Helm release to be deployed
1. run `kubectl -n kubeaddons get jobs` and see that there is one job from that release.
1. Then change the `initCertJobImage` field in the `values-override.yaml` to:
   ```
   initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.2.10
   ```
1. Upgrade the release:
   ```
   helm upgrade traefik-kubeaddons -f values-override.yaml .
   ```
1. The upgrade should succeed. Then check the jobs again: `kubectl -n kubeaddons get jobs`. There should still be only one job (the latest).