### PR TITLE
chore: bump kubeaddons-catalog image to v0.10.0

### DIFF
--- a/staging/kubeaddons-catalog/Chart.yaml
+++ b/staging/kubeaddons-catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.8.3"
 description: "A Catalog service for Kubeaddons"
 name: kubeaddons-catalog
-version: 0.1.11
+version: 0.1.12
 home: https://github.com/mesosphere/kommander-catalog-api
 sources:
 - https://github.com/mesosphere/kommander-catalog-api

--- a/staging/kubeaddons-catalog/values.yaml
+++ b/staging/kubeaddons-catalog/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: mesosphere/kubeaddons-catalog
-  tag: v0.8.6
+  tag: v0.10.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
This bumps the image used in the kubeaddons-catalog to v0.10.0, a version of kubeaddons-catalog which uses kubeaddons as a a backend. This will be followed by a PR updating the kommander chart.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-70803

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [X] The commit message explains the changes and why are needed.
* [X] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
