### PR TITLE
prometheus-operator: Fix KubePodNotReady prometheus rule

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.13
+version: 8.13.14
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -37,10 +37,17 @@ spec:
       annotations:
         message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been in a non-ready state for longer than 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
+      expr: |-
+        sum by (namespace, pod) (
+          max by(namespace, pod) (
+            kube_pod_status_phase{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", phase=~"Pending|Unknown"}
+          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+          )
+        ) > 0
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         message: Deployment generation for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} does not match, this indicates that the Deployment has failed but has not been rolled back.


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
We started seeing a lot of rule evaluation errors in SOAK:
```
level=warn ts=2020-06-23T16:59:50.051Z caller=manager.go:570 component="rule manager" group=kubernetes-apps msg="Evaluating rule failed" rule="alert: KubePodNotReady\nexpr: sum by(namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job=\"kube-state-metrics\",namespace=~\".*\",phase=~\"Pending|Unknown\"})\n  * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!=\"Job\"}))\n  > 0\nfor: 15m\nlabels:\n  severity: critical\nannotations:\n  message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state\n    for longer than 15 minutes.\n  runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready\n" err="found duplicate series for the match group {namespace=\"kubeaddons\", pod=\"prometheus-kubeaddons-kube-state-metrics-6599df558b-v4xtp\"} on the right hand-side of the operation: [{namespace=\"kubeaddons\", owner_kind=\"StatefulSet\", pod=\"prometheus-kubeaddons-kube-state-metrics-6599df558b-v4xtp\"}, {namespace=\"kubeaddons\", owner_kind=\"DaemonSet\", pod=\"prometheus-kubeaddons-kube-state-metrics-6599df558b-v4xtp\"}];many-to-many matching not allowed: matching labels must be unique on one side"
```
I traced this back to an error in the rule which was fixed in the upstream kubernetes-mixin repo here:https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/417. However this fix has not yet been synced to upstream chart. Since we need to get this fixed in SOAK ASAP, we are making a one-off manual update here to fix this specific rule.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
