### PR TITLE
[kubefed] update charts and enable better helm3 migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,6 @@ test.helm2: HELM_VERSION = v2.16.9
 test.helm2: CT_VERSION = v2.4.1
 test.helm2: ct.test
 
-.PHONY: test.helm3
 test.helm3: HELM_VERSION = v3.3.0
 test.helm3: CT_VERSION = v3.0.0
 test.helm3: ct.test

--- a/staging/kubefed/Chart.yaml
+++ b/staging/kubefed/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeFed helm chart
 name: kubefed
-version: 0.0.4
-appVersion: v0.1.0-rc6
+version: 0.0.5
+appVersion: v0.3.1
 home: https://github.com/kubernetes-sigs/kubefed
 maintainers:
   - name: s12chung

--- a/staging/kubefed/charts/controllermanager/Chart.yaml
+++ b/staging/kubefed/charts/controllermanager/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 description: A Helm chart for KubeFed Controller Manager
 name: controllermanager
-version: 0.0.2
+version: 0.0.3

--- a/staging/kubefed/charts/controllermanager/crds/crds.yaml
+++ b/staging/kubefed/charts/controllermanager/crds/crds.yaml
@@ -1,0 +1,928 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clusterpropagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: ClusterPropagatedVersion
+    plural: clusterpropagatedversions
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - templateVersion
+          - overridesVersion
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: federatedservicestatuses.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedServiceStatus
+    plural: federatedservicestatuses
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        clusterStatus:
+          items:
+            properties:
+              clusterName:
+                type: string
+              status:
+                type: object
+            required:
+            - clusterName
+            - status
+            type: object
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: propagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: PropagatedVersion
+    plural: propagatedversions
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - templateVersion
+          - overridesVersion
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: federatedtypeconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedTypeConfig
+    plural: federatedtypeconfigs
+    shortNames:
+    - ftc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            federatedType:
+              description: Configuration for the federated type that defines (via
+                template, placement and overrides fields) how the target type should
+                appear in multiple cluster.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - version
+              - kind
+              - pluralName
+              - scope
+              type: object
+            propagation:
+              description: Whether or not propagation to member clusters should be
+                enabled.
+              type: string
+            statusCollection:
+              description: Whether or not Status object should be populated.
+              type: string
+            statusType:
+              description: Configuration for the status type that holds information
+                about which type holds the status of the federated resource. If not
+                provided, the group and version will default to those provided for
+                the federated type api resource.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - version
+              - kind
+              - pluralName
+              - scope
+              type: object
+            targetType:
+              description: The configuration of the target type. If not set, the pluralName
+                and groupName fields will be set from the metadata.name of this resource.
+                The kind field must be set.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - version
+              - kind
+              - pluralName
+              - scope
+              type: object
+          required:
+          - targetType
+          - propagation
+          - federatedType
+          type: object
+        status:
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the FederatedTypeConfig.
+              format: int64
+              type: integer
+            propagationController:
+              description: PropagationController tracks the status of the sync controller.
+              type: string
+            statusController:
+              description: StatusController tracks the status of the status controller.
+              type: string
+          required:
+          - observedGeneration
+          - propagationController
+          type: object
+      required:
+      - spec
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: kubefedclusters.core.kubefed.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: ready
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: core.kubefed.io
+  names:
+    kind: KubeFedCluster
+    plural: kubefedclusters
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            apiEndpoint:
+              description: The API endpoint of the member cluster. This can be a hostname,
+                hostname:port, IP or IP:port.
+              type: string
+            caBundle:
+              description: CABundle contains the certificate authority information.
+              format: byte
+              type: string
+            disabledTLSValidations:
+              description: DisabledTLSValidations defines a list of checks to ignore
+                when validating the TLS connection to the member cluster.  This can
+                be any of *, SubjectName, or ValidityPeriod. If * is specified, it
+                is expected to be the only option in list.
+              items:
+                type: string
+              type: array
+            secretRef:
+              description: Name of the secret containing the token required to access
+                the member cluster. The secret needs to exist in the same namespace
+                as the control plane and should have a "token" key.
+              properties:
+                name:
+                  description: Name of a secret within the enclosing namespace
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - apiEndpoint
+          - secretRef
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions is an array of current cluster conditions.
+              items:
+                properties:
+                  lastProbeTime:
+                    description: Last time the condition was checked.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of cluster condition, Ready or Offline.
+                    type: string
+                required:
+                - type
+                - status
+                - lastProbeTime
+                type: object
+              type: array
+            region:
+              description: Region is the name of the region in which all of the nodes
+                in the cluster exist.  e.g. 'us-east1'.
+              type: string
+            zones:
+              description: Zones are the names of availability zones in which the
+                nodes of the cluster exist, e.g. 'us-east1-a'.
+              items:
+                type: string
+              type: array
+          required:
+          - conditions
+          type: object
+      required:
+      - spec
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: kubefedconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: KubeFedConfig
+    plural: kubefedconfigs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterHealthCheck:
+              properties:
+                failureThreshold:
+                  description: Minimum consecutive failures for the cluster health
+                    to be considered failed after having succeeded.
+                  format: int64
+                  type: integer
+                period:
+                  description: How often to monitor the cluster health.
+                  type: string
+                successThreshold:
+                  description: Minimum consecutive successes for the cluster health
+                    to be considered successful after having failed.
+                  format: int64
+                  type: integer
+                timeout:
+                  description: Duration after which the cluster health check times
+                    out.
+                  type: string
+              type: object
+            controllerDuration:
+              properties:
+                availableDelay:
+                  description: Time to wait before reconciling on a healthy cluster.
+                  type: string
+                unavailableDelay:
+                  description: Time to wait before giving up on an unhealthy cluster.
+                  type: string
+              type: object
+            featureGates:
+              items:
+                properties:
+                  configuration:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                - configuration
+                type: object
+              type: array
+            leaderElect:
+              properties:
+                leaseDuration:
+                  description: The duration that non-leader candidates will wait after
+                    observing a leadership renewal until attempting to acquire leadership
+                    of a led but unrenewed leader slot. This is effectively the maximum
+                    duration that a leader can be stopped before it is replaced by
+                    another candidate. This is only applicable if leader election
+                    is enabled.
+                  type: string
+                renewDeadline:
+                  description: The interval between attempts by the acting master
+                    to renew a leadership slot before it stops leading. This must
+                    be less than or equal to the lease duration. This is only applicable
+                    if leader election is enabled.
+                  type: string
+                resourceLock:
+                  description: The type of resource object that is used for locking
+                    during leader election. Supported options are `configmaps` (default)
+                    and `endpoints`.
+                  type: string
+                retryPeriod:
+                  description: The duration the clients should wait between attempting
+                    acquisition and renewal of a leadership. This is only applicable
+                    if leader election is enabled.
+                  type: string
+              type: object
+            scope:
+              description: The scope of the KubeFed control plane should be either
+                `Namespaced` or `Cluster`. `Namespaced` indicates that the KubeFed
+                namespace will be the only target of the control plane.
+              type: string
+            syncController:
+              properties:
+                adoptResources:
+                  description: Whether to adopt pre-existing resources in member clusters.
+                    Defaults to "Enabled".
+                  type: string
+              type: object
+          required:
+          - scope
+          type: object
+      required:
+      - spec
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: dnsendpoints.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: DNSEndpoint
+    plural: dnsendpoints
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            endpoints:
+              items:
+                properties:
+                  dnsName:
+                    description: The FQDN of the DNS record.
+                    type: string
+                  labels:
+                    description: Labels stores labels defined for the Endpoint.
+                    type: object
+                  recordTTL:
+                    description: TTL for the record in seconds.
+                    format: int64
+                    type: integer
+                  recordType:
+                    description: RecordType type of record, e.g. CNAME, A, SRV, TXT
+                      etc.
+                    type: string
+                  targets:
+                    description: The targets that the DNS record points to.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the DNSEndpoint.
+              format: int64
+              type: integer
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: domains.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: Domain
+    plural: domains
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        domain:
+          description: Domain is the DNS zone associated with the KubeFed control
+            plane
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        nameServer:
+          description: NameServer is the authoritative DNS name server for the KubeFed
+            domain
+          type: string
+      required:
+      - domain
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: ingressdnsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: IngressDNSRecord
+    plural: ingressdnsrecords
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            hosts:
+              description: Host from the IngressRule in Cluster Ingress Spec
+              items:
+                type: string
+              type: array
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for the Ingress, if omitted a default would be used
+              format: int64
+              type: integer
+          type: object
+        status:
+          properties:
+            dns:
+              description: Array of Ingress Controller LoadBalancers
+              items:
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding ingress controller
+                    type: object
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: servicednsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: ServiceDNSRecord
+    plural: servicednsrecords
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allowServiceWithoutEndpoints:
+              description: AllowServiceWithoutEndpoints allows DNS records to be written
+                for Service shards without endpoints
+              type: boolean
+            dnsPrefix:
+              description: DNSPrefix when specified, an additional DNS record would
+                be created with <DNSPrefix>.<KubeFedDomain>
+              type: string
+            domainRef:
+              description: DomainRef is the name of the domain object to which the
+                corresponding federated service belongs
+              type: string
+            externalName:
+              description: ExternalName when specified, replaces the service name
+                portion of a resource record with the value of ExternalName.
+              type: string
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for this Service, if omitted a default would be used
+              format: int64
+              type: integer
+          required:
+          - domainRef
+          type: object
+        status:
+          properties:
+            dns:
+              items:
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding service
+                    type: object
+                  region:
+                    description: Region to which the cluster belongs
+                    type: string
+                  zones:
+                    description: Zones to which the cluster belongs
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            domain:
+              description: Domain is the DNS domain of the KubeFed control plane as
+                in Domain API
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: replicaschedulingpreferences.scheduling.kubefed.io
+spec:
+  group: scheduling.kubefed.io
+  names:
+    kind: ReplicaSchedulingPreference
+    plural: replicaschedulingpreferences
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusters:
+              description: A mapping between cluster names and preferences regarding
+                a local workload object (dep, rs, .. ) in these clusters. "*" (if
+                provided) applies to all clusters if an explicit mapping is not provided.
+                If omitted, clusters without explicit preferences should not have
+                any replicas scheduled.
+              type: object
+            rebalance:
+              description: If set to true then already scheduled and running replicas
+                may be moved to other clusters in order to match current state to
+                the specified preferences. Otherwise, if set to false, up and running
+                replicas will not be moved.
+              type: boolean
+            targetKind:
+              description: TODO (@irfanurrehman); upgrade this to label selector only
+                if need be. The idea of this API is to have a a set of preferences
+                which can be used for a target FederatedDeployment or FederatedReplicaset.
+                Although the set of preferences in question can be applied to multiple
+                target objects using label selectors, but there are no clear advantages
+                of doing that as of now. To keep the implementation and usage simple,
+                matching ns/name of RSP resource to the target resource is sufficient
+                and only additional information needed in RSP resource is a target
+                kind (FederatedDeployment or FederatedReplicaset).
+              type: string
+            totalReplicas:
+              description: Total number of pods desired across federated clusters.
+                Replicas specified in the spec for target deployment template or replicaset
+                template will be discarded/overridden when scheduling preferences
+                are specified.
+              format: int32
+              type: integer
+          required:
+          - targetKind
+          - totalReplicas
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---

