### PR TITLE
traefik: Only install servicemonitor if monitoring api installed

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.2
+version: 1.87.3
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/servicemonitor.yaml
+++ b/staging/traefik/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if ( .Values.metrics.serviceMonitor )  }}
+{{- if and ( .Values.metrics.serviceMonitor ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 {{- if and ( .Values.metrics.serviceMonitor.enabled ) ( .Values.metrics.prometheus.enabled ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
If prometheus isn't installed, traefik addon fails on `no matches for kind \"ServiceMonitor\" in version \"monitoring.coreos.com/v1\"`. We should only install the servicemonitor if the crd is installed.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
