### PR TITLE
feat: adds caSecretName key to konvoyconfig

### DIFF
--- a/staging/konvoyconfig/Chart.yaml
+++ b/staging/konvoyconfig/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 0.0.1
 description: "Adds a ConfigMap to the kubeaddons namespace containing the values provided to this chart"
 name: konvoyconfig
 home: https://github.com/mesosphere/charts
-version: 0.0.3
+version: 0.0.4
 keywords:
   - konvoy
   - kommander

--- a/staging/konvoyconfig/templates/configmap.yaml
+++ b/staging/konvoyconfig/templates/configmap.yaml
@@ -14,12 +14,15 @@ data:
   {{- if .Values.config.externalDex }}
   externalDex: {{ toYaml .Values.config.externalDex | nindent 4 }}
   {{- end }}
+  {{- if .Values.config.caSecretName }}
+  caSecretName: {{ .Values.config.caSecretName }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: konvoy-kubeaddons
-  namespace: kubeaddons
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: kubeaddons
     app.kubernetes.io/component: controller
@@ -41,4 +44,7 @@ metadata:
     issuerURL: {{ .Values.clusterIssuerURL }}
     {{- else if .Values.clusterIssuerHostname }}
     issuerURL: https://{{ .Values.clusterIssuerHostname }}/dex
+    {{- end }}
+    {{- if .Values.config.caSecretName }}
+    caSecretName: {{ .Values.config.caSecretName }}
     {{- end }}

--- a/staging/konvoyconfig/values.yaml
+++ b/staging/konvoyconfig/values.yaml
@@ -25,3 +25,7 @@ config:
 # It's possible to set the full Dex issuer URL, however, this is usually not
 # necessary. Only use this if you know what you are doing.
 # clusterIssuerURL: https://name1.example.com/custom/dex
+
+# caSecretName takes the name of the secret that holds the CA bundle for the
+# custom certificate.
+# caSecretName: custom-cert


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
This PR adds a new field to konvoyconfig addon to take a secret name which holds custom certificate CA bundle. This is needed by Kommander to populate appropriate CA bundle in the federated addons. In order to do that it needs to know the name of the secret that holds the CA bundle.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/COPS-6173

**Special notes for your reviewer**:
related to https://github.com/mesosphere/yakcl/pull/101

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
konvoyconfig has a new field `caSecretName` to support custom certificate in managed cluster
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
