### PR TITLE
Fixed the KubeHpaReplicasMismatch fault alert.

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -189,7 +189,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubehpareplicasmismatch
       expr: |-
         (kube_hpa_status_desired_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
-          !=
+          >
         kube_hpa_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"})
           and
         changes(kube_hpa_status_current_replicas[15m]) == 0


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
KubeHpaReplicasMismatch alert is faulty on konvoy soak cluster. The alert is due to
kube_hpa_status_current_replicas is 1, while
kube_hpa_status_desired_replicas is 0

The Prometheus alert expects the knative autoscaler hpa pod scales back to zore, which conflict with the knative HPA config `spec.minReplicas: 1`.

The alert should be less strict as "currentReplicas >= desiredReplicas" instead.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-71382

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No.

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
