### PR TITLE
traefik: revert change to include extraServicePorts for velero and metrics

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.22
+version: 1.72.23
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/service.yaml
+++ b/staging/traefik/templates/service.yaml
@@ -56,3 +56,11 @@ spec:
     nodePort: {{ .Values.service.nodePorts.http }}
     {{- end }}
     targetPort: http
+  {{- if (and (.Values.metrics.prometheus.enabled) (not (.Values.metrics.prometheus.restrictAccess)))}}
+  - port: 8080
+    name: metrics
+    targetPort: dash
+  {{- end }}
+  {{- if .Values.extraServicePorts }}
+  {{- toYaml .Values.extraServicePorts | nindent 2 }}
+  {{- end }}    

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -17,6 +17,7 @@ testFramework:
 
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
+extraServicePorts: []
 # loadBalancerIP: ""
 # loadBalancerSourceRanges: []
 whiteListSourceRange: []
@@ -430,6 +431,9 @@ rbac:
 metrics:
   prometheus:
     enabled: false
+    ## If true, prevents exposing port 8080 on the main Traefik service, reserving
+    ## it to the dashboard service only
+    restrictAccess: false
     # buckets: [0.1,0.3,1.2,5]
     service:
       # Set a custom service name


### PR DESCRIPTION
Signed-off-by: Dimitri Koshkin <dimitri.koshkin@gmail.com>

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Revert the changes made in https://github.com/mesosphere/charts/pull/614#discussion_r446304599 which broke `velero` and metrics collection.

Tested locally with the patch
~https://ad3721e184e2349bbbc7c80f94b8568d-1341071842.us-west-2.elb.amazonaws.com:9000/minio/login is working again~ my cluster timed out, here is a screenshot I had open.
![image](https://user-images.githubusercontent.com/4969231/85900149-27ec1100-b7b4-11ea-82ce-976c41c72559.png)


Before the fix:
```
➜  dkkonvoyrc1 k get svc -n kubeaddons     traefik-kubeaddons
NAME                 TYPE           CLUSTER-IP   EXTERNAL-IP                                                               PORT(S)                      AGE
traefik-kubeaddons   LoadBalancer   10.0.56.24   ad3721e184e2349bbbc7c80f94b8568d-1341071842.us-west-2.elb.amazonaws.com   443:30620/TCP,80:30566/TCP   80m
```
After the fix, notice new ports `8080:30758/TCP,9000:31751/TCP`
```
traefik-kubeaddons   LoadBalancer   10.0.56.24   ad3721e184e2349bbbc7c80f94b8568d-1341071842.us-west-2.elb.amazonaws.com      443:30620/TCP,80:30566/TCP,8080:30758/TCP,9000:31751/TCP   111m
```


**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
traefik: revert changes to the service ports that broke Velero functionality.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
