### PR TITLE
prometheus-operator: Move apiserver availability rules to new group with 3m interval

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.14
+version: 8.13.16
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.15
+version: 8.13.14
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/staging/prometheus-operator/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -106,7 +106,7 @@ data:
                         "tableColumn": "",
                         "targets": [
                             {
-                                "expr": "apiserver_request:availability7d{verb=\"all\"}",
+                                "expr": "apiserver_request:availability30d{verb=\"all\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
@@ -114,7 +114,7 @@ data:
                             }
                         ],
                         "thresholds": "",
-                        "title": "Availability (7d) > 99.000",
+                        "title": "Availability (30d) > 99.000",
                         "tooltip": {
                             "shared": false
                         },
@@ -174,7 +174,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "100 * (apiserver_request:availability7d{verb=\"all\"} - 0.990000)",
+                                "expr": "100 * (apiserver_request:availability30d{verb=\"all\"} - 0.990000)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "errorbudget",
@@ -186,7 +186,7 @@ data:
                         ],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "ErrorBudget (7d) > 99.000",
+                        "title": "ErrorBudget (30d) > 99.000",
                         "tooltip": {
                             "shared": false,
                             "sort": 0,
@@ -298,7 +298,7 @@ data:
                         "tableColumn": "",
                         "targets": [
                             {
-                                "expr": "apiserver_request:availability7d{verb=\"read\"}",
+                                "expr": "apiserver_request:availability30d{verb=\"read\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
@@ -306,7 +306,7 @@ data:
                             }
                         ],
                         "thresholds": "",
-                        "title": "Read Availability (7d)",
+                        "title": "Read Availability (30d)",
                         "tooltip": {
                             "shared": false
                         },
@@ -669,7 +669,7 @@ data:
                         "tableColumn": "",
                         "targets": [
                             {
-                                "expr": "apiserver_request:availability7d{verb=\"write\"}",
+                                "expr": "apiserver_request:availability30d{verb=\"write\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
@@ -677,7 +677,7 @@ data:
                             }
                         ],
                         "thresholds": "",
-                        "title": "Write Availability (7d)",
+                        "title": "Write Availability (30d)",
                         "tooltip": {
                             "shared": false
                         },

--- a/staging/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver.rules.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver.rules.yaml
@@ -283,6 +283,44 @@ spec:
       labels:
         verb: write
       record: apiserver_request:burnrate6h
+    - expr: sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
+      labels:
+        verb: read
+      record: code_resource:apiserver_request_total:rate5m
+    - expr: sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+      labels:
+        verb: write
+      record: code_resource:apiserver_request_total:rate5m
+    - expr: histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET"}[5m]))) > 0
+      labels:
+        quantile: '0.99'
+        verb: read
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))) > 0
+      labels:
+        quantile: '0.99'
+        verb: write
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - expr: |-
+        sum(rate(apiserver_request_duration_seconds_sum{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod)
+        /
+        sum(rate(apiserver_request_duration_seconds_count{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod)
+      record: cluster:apiserver_request_duration_seconds:mean5m
+    - expr: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+      labels:
+        quantile: '0.99'
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+      labels:
+        quantile: '0.9'
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+      labels:
+        quantile: '0.5'
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+  - name: kube-apiserver-availability.rules
+    interval: 3m
+    rules:
     - expr: |-
         1 - (
           (
@@ -355,39 +393,4 @@ spec:
       labels:
         verb: write
       record: code:apiserver_request_total:increase30d
-    - expr: sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
-      labels:
-        verb: read
-      record: code_resource:apiserver_request_total:rate5m
-    - expr: sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
-      labels:
-        verb: write
-      record: code_resource:apiserver_request_total:rate5m
-    - expr: histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET"}[5m]))) > 0
-      labels:
-        quantile: '0.99'
-        verb: read
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))) > 0
-      labels:
-        quantile: '0.99'
-        verb: write
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: |-
-        sum(rate(apiserver_request_duration_seconds_sum{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod)
-        /
-        sum(rate(apiserver_request_duration_seconds_count{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod)
-      record: cluster:apiserver_request_duration_seconds:mean5m
-    - expr: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: '0.99'
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: '0.9'
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: '0.5'
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
 {{- end }}

--- a/staging/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver.rules.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver.rules.yaml
@@ -287,74 +287,74 @@ spec:
         1 - (
           (
             # write too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[7d]))
+            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
             -
-            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[7d]))
+            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
           ) +
           (
             # read too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"LIST|GET"}[7d]))
+            sum(increase(apiserver_request_duration_seconds_count{verb=~"LIST|GET"}[30d]))
             -
             (
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="resource",le="0.1"}[7d])) +
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="namespace",le="0.5"}[7d])) +
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="cluster",le="5"}[7d]))
+              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="resource",le="0.1"}[30d])) +
+              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="namespace",le="0.5"}[30d])) +
+              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
             )
           ) +
           # errors
