### PR TITLE
fix: increase priority of kommander-kubecost-thanos ingress

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.8.23
+version: 0.8.24

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -273,7 +273,7 @@ kubecost:
               traefik.ingress.kubernetes.io/auth-response-headers: "X-Forwarded-User"
               traefik.ingress.kubernetes.io/auth-type: "forward"
               traefik.ingress.kubernetes.io/auth-url: "http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/"
-              traefik.ingress.kubernetes.io/priority: "2"
+              traefik.ingress.kubernetes.io/priority: "4"
             path: "/ops/portal/kommander/kubecost/query"
             hosts:
               - ""


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
Allows /kubecost/query to be matched prior to the /kubecost/(.*) regex in
kommander-kubecost-cost-analyzer ingress.

**Which issue(s) this PR fixes**:
Fixes https://jira.d2iq.com/browse/D2IQ-69510

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
