### PR TITLE
[BUG] force `make publish` use helm2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ stagingrepo: $(STAGING_TARGETS) | gh-pages/staging/index.yaml
 .PHONY: stablerepo
 stablerepo: $(STABLE_TARGETS) | gh-pages/stable/index.yaml
 
+# TODO: Publish uses helm v2 we should consider testing with helm3 soon.
 .PHONY: publish
+publish: HELM_VERSION = v2.16.9
 publish: export LC_COLLATE := C
 publish:
 	-git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ $(STABLE_TARGETS) $(STAGING_TARGETS): $(TMPDIR)/.helm/repository/local/index.yam
 	$(HELM) --home $(TMPDIR)/.helm repo index $(patsubst %/index.yaml,%,$@) --url=https://$(GITHUB_USER).github.io/charts/$(patsubst gh-pages/%index.yaml,%,$@)
 
 $(TMPDIR)/.helm/repository/local/index.yaml: $(HELM)
-	$(HELM) --home $(TMPDIR)/.helm init --client-only
+	$(HELM) --home $(TMPDIR)/
 
 .PHONY: ct.lint
 ct.lint:

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ $(STABLE_TARGETS) $(STAGING_TARGETS): $(TMPDIR)/.helm/repository/local/index.yam
 	$(HELM) --home $(TMPDIR)/.helm repo index $(patsubst %/index.yaml,%,$@) --url=https://$(GITHUB_USER).github.io/charts/$(patsubst gh-pages/%index.yaml,%,$@)
 
 $(TMPDIR)/.helm/repository/local/index.yaml: $(HELM)
-	$(HELM) --home $(TMPDIR)/
+	$(HELM) --home $(TMPDIR)/.helm init --client-only
 
 .PHONY: ct.lint
 ct.lint:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
BUG

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Helm2 is currently used for publishing, we will force this to be the case for now. 

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
