### PR TITLE
[test] set ct version for helm2 correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,12 @@ lint: ct.lint
 
 .PHONY: test.helm2
 test.helm2: HELM_VERSION = v2.16.9
+test.helm2: CT_VERSION = v2.4.1
 test.helm2: ct.test
 
 .PHONY: test.helm3
 test.helm3: HELM_VERSION = v3.3.0
+test.helm3: CT_VERSION = v3.0.0
 test.helm3: ct.test
 
 .PHONY: test


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
BUG

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
CT Testing should be consistent with helm version, here we fix that by setting the correct version for helm2

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:
This is an important followup to https://github.com/mesosphere/charts/pull/729

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
