### PR TITLE
[kommander] fix: kommander should not force a value of catalog image

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.8.35
+version: 0.8.36

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -27,11 +27,6 @@ kommander-karma:
 kubeaddons-catalog:
   enabled: true
 
-  image:
-    repository: mesosphere/kubeaddons-catalog
-    tag: "v0.8.2"
-    pullPolicy: IfNotPresent
-
 grafana:
   enabled: true
 


### PR DESCRIPTION
The image of catalog was forced by the values file of kommander, this should never have been the case and we should avoid this. Removing the value explicitly should not break previous or future versions as this value still exists in the catalog's value file

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This PR resolves the issue of updating the catalog chart but image of catalog remaining the same. This should not happen at this level.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-69905

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
