### PR TITLE
fix: bring back defaultCertificate for traefik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /gh-pages/
-
+tmp*
+ct_previous*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HELM_VERSION := v2.16.6
+HELM_VERSION := v2.16.9
 
 STABLE_CHARTS = $(wildcard stable/*/Chart.yaml)
 STABLE_TARGETS = $(shell hack/chart_destination.sh $(STABLE_CHARTS))
@@ -118,7 +118,7 @@ ct.test:
 ifneq (,$(wildcard /teamcity/system/git))
 	$(DRUN) git fetch origin master
 endif
-	test/e2e-kind.sh $(CT_VERSION)
+	test/e2e-kind.sh $(CT_VERSION) $(HELM_VERSION)
 
 .PHONY: lint
 lint: ct.lint

--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.23
+version: 1.72.24
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/ci/test-values.yaml
+++ b/staging/traefik/ci/test-values.yaml
@@ -1,10 +1,22 @@
 # These test values are used for chart testing
 # DO NOT EDIT unless you know what you are doing
+
+# We enable the testFramework here, you find it in the templates/tests folder.
+# We adapted the very simple bats test from upstream to check now also that
+# defaultCertificate and custom certificate are working and can both be defined.
 testFramework:
   enabled: true
 
+# For test we need to enable rbac, only on older clusters non rbac is working!
 rbac:
   enabled: true
+
+# We enable ssl and configure to let the certManager create an initial certificate
+# it will get updated by templates/test/test-certificate defined resources to mimic what
+# we do with konvoy-kubeaddons configmap, for that wealso trigger a reload with
+# templates/test/test-reloadTrigger to create the test-only-reload-trigger configmap.
+# We define the caSecretName which will contain after deployment of
+# templates/test/test-customCertificate certificate content.
 ssl:
   enabled: true
   enforced: false

--- a/staging/traefik/ci/test-values.yaml
+++ b/staging/traefik/ci/test-values.yaml
@@ -1,0 +1,16 @@
+# These test values are used for chart testing
+# DO NOT EDIT unless you know what you are doing
+testFramework:
+  enabled: true
+
+rbac:
+  enabled: true
+ssl:
+  enabled: true
+  enforced: false
+  insecureSkipVerify: true
+  useCertManager: true
+  caSecretName: konvoy-company-cert
+deploymentAnnotations:
+  configmap.reloader.stakater.com/reload: test-only-reload-trigger
+initCertJobImage: null

--- a/staging/traefik/templates/configmap.yaml
+++ b/staging/traefik/templates/configmap.yaml
@@ -104,7 +104,7 @@ data:
           optional = {{ .Values.ssl.mtls.optional }}
           {{- end }}
           {{- end }}
-          [[entryPoints.https.tls.certificates]]
+          [entryPoints.https.tls.defaultCertificate]
           CertFile = "/ssl/tls.crt"
           KeyFile = "/ssl/tls.key"
           {{- if .Values.ssl.extraCerts }}

--- a/staging/traefik/templates/tests/test-certificate.yaml
+++ b/staging/traefik/templates/tests/test-certificate.yaml
@@ -1,0 +1,139 @@
+{{- if .Values.testFramework.enabled  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoyconfig-setup
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: konvoyconfig-setup
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konvoyconfig-setup
+subjects:
+  - kind: ServiceAccount
+    name: konvoyconfig-setup
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konvoyconfig-setup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "traefik.fullname" . }}-konvoyconfig-kubeaddons-deploy-config
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+data:
+  resource.yml: |
+    apiVersion: v1
+    data:
+      clusterHostname: custom.whalesdolphines.tld
+    kind: ConfigMap
+    metadata:
+      name: konvoyconfig-kubeaddons
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "traefik.fullname" . }}-konvoyconfig-kubeaddons-deploy-job
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      serviceAccountName: konvoyconfig-setup
+      restartPolicy: Never
+      containers:
+      - name: {{ template "traefik.fullname" . }}-konvoyconfig-kubeaddons-deploy-job-pod
+        image: bitnami/kubectl:latest
+        command:
+        - kubectl
+        - apply
+        - -f
+        - /etc/config/resource.yml
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      volumes:
+      - name: config-volume
+        configMap:
+          defaultMode: 420
+          name: {{ template "traefik.fullname" . }}-konvoyconfig-kubeaddons-deploy-config
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "traefik.fullname" . }}-initialize-traefik-certificate
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "3"
+spec:
+  template:
+    metadata:
+      name: "update-traefik-certificate"
+    spec:
+      serviceAccountName: {{ template "traefik.fullname" . }}-cert-init
+      restartPolicy: Never
+      containers:
+      - name: initialize-traefik-certificate
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.10
+        args: ["traefik"]
+        env:
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: "{{ template "traefik.fullname" . }}"
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: "{{ template "traefik.fullname" . }}"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: "{{ template "traefik.fullname" . }}"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: "kubernetes-ca"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: "{{ template "traefik.fullname" . }}-certificate"
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: "konvoyconfig-kubeaddons"
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: "clusterHostname"
+{{- end }}

--- a/staging/traefik/templates/tests/test-configmap.yaml
+++ b/staging/traefik/templates/tests/test-configmap.yaml
@@ -8,9 +8,24 @@ metadata:
     chart: {{ template "traefik.chart" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "6"
 data:
   run.sh: |-
-    @test "Test Access" {
-      curl -D - http://{{ template "traefik.fullname" . }}/
+    @test "Test HTTP" {
+      curl -D - http://{{ template "traefik.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local./
+    }
+    @test "Test HTTPS" {
+      curl -k -vvv -D - https://{{ template "traefik.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local./
+    }
+    @test "Test Default Certificate" {
+      echo -n | openssl s_client -connect {{ template "traefik.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local.:443 2> /dev/null | openssl x509 -noout -subject | grep -q "traefik.localhost.localdomain"
+    }
+    @test "Test Default Certificate SNI" {
+      echo -n | openssl s_client -servername custom.whalesdolphines.tld -connect {{ template "traefik.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local.:443 2> /dev/null | openssl x509 -noout -text | grep -q "custom.whalesdolphines.tld"
+    }
+    @test "Test Custom Certificate SNI" {
+      echo -n | openssl s_client -servername konvoy.company.tld -connect {{ template "traefik.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local.:443 2> /dev/null | openssl x509 -noout -subject | grep -q "konvoy.company.tld"
     }
 {{- end }}

--- a/staging/traefik/templates/tests/test-customCertificate.yaml
+++ b/staging/traefik/templates/tests/test-customCertificate.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.testFramework.enabled  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konvoy-company-cert-setup
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: konvoy-company-cert-setup
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konvoy-company-cert-setup
+subjects:
+  - kind: ServiceAccount
+    name: konvoy-company-cert-setup
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konvoy-company-cert-setup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "traefik.fullname" . }}-konvoy-company-cert-deploy-config
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+data:
+  resource.yml: |
+    apiVersion: v1
+    data:
+      tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUV0akNDQXA0Q0NRQ0VCRXQ4NGV6VE9UQU5CZ2txaGtpRzl3MEJBUXNGQURBZE1Sc3dHUVlEVlFRRERCSnIKYjI1MmIza3VZMjl0Y0dGdWVTNTBiR1F3SGhjTk1qQXdOekF5TVRFMU5UQTBXaGNOTWpBd056QXpNVEUxTlRBMApXakFkTVJzd0dRWURWUVFEREJKcmIyNTJiM2t1WTI5dGNHRnVlUzUwYkdRd2dnSWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElDRHdBd2dnSUtBb0lDQVFEa0tyQzROK3ZGdUN2b0hDU2ROVjYwMmRScUpIMDBSaDliaG1odGs4QjEKd0hKL1YxR3ZKRHZ6OGR5aTlWMjNoNm5sTmN6WVZRUTIxZGxCTHVzSGMzWHhOejQyek00QWRqRnVxVVRuSXlqbApmd1BJTnhjVFBSU211bGxueFRxWFpPR0Q1WU5VVzBXUklabXZlZWdaSFBRRHIyVkVVUGZ3K1dIaXVQY0pvNURoCjBzaksvbTRTWmlkM0xlaUtLZVNKMCtTdjhQaWRBYWlGRUJWQmhURzk3Zk0zUUJGdERXYnFwME9WdXR3bXdERFcKNnZvbVhBelhDLzd2cHh6SXRVeFkzRGJxVkM3blJDUFl2QWlTR2F2Y1hCVnVveEs1cXMyRkdoUElyNUdoVzBCVwpJTUxGR1ZCQWhrV05iK0FDT3RBSUhPS3RIcWRFQlJzSDRPMGVpOUtFOTh1ZnMybm8wMTdIdWwzbUpLajk1VVJxCjNVMjJBMlFGRElGamU1bllNZUF4RWpYeU1oNUtDaXhvbmhSaTRXSW9tUlZzWmtoVU9LbXlTWTc0T2tlaXZLdXYKVUlxN003d2FuRlg2TDB2VElraElvYzZXWkl3TEN3VWVudDg2U3VicVlRb1JuaHBIQWJWNzRVTXl2MCtocGhPNgpyKzVLM1BBQ0xTeDJZTlhBdTM5cC82WERONklJUUl3M3FDeHNJL3cyd2hhUHZRN2lxTkl1UURaR1lnOUg0aktRClVXWkVDRVJBMitGVWpFUzRIcXFMUmpKcDlFUG40cVNUVlNwbmNZa0IzaXVrT2pVa1RaYnROQ1kxMm9DK05EYW4KdUNOVWpyQ3JidnF4bmJydDlaZVpwdVdjUndvNmpQSW9jZlZ6OHRuQWJTYVRINDhqZHFJNjdzckZJaENaVGlCYgpDUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQ0FRQ1VUKzM3L1cxRWpJakdralRxSUlsWkVxSDRpNFZtCnRGb0xZb1JwcE8rd1U0Umk5WFlweE1EYkgrU3hLeDlrUjN4WXNtUFBKTmtIZFB3RmVHYnFVOWNVZEZJeDV5RjEKTUZUUU56Q2R0T1JVYnp0M21ZMHYyN2RYQ2NzZVIyczZWcG5YUmIzOFBJUnhEbkIwUTZackk3ZWJmVk5mSGwxSwpkR3FOaDVmeHRvMXF0Qk1xSGU4eWN0Yi9kOHZ6WUdnSVFYSStLVktOT3pHZUIzRHhvSmV4QzBtQ1hyVWFOeU9wCjNWdlBUbmhwdm9sMUtqaEhCbURhZ1RiOWZQV0xqWEsvY2pxeVFMVXZqT0J5QWlhZTZscU5yWDVpcmRUUUpyN0wKYkJlWnBxbUc4L2xTZy9LM2lVRitQMUw0aWlmOGJEMm0zL2Vjdi9LZWhLcGFydUpqZ3hSZlpWRmRHdEU4bHIrSQpldUU0c3JEZnBOMUo1dHBWYVpCbE9sSUV3bXVqanRCTW0zUXV1ZG1Bb1Z6ckZmTUFEUjJFbDE3NDRIRXFzVVdwClZLVjZVS2kxQmdRL1JXaHdOQ2tKazBFRjN2WUYvYVpJdWxua2VCeUVpQ1JQWUp1dVJ4OEhoQ0UzNFM1NTY4ZFUKSFNQZXpOZFhOVG9udEgzc05Pc1N6b1gxbGRBK0huVkxUSEVNYU5JUGJ4YjE5NElFNlo1MnJFeVROTGR3MDRubwpFN3EycHdNNHAxeG9WNDQ1d0lNOVd5V0Z5RUdwcmNmV1ZOOWhpZFFYdm9LTDVCTWdaSlltT1JCVm8zdzFZNkdYClU3cTZ2L2ozNndLWG1CektLSHgzaDUzV2tpajMrVVVrWVR4V0tSLzNheUpxdUxCUlNYMzNjVmtZZzk0T1IyUmgKZkVqanBabXlSUE5lSlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlKS1FJQkFBS0NBZ0VBNUNxd3VEZnJ4YmdyNkJ3a25UVmV0Tm5VYWlSOU5FWWZXNFpvYlpQQWRjQnlmMWRSCnJ5UTc4L0hjb3ZWZHQ0ZXA1VFhNMkZVRU50WFpRUzdyQjNOMThUYytOc3pPQUhZeGJxbEU1eU1vNVg4RHlEY1gKRXowVXBycFpaOFU2bDJUaGcrV0RWRnRGa1NHWnIzbm9HUnowQTY5bFJGRDM4UGxoNHJqM0NhT1E0ZExJeXY1dQpFbVluZHkzb2lpbmtpZFBrci9ENG5RR29oUkFWUVlVeHZlM3pOMEFSYlExbTZxZERsYnJjSnNBdzF1cjZKbHdNCjF3dis3NmNjeUxWTVdOdzI2bFF1NTBRajJMd0lraG1yM0Z3VmJxTVN1YXJOaFJvVHlLK1JvVnRBVmlEQ3hSbFEKUUlaRmpXL2dBanJRQ0J6aXJSNm5SQVViQitEdEhvdlNoUGZMbjdOcDZOTmV4N3BkNWlTby9lVkVhdDFOdGdOawpCUXlCWTN1WjJESGdNUkkxOGpJZVNnb3NhSjRVWXVGaUtKa1ZiR1pJVkRpcHNrbU8rRHBIb3J5cnIxQ0t1ek84CkdweFYraTlMMHlKSVNLSE9sbVNNQ3dzRkhwN2ZPa3JtNm1FS0VaNGFSd0cxZStGRE1yOVBvYVlUdXEvdVN0encKQWkwc2RtRFZ3THQvYWYrbHd6ZWlDRUNNTjZnc2JDUDhOc0lXajcwTzRxalNMa0EyUm1JUFIrSXlrRkZtUkFoRQpRTnZoVkl4RXVCNnFpMFl5YWZSRDUrS2trMVVxWjNHSkFkNHJwRG8xSkUyVzdUUW1OZHFBdmpRMnA3Z2pWSTZ3CnEyNzZzWjI2N2ZXWG1hYmxuRWNLT296eUtISDFjL0xad0cwbWt4K1BJM2FpT3U3S3hTSVFtVTRnV3drQ0F3RUEKQVFLQ0FnQWlHZXROclRYMDJDRGYwUXo3M2hVb2pJSDkxelJMVXN1dS96aXVYKzNjNjRWeFdOaWhoNVhhVU9TOApDbFlXYnhWS1o2OFZDaWZXRmtJaFJ1VGp1VE1BZVZRNEZvWVhkWkxQeWthOUVQazB5N1lCLzVIWVUwRzU1WklsCk8wb1ZoSU5jRmpwNXFpYU1tV3dCMlFPQ2RWeFhES2ppL0FNQ3BoTW1NcVRoY092ZmhJUjBLbkRER1RkK3pZSzYKMjZZSG4zN0hlUWwvVmRjZEJCbFpNSklOby9tODRUdDVoQTVFdGZrWThOT2tpd2NCcUI3NUNycjBqUnR1TUJqUwpPcDZOaldRN3c1YzdBMmtrSkg1WGI3VEsrNHhNZTl6NW1QaWNreGd2MzJXeHF4VERpcVB4bDJYeUx0OUlVMWMwCm5odW5pc0dxUkRHVnJmbXJSTWZMei9RSDRZMHlLZnYvSm1HMXpyMUtxVUJKUHA3Zk9SUDMzb2RtZjBUd1VmazgKaXh5ZDduOCtOTktDR1k1UWNQQ0VEUTJzcDdDYmdxSXN6VmxSODlaVWN2WmJRQnA3RDgwYmhVL1o0b0FLdHBlcgp4ZXRJc09ySFpUQ1p1U1Zna1lyQ1kwOHFBWGRudmFxRGl1aW80N1Z2d2ZnT1c5V3hKdWZKZjBNblFlSS9ZRXhtCkMyUVk2emJSWk9aVUF5Z2ZmK2txRWJJRVlOYkNZWStxL1dTdklndnd4Y2ZKK1FHNWRGZGtNbkIxWWFZekdsMWMKZHN1a3ZmSC9BamRFRGhZV2VUS2ZJSzgxMFRoRVpYMDVIalI0ZDJ4TmRROGVOSmpVcERPN2h0L0RRQjBvcW9KZgpRU0dsMm5zY3hSU3gzbVoyREZjRWlqVU5TUldXalRheExCM1JhTklCUlRXMDlOZmx2UUtDQVFFQTlGVXIyaU9GCjZ6d2R6bUdnZjhpUWVwZS85b2tzY2NGSkZKUnpGaUFnaXdEeWdNeVRrazRoR2R3bU1iTFdmSmlCOHlhUVRIb0EKZlpWZ3pvb3hyRElYSGtFNmsra1R5amtZWUxCRFVBSjZtZ2FrcmxpSVljbFpVUjk1VkVpWk5GUTF5ZmEyNG9HZgpidXZiOFVSVkh3T21sVURIeU9Fb0N4cHNjbFoydW1qeTEvbUhsKzBlK3dtSUI3R1NQUE5QZmI1cEhPZU1ISStOCkZnZXFINmdjOEdIQ2NRZkkxa1YzM2UrS2ZiTkdCaHZ6SFFIdHp3bi9TdG9wbENONVorTms3YkhXMkV6K1VQbDUKRm5yTEFMSEN5cjdyeFdxcG53TjB2NEU2RFJPMThHbEJrWS9uNTRmZk9WL2dXMzJ6Q0RKSWRkRUVtTHpXN2loUwpCc29YbjRqVTI1OTR6d0tDQVFFQTd3L21TTXJlUmJVWmVYVjdSYVc2QitKSjd0NjlXbjlNRUEyQ2VkVzY0Tkp5CjBhN0l5YW1XOW04bUNhMXlVOEllUHB0eE1HeHp6SEFpeTV4ejVyRGVETTNSeW9VOXpSOXdFdDFCOG95REpXZ2YKU3hqTlNRMFpnK3VCdythTVZGK3ZBUUhsQnFmaUZSU0dHWnVJcElycXhKYU41YlBJQzlEU3ZxWURhc0JDOUNQUQplWG92dUk2Q0psUjhBQklUT3lyRi9rUndYbEowUHBEcGEyVTJ5aGpmNkkyNGZQWXc3bURtSTF3dmVNS1FmTnRjCnBYRHhoYXpDcjhaa1gxME1DQVdjMUJxZ2VWaUVGbStmTVB1Q3NzQmlxdDFEMEpGRmJlT2NOMUh4cGtqWW5hSS8KN3VEQ3NPVEgwWXZHMS9PZGk3eUtqeWNGWllHOG5aVlBRalgxUVNtMHB3S0NBUUVBeUErTlRwcFRwMStjRUVjRQpBbDJaWDZndHVKSnRYOStpRlVYUVRrZVVIZjF5azEvdlhaYTNwOU1KT3h4eVg2Y0lrSzM4N1lIZ01QUkZSaGtGCnZ6ZHNrb3RhaVk0SmRFWDMzZ08xdWlldGQ3MEV6dlVUQnU2MVFhV0IxUzkwc3RKWkVMd0ExOHJIWHkyazlCSzkKbUIySEl5TGQ4Mi9aTis0MDZoSStPVGlCejdJMEFvUllIN21ZTnFTQlY0THFqYzJCaC9kWVZISitWWkdGRFZLOApEMkFjdEN4cG1IbGRRczVIR2RIVy9sMllYU0lkTksrODUrOW1xRE83endMMHUyUW94UWVXSFh1SVdJM0c5eFNXCnFTaFhLVmpDOXI3L3MyYit2NEpxTVNZZVdDLzY5U3ZkN2I3Qm1HaCtWYkhHZnlIY242dlFXVVdPbEp5Wlp6bkYKQU9lOUpRS0NBUUVBakRnZk1vTUxiSWVVc1pFZkJQTDM4cmZmOWFQZ0hMeWR1S3l6NHhKaDBveWRuQytReGZnYQorK0NseHZkZEg1TzBlYlJpNTZ3MUg2eUdQRGRBSkFlSnRxamliSTlLZUk0QUJwQ1FwZHVVOE5QcHh2cDlMbVBvCm0xLy9kUkE5THlBUVhkN21uc2pKNnVObTVJNDl6NFZMdnBNd0Y1TWp1d3A1RWluOXh4ZU9MZlR6eXN6SVFOQVYKdHJYSEphTjBkRGZhZWhGYWQzaVZoajBwTER6cHJoQjVCTVpiZDdCUGN3S1MraHFRSFp6QmN2cVhsTkp5VjUzRgpjNlJDSzAxQVNWUkJjSWROcU44cVdwNk9HUVRzM0R2TG83eTBraGtqU0JsQS81R28wNGZXeGw3c2NRaVVLWDJIClZubE40RXljRStJNncweDM5ZG5xNytNcjRnSVVJR3g5OFFLQ0FRQk5ueGF5TVZyRktodS9FNUczalJmTXdjN1cKVXVCQkpkSVhVRWFyN09WdUs3VEFpT2QybzFhNlBIQytQM2s5UDY0YzVsN05OSFRQMDZ5aHVYOWpUZ2RwdXhobgo5ZzdOUnNhV09jQUNoYlp4NkNqclV6eUVsdExDNmt1RWptUUd2ZzRWaGhjNGwvMCs4MCtISmFkVFpETC9rYTA0CmNxWkc5KzJSVzFyYzFFSXNGQW4zSHVlbWN2WU95bUtDdWo1ZGtXMkhUQVkzc0xrcXB5VHZZU3JKWjZTZ2k0UFIKMTgrQmNZaU1tZ3pTS2JpYzV0dFNEUTNmL1Z4aTNtQlcvdncwbExDdjdEalpjMUVGMFJzTndsMkpPRFdOS0NJNQplcWFqQVQrMFZVWC9NcW9pN1BjRGZROFZYT2U2M0NLNk9EMlhBb2N4MEI5a2FHWFUvU1RZWkl3SldXQzcKLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K
+    kind: Secret
+    metadata:
+      name: konvoy-company-cert
+    type: kubernetes.io/tls
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "traefik.fullname" . }}-konvoy-company-cert-deploy-job
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      serviceAccountName: konvoy-company-cert-setup
+      restartPolicy: Never
+      containers:
+      - name: {{ template "traefik.fullname" . }}-konvoy-company-cert-deploy-job-pod
+        image: bitnami/kubectl:latest
+        command:
+        - kubectl
+        - apply
+        - -f
+        - /etc/config/resource.yml
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      volumes:
+      - name: config-volume
+        configMap:
+          defaultMode: 420
+          name: {{ template "traefik.fullname" . }}-konvoy-company-cert-deploy-config
+      restartPolicy: Never
+{{- end }}

--- a/staging/traefik/templates/tests/test-reloadTrigger.yaml
+++ b/staging/traefik/templates/tests/test-reloadTrigger.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.testFramework.enabled  }}
+apiVersion: v1
+data:
+  foo: {{ template "traefik.fullname" . }}
+kind: ConfigMap
+metadata:
+  name: test-only-reload-trigger
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "5"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-only-reload-trigger-sleep-job
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "4"
+spec:
+  template:
+    metadata:
+      name: test-only-reload-trigger-sleep-job
+      labels:
+        app: {{ template "traefik.fullname" . }}
+        chart: {{ template "traefik.chart" . }}
+        heritage: "{{ .Release.Service }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: sleeper
+        image: "alpine:3.12"
+        command: ["/bin/sleep", "10"]
+{{- end }}

--- a/staging/traefik/templates/tests/test.yaml
+++ b/staging/traefik/templates/tests/test.yaml
@@ -10,6 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
   annotations:
     "helm.sh/hook": test-success
+    "helm.sh/hook-weight": "7"
 spec:
   initContainers:
     - name: test-framework

--- a/test/ct-e2e.yaml
+++ b/test/ct-e2e.yaml
@@ -25,7 +25,6 @@ excluded-charts:
   - kudo                  # DCOS-62815
   - nvidia                # DCOS-62816
   - prometheus-operator   # DCOS-62817
-  - traefik               # DCOS-62818
   - traefik-forward-auth  # DCOS-62819
   - local-path-provisioner
 chart-repos:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- defaultCertificate back for traefik
- added tests to prove it works
- slightly needed to modifiy e2e to make it possible
- tiller has a bug in 2.16.5 of a SIGSEGV, so we need to make sure to update and are using now 2.16.9 in ct container

- hint: kind 0.8.1 atm not working as of a resolv.conf issue with 
127.0.0.1, so atm we stay with 0.7.0

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
[D2IQ-69838]
[D2IQ-62818]

[D2IQ-69838]: https://jira.d2iq.com/browse/D2IQ-69838
[D2IQ-62818]: https://jira.d2iq.com/browse/D2IQ-62818

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [ ] The documentation is updated where needed.