--- a/staging/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
+++ b/staging/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
@@ -1,0 +1,130 @@
+{{- if or (not .Values.global.scope) (eq .Values.global.scope "Cluster") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kubefed-admin
+rules:
+  - apiGroups:
+      - multiclusterdns.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - scheduling.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - core.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - types.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: kubefed-edit
+rules:
+  - apiGroups:
+      - scheduling.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - multiclusterdns.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - core.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - types.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: kubefed-view
+rules:
+  - apiGroups:
+      - scheduling.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - multiclusterdns.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - core.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - types.kubefed.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+{{- end }}

--- a/staging/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/staging/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -26,9 +26,20 @@ spec:
       containers:
       - command:
         - /hyperfed/controller-manager
+        - "--v={{ .Values.logLevel }}"
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: controller-manager
+{{- if .Values.env }}
+        env:
+{{- range $key, $value := .Values.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+{{- end }}
+{{- end }}
+        ports:
+        - containerPort: 9090
+          name: metrics
         livenessProbe:
           httpGet:
             path: /healthz
@@ -68,15 +79,20 @@ spec:
       serviceAccountName: kubefed-admission-webhook
       containers:
       - name: admission-webhook
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
-        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        image: "{{ .Values.webhook.repository }}/{{ .Values.webhook.image }}:{{ .Values.webhook.tag }}"
+        imagePullPolicy: "{{ .Values.webhook.imagePullPolicy }}"
+{{- if .Values.webhook.env }}
+        env:
+{{- range $key, $value := .Values.webhook.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+{{- end }}
+{{- end }}
         command:
         - "/hyperfed/webhook"
         - "--secure-port=8443"
-        - "--audit-log-path=-"
-        - "--tls-cert-file=/var/serving-cert/tls.crt"
-        - "--tls-private-key-file=/var/serving-cert/tls.key"
-        - "--v=8"
+        - "--cert-dir=/var/serving-cert/"
+        - "--v={{ .Values.webhook.logLevel }}"
         ports:
         - containerPort: 8443
         volumeMounts:
@@ -84,9 +100,13 @@ spec:
           name: serving-cert
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 8443
             scheme: HTTPS
+        resources:
+{{- if .Values.webhook.resources }}
+{{ toYaml .Values.webhook.resources | indent 12 }}
+{{- end }}
       volumes:
       - name: serving-cert
         secret:

--- a/staging/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
+++ b/staging/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
@@ -3,10 +3,6 @@ kind: KubeFedConfig
 metadata:
   name: kubefed
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   scope: {{ .Values.global.scope | default "Cluster" | quote }}
   controllerDuration:

--- a/staging/kubefed/charts/controllermanager/templates/roles.yaml
+++ b/staging/kubefed/charts/controllermanager/templates/roles.yaml
@@ -38,6 +38,7 @@ rules:
   - list
   - create
   - update
+  - delete
 - apiGroups:
   - types.kubefed.io
   resources:

--- a/staging/kubefed/charts/controllermanager/templates/service.yaml
+++ b/staging/kubefed/charts/controllermanager/templates/service.yaml
@@ -9,3 +9,20 @@ spec:
   ports:
   - port: 443
     targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubefed-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/port: "9090"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    kubefed-control-plane: "controller-manager"
+  ports:
+    - name: metrics
+      port: 9090
+      targetPort: metrics

--- a/staging/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/staging/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -14,16 +14,16 @@ metadata:
   name: validations.core.kubefed.io
 {{- end }}
   annotations:
-  {{- if .Values.certManager.enabled }}
+{{- if .Values.certManager.enabled }}
     certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s%s" .Release.Namespace .Release.Name "-root-certificate" | quote }}
-  {{- end }}
+{{- end }}
 webhooks:
 - name: federatedtypeconfigs.core.kubefed.io
   clientConfig:
     service:
       namespace: {{ .Release.Namespace | quote }}
       name: kubefed-admission-webhook
-      path: /apis/validation.core.kubefed.io/v1beta1/federatedtypeconfigs
+      path: /validate-federatedtypeconfigs
     {{- if not .Values.certManager.enabled }}
     caBundle: {{ b64enc $ca.Cert | quote }}
     {{- end }}
@@ -55,7 +55,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace | quote }}
       name: kubefed-admission-webhook
-      path: /apis/validation.core.kubefed.io/v1beta1/kubefedclusters
+      path: /validate-kubefedcluster
     {{- if not .Values.certManager.enabled }}
     caBundle: {{ b64enc $ca.Cert | quote }}
     {{- end }}
@@ -82,7 +82,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace | quote }}
       name: kubefed-admission-webhook
-      path: /apis/validation.core.kubefed.io/v1beta1/kubefedconfigs
+      path: /validate-kubefedconfig
     {{- if not .Values.certManager.enabled }}
     caBundle: {{ b64enc $ca.Cert | quote }}
     {{- end }}
@@ -120,7 +120,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace | quote }}
       name: kubefed-admission-webhook
