### PR TITLE
fix: lint requires ct.yaml to be in test dir

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -44,7 +44,7 @@ dind_task("lint",
               "/bin/bash", "-c",
               """
               git fetch origin master --unshallow
-              make lint HELM_VERSION=v2.16.9 CT_VERSION=v2.4.1
+              make lint
               """
             ]
         )

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -1,0 +1,20 @@
+debug: true
+target-branch: master
+chart-dirs:
+  - stable
+  - staging
+excluded-charts:
+  - common
+  - dex-controller # Moved to a different helm repo
+chart-repos:
+  - mesosphere-staging=https://mesosphere.github.io/charts/staging
+  - mesosphere-stable=https://mesosphere.github.io/charts/stable
+  - kubefed-charts=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
+  - jetstack-charts=https://charts.jetstack.io
+  - banzaicloud=https://kubernetes-charts.banzaicloud.com
+  - helm-stable=https://kubernetes-charts.storage.googleapis.com/
+  - dex-controller=https://mesosphere.github.io/dex-controller/charts
+  - kommander=https://mesosphere.github.io/kommander/charts
+  - kubecost=https://kubecost.github.io/cost-analyzer
+  - yakcl=https://mesosphere.github.io/yakcl/charts
+helm-extra-args: --timeout 600s


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Lint is broken because we need to have the ct file in a particular location, reverting back to 3.0.0 but using the right ct file.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
