### PR TITLE
Exposing 'registriesSkippingTagResolving' parameter for KNative Serving

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative
-version: 0.3.1
+version: 0.3.2
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: serving
-version: 0.3.1
+version: 0.3.2
 kubeVersion: ">=1.15.0"
 description: "Knative Serving"
 sources:

--- a/staging/knative/charts/serving/templates/serving.yaml
+++ b/staging/knative/charts/serving/templates/serving.yaml
@@ -423,6 +423,9 @@ data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
   queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue:{{ .Chart.AppVersion }}
+  {{- if .Values.deployment.registriesSkippingTagResolving }}
+  registriesSkippingTagResolving: "{{ .Values.deployment.registriesSkippingTagResolving }}"
+  {{- end }}
   _example: |
     ################################
     #                              #

--- a/staging/knative/charts/serving/templates/serving.yaml
+++ b/staging/knative/charts/serving/templates/serving.yaml
@@ -423,8 +423,8 @@ data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
   queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue:{{ .Chart.AppVersion }}
-  {{- if .Values.deployment.registriesSkippingTagResolving }}
-  registriesSkippingTagResolving: "{{ .Values.deployment.registriesSkippingTagResolving }}"
+  {{- if .Values.configDeployment.registriesSkippingTagResolving }}
+  registriesSkippingTagResolving: "{{ .Values.configDeployment.registriesSkippingTagResolving }}"
   {{- end }}
   _example: |
     ################################

--- a/staging/knative/charts/serving/values.yaml
+++ b/staging/knative/charts/serving/values.yaml
@@ -7,3 +7,6 @@ customMetricsApiservice:
 
 namespaceKnativeServing:
   additionalLabels: {}
+
+deployment:
+  registriesSkippingTagResolving: ""

--- a/staging/knative/charts/serving/values.yaml
+++ b/staging/knative/charts/serving/values.yaml
@@ -8,5 +8,5 @@ customMetricsApiservice:
 namespaceKnativeServing:
   additionalLabels: {}
 
-deployment:
+configDeployment:
   registriesSkippingTagResolving: ""

--- a/staging/knative/requirements.yaml
+++ b/staging/knative/requirements.yaml
@@ -6,5 +6,5 @@ dependencies:
     version: 0.2.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 0.3.1
+    version: 0.3.2
     condition: serving.enabled

--- a/staging/knative/values.yaml
+++ b/staging/knative/values.yaml
@@ -14,3 +14,5 @@ serving:
     enabled: true
   namespaceKnativeServing:
     additionalLabels: {}
+  deployment:
+    registriesSkippingTagResolving: ""

--- a/staging/knative/values.yaml
+++ b/staging/knative/values.yaml
@@ -14,5 +14,5 @@ serving:
     enabled: true
   namespaceKnativeServing:
     additionalLabels: {}
-  deployment:
+  configDeployment:
     registriesSkippingTagResolving: ""


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
KNative Serving resolves image tags to their digests when service deployment is created. This doesn't work for air-gapped installations and we need an option to exclude registries for which it doesn't work.

**Which issue(s) this PR fixes**:
[D2IQ-71478: pods launched by kfserving use image SHA instead of tags](https://jira.d2iq.com/browse/D2IQ-71478)

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
NONE

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
