### PR TITLE
fix: update release label in service monitors

### DIFF
--- a/staging/istio/Chart.yaml
+++ b/staging/istio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio
-version: 1.6.3
+version: 1.6.4
 appVersion: 1.6.3
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for istio

--- a/staging/istio/charts/prometheus-operator/templates/servicemonitors.yaml
+++ b/staging/istio/charts/prometheus-operator/templates/servicemonitors.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-proxies
-    release: {{ .Release.Name }}
+    release: prometheus-kubeaddons
 spec:
   selector:
     matchExpressions:
@@ -38,7 +38,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-pods
-    release: {{ .Release.Name }}
+    release: prometheus-kubeaddons
 spec:
   selector:
     matchExpressions:
@@ -83,7 +83,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-services
-    release: {{ .Release.Name }}
+    release: prometheus-kubeaddons
 spec:
   selector:
     matchExpressions:

--- a/staging/istio/charts/security/templates/istio-cacert-job.yaml
+++ b/staging/istio/charts/security/templates/istio-cacert-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cacert-job-{{ .Values.tag | printf "%v" | trunc 32 }}
+  name: cacert-job-{{ randAlphaNum 5 | lower }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
Adds the right `release` label on the service monitor

**Which issue(s) this PR fixes**:
 no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