-      path: /apis/mutation.core.kubefed.io/v1beta1/kubefedconfigs
+      path: /default-kubefedconfig
     {{- if not .Values.certManager.enabled }}
     caBundle: {{ b64enc $ca.Cert | quote }}
     {{- end }}

--- a/staging/kubefed/charts/controllermanager/values.yaml
+++ b/staging/kubefed/charts/controllermanager/values.yaml
@@ -7,8 +7,15 @@ replicaCount: 2
 repository: quay.io/kubernetes-multicluster
 image: kubefed
 tag: canary
+logLevel: 2
 imagePullPolicy: IfNotPresent
-resources: {}
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi
 clusterAvailableDelay:
 clusterUnavailableDelay:
 leaderElectLeaseDuration:
@@ -34,4 +41,16 @@ certManager:
 
 webhook:
   annotations: {}
-
+  repository: quay.io/kubernetes-multicluster
+  image: kubefed
+  tag: canary
+  imagePullPolicy: IfNotPresent
+  logLevel: 8
+  env: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi

--- a/staging/kubefed/crds/crds.yaml
+++ b/staging/kubefed/crds/crds.yaml
@@ -1,0 +1,1268 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedclusterroles.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedClusterRole
+    plural: federatedclusterroles
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedconfigmaps.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedConfigMap
+    plural: federatedconfigmaps
+    shortNames:
+    - fcm
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federateddeployments.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedDeployment
+    plural: federateddeployments
+    shortNames:
+    - fdeploy
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedingresses.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedIngress
+    plural: federatedingresses
+    shortNames:
+    - fing
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedjobs.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedJob
+    plural: federatedjobs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatednamespaces.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedNamespace
+    plural: federatednamespaces
+    shortNames:
+    - fns
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedreplicasets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedReplicaSet
+    plural: federatedreplicasets
+    shortNames:
+    - frs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedsecrets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedSecret
+    plural: federatedsecrets
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedserviceaccounts.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedServiceAccount
+    plural: federatedserviceaccounts
+    shortNames:
+    - fsa
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedservices.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedService
+    plural: federatedservices
+    shortNames:
+    - fsvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+  version: v1beta1

