### PR TITLE
Use 3.3.0 for publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ ifeq ($(shell uname),Darwin)
 	# mounting /var/folders/
 	TMPDIR := /private${TMPDIR}
 endif
+export HELM_CONFIG_HOME=$(TMPDIR)/.helm/config
+export HELM_CACHE_HOME=$(TMPDIR)/.helm/cache
+export HELM_DATA_HOME=$(TMPDIR)/.helm/data
 
 HELM := $(shell bash -c "command -v helm")
 ifeq ($(HELM),)
@@ -55,9 +58,7 @@ stagingrepo: $(STAGING_TARGETS) | gh-pages/staging/index.yaml
 .PHONY: stablerepo
 stablerepo: $(STABLE_TARGETS) | gh-pages/stable/index.yaml
 
-# TODO: Publish uses helm v2 we should consider testing with helm3 soon.
 .PHONY: publish
-publish: HELM_VERSION = v2.16.9
 publish: export LC_COLLATE := C
 publish:
 	-git remote add publish $(GIT_REMOTE_URL) >/dev/null 2>&1
@@ -91,7 +92,7 @@ $(STABLE_TARGETS) $(STAGING_TARGETS): $(TMPDIR)/.helm/repository/local/index.yam
 	@mkdir -p $(shell dirname $@)
 	$(eval PACKAGE_SRC := $(shell echo $@ | sed 's@gh-pages/\(.*\)-[v0-9][0-9.]*.tgz@\1@'))
 	$(eval UNPACKED_TMP := $(shell mktemp -d))
-	$(HELM) --home $(TMPDIR)/.helm package $(PACKAGE_SRC) -d $(shell dirname $@)
+	$(HELM) package $(PACKAGE_SRC) -d $(shell dirname $@)
 	tar -xzmf $@ -C $(UNPACKED_TMP)
 	tar -c \
 			--owner=root:0 --group=root:0 --numeric-owner \
@@ -102,12 +103,9 @@ $(STABLE_TARGETS) $(STAGING_TARGETS): $(TMPDIR)/.helm/repository/local/index.yam
 	rm -rf $(UNPACKED_TMP)
 
 %/index.yaml: $(STABLE_TARGETS) $(STAGING_TARGETS)
-%/index.yaml: $(TMPDIR)/.helm/repository/local/index.yaml
+%/index.yaml:
 	@mkdir -p $(patsubst %/index.yaml,%,$@)
-	$(HELM) --home $(TMPDIR)/.helm repo index $(patsubst %/index.yaml,%,$@) --url=https://$(GITHUB_USER).github.io/charts/$(patsubst gh-pages/%index.yaml,%,$@)
-
-$(TMPDIR)/.helm/repository/local/index.yaml: $(HELM)
-	$(HELM) --home $(TMPDIR)/.helm init --client-only
+	$(HELM) repo index $(patsubst %/index.yaml,%,$@) --url=https://$(GITHUB_USER).github.io/charts/$(patsubst gh-pages/%index.yaml,%,$@)
 
 .PHONY: ct.lint
 ct.lint:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Use helm 3.3.0 for the make publish target

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-71191

**Special notes for your reviewer**:
tested this up-to the push. All tarballs will be recreated to change the chart file permissions from 744 to 644. This is expected behavior.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
