### PR TITLE
[velero] fix: allow velero to deploy on helm2&3 without needing install hooks

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -20,4 +20,4 @@ name: velero
 sources:
 - https://github.com/heptio/velero
 tillerVersion: '>=2.10.0'
-version: 3.0.5
+version: 3.0.6

--- a/staging/velero/crds/crds.yaml
+++ b/staging/velero/crds/crds.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backups
+    kind: Backup
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backupstoragelocations.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backupstoragelocations
+    kind: BackupStorageLocation
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: deletebackuprequests.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: deletebackuprequests
+    kind: DeleteBackupRequest
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: downloadrequests.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: downloadrequests
+    kind: DownloadRequest
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumebackups.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: podvolumebackups
+    kind: PodVolumeBackup
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podvolumerestores.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: podvolumerestores
+    kind: PodVolumeRestore
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resticrepositories.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: resticrepositories
+    kind: ResticRepository
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: restores
+    kind: Restore
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: schedules.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: schedules
+    kind: Schedule
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverstatusrequests.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: serverstatusrequests
+    kind: ServerStatusRequest
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotlocations.velero.io
+spec:
+  group: velero.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: volumesnapshotlocations
+    kind: VolumeSnapshotLocation

--- a/staging/velero/templates/backupstoragelocation.yaml
+++ b/staging/velero/templates/backupstoragelocation.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
 {{- with .Values.configuration }}
 {{- with .backupStorageLocation }}

--- a/staging/velero/templates/schedule.yaml
+++ b/staging/velero/templates/schedule.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ include "velero.chart" $ }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   schedule: {{ $schedule.schedule | quote }}
 {{- with $schedule.template }}

--- a/staging/velero/templates/volumesnapshotlocation.yaml
+++ b/staging/velero/templates/volumesnapshotlocation.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
 {{- with .Values.configuration }}
 {{- with .volumeSnapshotLocation }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
BUG

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-70289

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
