### PR TITLE
fix[cert-manager-setup]: deploy Certificate CRs in the release namespace

### DIFF
--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.11
+version: 0.1.12
 appVersion: 0.10.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/templates/certificates.yaml
+++ b/staging/cert-manager-setup/templates/certificates.yaml
@@ -5,6 +5,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-3"


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
The certificates are not created with the right namespace, because the certificate template does not define a namespace. Where helm v2 used the release namespace (correct), helm v3 uses the kubeaddons-controller namespace (incorrect).

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-70273

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
