### PR TITLE
Enable wal compression as a default and update Prometheus version

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.16
+version: 8.13.17
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -1577,7 +1577,7 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.19.2
+      tag: v2.17.2
 
     ## Tolerations for use with node taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -1730,7 +1730,7 @@ prometheus:
 
     ## Enable compression of the write-ahead log using Snappy.
     ##
-    walCompression: true
+    walCompression: false
 
     ## If true, the Operator won't process any Prometheus configuration changes
     ##

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -1577,7 +1577,7 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.17.2
+      tag: v2.19.2
 
     ## Tolerations for use with node taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -1730,7 +1730,7 @@ prometheus:
 
     ## Enable compression of the write-ahead log using Snappy.
     ##
-    walCompression: false
+    walCompression: true
 
     ## If true, the Operator won't process any Prometheus configuration changes
     ##


### PR DESCRIPTION
- enabling wal compression by default per D2IQ-69798
- updating Prometheus to latest version per D2IQ-69855 
- bumping the Chart version 

**What type of PR is this?** Chore
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**: Enable wal compression based on findings in soak and update Prometheus version to latest for some bug fixes.
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:[ D2IQ-69798](https://jira.d2iq.com/browse/D2IQ-69798) and[ D2IQ-69855](https://jira.d2iq.com/browse/D2IQ-69855). 

This is based on current AWS soak findings and what is currently running there.
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
