### PR TITLE
traefik: Fix yaml indentation bug

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.3
+version: 1.87.4
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/prometheus-service.yaml
+++ b/staging/traefik/templates/prometheus-service.yaml
@@ -13,7 +13,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   {{- if .Values.metrics.prometheus.service.labels }}
-    {{ toYaml .Values.metrics.prometheus.service.labels | indent 4 }}
+    {{- toYaml .Values.metrics.prometheus.service.labels | nindent 4 }}
   {{- end }}
   {{- with .Values.metrics.prometheus.service.annotations }}
   annotations:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
We were seeing `Error: YAML parse error on traefik/templates/prometheus-service.yaml: error converting YAML to JSON: yaml: line 9: did not find expected key\n` which led to the yaml indentation bug in the template 😢  I think the other fix would be to unindent `{{ toYaml .Values.metrics.prometheus.service.labels | indent 4 }}` but to keep the indentation consistent in the file, chose to go with the current fix instead.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-70138

**Special notes for your reviewer**:
Tested on new cluster using testing kba branch `gracedo/test_traefik` - verified that targets are coming up in service monitor and traefik dashboards are populating
![image](https://user-images.githubusercontent.com/5897740/87584088-d25ba380-c691-11ea-971b-ab8e42cc7c91.png)
![image](https://user-images.githubusercontent.com/5897740/87584101-d7205780-c691-11ea-9c63-2006fa7e6960.png)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
