### PR TITLE
traefik: Add prometheus service labels option

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.2
+version: 1.87.3
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/README.md
+++ b/staging/traefik/README.md
@@ -216,6 +216,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `metrics.prometheus.buckets`           | A list of response times (in seconds) - for each list element, Traefik will report all response times less than the element. | `[0.1,0.3,1.2,5]`                                 |
 | `metrics.prometheus.service.name`      | Custom service name for the Prometheus service                                                 | ``                                           |
 | `metrics.prometheus.service.annotations`      | Annotations for the Prometheus service                                                 | `{ prometheus.io/scrape: "true" }`                                           |
+| `metrics.prometheus.service.labels`    | Labels for the Prometheus service                                               | None                                           |
 | `metrics.prometheus.service.port`      | Port for the Prometheus service                                                 | `9100`                                           |
 | `metrics.prometheus.service.type`      | Type for the Prometheus service                                                 | `ClusterIP`                                           |
 | `metrics.prometheus.service.loadBalancerIP`      | Static IP for the Prometheus Service when its type is `LoadBalancer`                                            | ``                                           |

--- a/staging/traefik/README.md
+++ b/staging/traefik/README.md
@@ -216,7 +216,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `metrics.prometheus.buckets`           | A list of response times (in seconds) - for each list element, Traefik will report all response times less than the element. | `[0.1,0.3,1.2,5]`                                 |
 | `metrics.prometheus.service.name`      | Custom service name for the Prometheus service                                                 | ``                                           |
 | `metrics.prometheus.service.annotations`      | Annotations for the Prometheus service                                                 | `{ prometheus.io/scrape: "true" }`                                           |
-| `metrics.prometheus.service.labels`    | Labels for the Prometheus service                                               | None                                           |
+| `metrics.prometheus.service.labels`    | Labels for the Prometheus service                                               | `{}`                                           |
 | `metrics.prometheus.service.port`      | Port for the Prometheus service                                                 | `9100`                                           |
 | `metrics.prometheus.service.type`      | Type for the Prometheus service                                                 | `ClusterIP`                                           |
 | `metrics.prometheus.service.loadBalancerIP`      | Static IP for the Prometheus Service when its type is `LoadBalancer`                                            | ``                                           |

--- a/staging/traefik/templates/prometheus-service.yaml
+++ b/staging/traefik/templates/prometheus-service.yaml
@@ -12,6 +12,9 @@ metadata:
     chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+  {{- if .Values.metrics.prometheus.service.labels }}
+    {{ toYaml .Values.metrics.prometheus.service.labels | indent 4 }}
+  {{- end }}
   {{- with .Values.metrics.prometheus.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -437,6 +437,7 @@ metrics:
       name:
       annotations:
         prometheus.io/scrape: "true"
+      # labels:
       port: 9100
       type: ClusterIP
       # loadBalancerIP: ""

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -437,7 +437,7 @@ metrics:
       name:
       annotations:
         prometheus.io/scrape: "true"
-      # labels:
+      labels: {}
       port: 9100
       type: ClusterIP
       # loadBalancerIP: ""


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Add option to define labels for the prometheus service. The prometheus addon targets this service via label selectors, so we'll need to define that label.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add option in traefik config to define labels for the prometheus service.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