-          sum(code:apiserver_request_total:increase7d{code=~"5.."})
+          sum(code:apiserver_request_total:increase30d{code=~"5.."})
         )
         /
-        sum(code:apiserver_request_total:increase7d)
+        sum(code:apiserver_request_total:increase30d)
       labels:
         verb: all
-      record: apiserver_request:availability7d
+      record: apiserver_request:availability30d
     - expr: |-
         1 - (
-          sum(increase(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[7d]))
+          sum(increase(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[30d]))
           -
           (
             # too slow
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[7d])) +
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[7d])) +
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[7d]))
+            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[30d])) +
+            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30d])) +
+            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
           )
           +
           # errors
-          sum(code:apiserver_request_total:increase7d{verb="read",code=~"5.."})
+          sum(code:apiserver_request_total:increase30d{verb="read",code=~"5.."})
         )
         /
-        sum(code:apiserver_request_total:increase7d{verb="read"})
+        sum(code:apiserver_request_total:increase30d{verb="read"})
       labels:
         verb: read
-      record: apiserver_request:availability7d
+      record: apiserver_request:availability30d
     - expr: |-
         1 - (
           (
             # too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[7d]))
+            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
             -
-            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[7d]))
+            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
           )
           +
           # errors
-          sum(code:apiserver_request_total:increase7d{verb="write",code=~"5.."})
+          sum(code:apiserver_request_total:increase30d{verb="write",code=~"5.."})
         )
         /
-        sum(code:apiserver_request_total:increase7d{verb="write"})
+        sum(code:apiserver_request_total:increase30d{verb="write"})
       labels:
         verb: write
-      record: apiserver_request:availability7d
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver"}[7d]))
-      record: code_verb:apiserver_request_total:increase7d
-    - expr: sum by (code) (code_verb:apiserver_request_total:increase7d{verb=~"LIST|GET"})
+      record: apiserver_request:availability30d
+    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver"}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
       labels:
         verb: read
-      record: code:apiserver_request_total:increase7d
-    - expr: sum by (code) (code_verb:apiserver_request_total:increase7d{verb=~"POST|PUT|PATCH|DELETE"})
+      record: code:apiserver_request_total:increase30d
+    - expr: sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
       labels:
         verb: write
-      record: code:apiserver_request_total:increase7d
+      record: code:apiserver_request_total:increase30d
     - expr: sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
       labels:
         verb: read

--- a/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
@@ -79,7 +79,6 @@ spec:
       expr: sum by(name, namespace)(increase(aggregator_unavailable_apiservice_count[5m])) > 2
       labels:
         severity: warning
-{{- if semverCompare ">=1.18.0-0" $kubeTargetVersion }}
     - alert: AggregatedAPIDown
       annotations:
         message: An aggregated API {{`{{`}} $labels.name {{`}}`}}/{{`{{`}} $labels.namespace {{`}}`}} is down. It has not been available at least for the past five minutes.
@@ -88,7 +87,6 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- end }}
 {{- if .Values.kubeApiServer.enabled }}
     - alert: KubeAPIDown
       annotations:

--- a/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
@@ -79,6 +79,7 @@ spec:
       expr: sum by(name, namespace)(increase(aggregator_unavailable_apiservice_count[5m])) > 2
       labels:
         severity: warning
+{{- if semverCompare ">=1.18.0-0" $kubeTargetVersion }}
     - alert: AggregatedAPIDown
       annotations:
         message: An aggregated API {{`{{`}} $labels.name {{`}}`}}/{{`{{`}} $labels.namespace {{`}}`}} is down. It has not been available at least for the past five minutes.
@@ -87,6 +88,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+{{- end }}
 {{- if .Values.kubeApiServer.enabled }}
     - alert: KubeAPIDown
       annotations:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Revert the apiserver rules change from 30d to 7d intervals. The evaluation duration did not decrease significantly and was still triggering `PrometheusRuleFailures` alerts. Instead, separate out the "availability" rules which are taking a long time to evaluate into its own group and set the evaluation interval to 3m (up from default of 30s). So - these rules are evaluated every 3min now instead of every 30s. Previously, the rules were taking longer than 30s to get evaluated so they were triggering the alert.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-69672

**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/5897740/86078608-592e4080-ba43-11ea-8e06-ece341d6d410.png)

![image](https://user-images.githubusercontent.com/5897740/86078615-60554e80-ba43-11ea-974d-67e10af5bb99.png)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
