### PR TITLE
fix: removes a left behind certificate upon istio addon deletion

### DIFF
--- a/staging/istio/Chart.yaml
+++ b/staging/istio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio
-version: 1.6.4
+version: 1.6.5
 appVersion: 1.6.3
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for istio

--- a/staging/istio/charts/security/templates/cert-delete-job.yaml
+++ b/staging/istio/charts/security/templates/cert-delete-job.yaml
@@ -2,38 +2,38 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-delete-job
+  name: cert-delete-job
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istio-delete-job
+  name: cert-delete-job
   namespace: {{ .Release.Namespace }}
 rules:
-- apiGroups: ["install.istio.io"]
-  resources: ["istiooperators"]
+- apiGroups: ["certmanager.k8s.io"]
+  resources: ["certificates"]
   verbs: ["get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istio-delete-job
+  name: cert-delete-job
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istio-delete-job
+  name: cert-delete-job
 subjects:
   - kind: ServiceAccount
-    name: istio-delete-job
+    name: cert-delete-job
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: istio-delete-{{ .Values.istioOperator.tag | printf "%v" }}-{{ randAlphaNum 5 | lower }}
+  name: cert-delete-{{ randAlphaNum 5 | lower }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
@@ -41,11 +41,11 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "false" 
+        sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istio-delete-job
+      serviceAccountName: cert-delete-job
       containers:
-      - name: istio-crd
+      - name: istio-ca-delete
         image: {{.Values.global.image}}:{{.Values.global.tag}}
-        command: ["kubectl",  "delete", "istiooperator", "istio-default", "-n", "{{ .Release.Namespace }}", "--ignore-not-found"]
+        command: ["kubectl",  "delete", "certificate", "istio-ca", "-n", "{{ .Release.Namespace }}", "--ignore-not-found"]
       restartPolicy: OnFailure

--- a/staging/istio/charts/security/templates/istio-cacert-job.yaml
+++ b/staging/istio/charts/security/templates/istio-cacert-job.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: istio-cacert-job
       containers:
       - name: istio-cacert-job
-        image: docker.io/bitnami/kubectl:1.16.2 
+        image: {{.Values.global.image}}:{{.Values.global.tag}} 
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c",
             "kubectl", "create", "secret", "generic", "cacerts",

--- a/staging/istio/templates/install-crd-job.yaml
+++ b/staging/istio/templates/install-crd-job.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: istio-crd-job
       containers:
       - name: istio-crd
-        image: docker.io/bitnami/kubectl:1.16.2
+        image: {{.Values.global.image}}:{{.Values.global.tag}}
         volumeMounts:
         - name: crd
           mountPath: /etc/istio/crd

--- a/staging/istio/values.yaml
+++ b/staging/istio/values.yaml
@@ -1,3 +1,7 @@
+global:
+  image: docker.io/bitnami/kubectl
+  tag: 1.16.2
+
 grafana:
   enabled: true
 security:


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
It adds a certificate deletion job so that future installation doesn't error out

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-69875

**Special notes for your reviewer**:
Verified by running manual test
```
1. helm install ./git/staging/istio --namespace istio-system -n istio-kubeaddons
2. helm delete --purge istio-kubeaddons
3. Verified that certificate is not left behind
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
