### PR TITLE
chore: Only add new files on publish of helm repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,16 +57,26 @@ stablerepo: $(STABLE_TARGETS) | gh-pages/stable/index.yaml
 
 # TODO: Publish uses helm v2 we should consider testing with helm3 soon.
 .PHONY: publish
-publish: HELM_VERSION = v2.16.9
+publish: HELM_VERSION = v2.16.10
 publish: export LC_COLLATE := C
 publish:
-	-git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1
+	-git remote add publish $(GIT_REMOTE_URL) &>/dev/null
 	rm -rf gh-pages
 	git fetch publish gh-pages
 	git worktree add gh-pages/ publish/gh-pages
 	$(MAKE) GIT_REF=$(GIT_REF) all
+# Check if any existing files other than repo index.yamls have been modified or deleted and exit if
+# there are, showing the list of changed files for easier troubleshooting.
 	cd gh-pages && \
-		git add -A . && \
+		export CHANGED=$$(git ls-files -md | grep -v index.yaml) && \
+		( \
+			[[ -z "$${CHANGED}" ]] || \
+			(printf "Aborting: following changed or deleted files:\n\n$${CHANGED}" && exit 1) \
+		)
+
+# Be doubly safe by only adding new files and index.yaml files to prevent overwrites.
+	cd gh-pages && \
+		git add $$(git ls-files -o --exclude-standard) staging/index.yaml stable/index.yaml && \
 		git commit -m "$(LAST_COMMIT_MESSAGE)" && \
 		git push publish HEAD:gh-pages
 	git worktree remove gh-pages/


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
Only adds new files when publishing the helm repo with checks for updated files before trying to publish.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