--- a/staging/kubefed/requirement.yaml
+++ b/staging/kubefed/requirement.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: controllermanager
-    version: 0.0.2
+    version: 0.0.3
     condition: controllermanager.enabled

--- a/staging/kubefed/templates/federatedtypeconfig.yaml
+++ b/staging/kubefed/templates/federatedtypeconfig.yaml
@@ -28,10 +28,6 @@ kind: FederatedTypeConfig
 metadata:
   name: configmaps
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation"
 spec:
   federatedType:
     group: types.kubefed.io
@@ -51,10 +47,6 @@ kind: FederatedTypeConfig
 metadata:
   name: deployments.apps
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io
@@ -75,10 +67,6 @@ kind: FederatedTypeConfig
 metadata:
   name: ingresses.extensions
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io
@@ -99,10 +87,6 @@ kind: FederatedTypeConfig
 metadata:
   name: jobs.batch
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io
@@ -123,10 +107,6 @@ kind: FederatedTypeConfig
 metadata:
   name: namespaces
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io
@@ -146,10 +126,6 @@ kind: FederatedTypeConfig
 metadata:
   name: replicasets.apps
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io
@@ -170,10 +146,6 @@ kind: FederatedTypeConfig
 metadata:
   name: secrets
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io
@@ -193,10 +165,6 @@ kind: FederatedTypeConfig
 metadata:
   name: serviceaccounts
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io
@@ -216,10 +184,6 @@ kind: FederatedTypeConfig
 metadata:
   name: services
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   federatedType:
     group: types.kubefed.io

--- a/staging/kubefed/values.yaml
+++ b/staging/kubefed/values.yaml
@@ -12,6 +12,7 @@ controllermanager:
   image: kubefed
   tag: canary
   imagePullPolicy: IfNotPresent
+  logLevel: 2
   resources:
     limits:
       cpu: 100m
@@ -45,6 +46,19 @@ controllermanager:
 
   webhook:
     annotations: {}
+    repository: quay.io/kubernetes-multicluster
+    image: kubefed
+    tag: canary
+    imagePullPolicy: IfNotPresent
+    logLevel: 8
+    env: {}
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 64Mi
 
 ## Configuration global values for all charts
 ##


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This allows for our tooling to allow kubefed to deploy from a helm2 or a helm3 driver just fine. 

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-70708

**Special notes for your reviewer**:
Tested this using helm2 and helm3 for installation and uninstallation, now issues helm3 is much faster. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
