### PR TITLE
fix: usage of kubectl:latest

### DIFF
--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.1.15
+version: 0.1.16
 appVersion: 0.10.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/templates/install-crds.yaml
+++ b/staging/cert-manager-setup/templates/install-crds.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: cert-manager-setup-crds
       containers:
         - name: cert-manager-setup-crds
-          image: "bitnami/kubectl:1.18.8"
+          image: "bitnami/kubectl:1.18.8-debian-10-r15"
           volumeMounts:
             - name: cert-manager-setup-crds
               mountPath: /etc/cert-manager-setup-crds

--- a/staging/cert-manager-setup/templates/install-crds.yaml
+++ b/staging/cert-manager-setup/templates/install-crds.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: cert-manager-setup-crds
       containers:
         - name: cert-manager-setup-crds
-          image: "bitnami/kubectl:1.18.8@sha256:817448e45d235d833c1cfdd3fd853668573b21d28fa6b95f1a6b24123db6eba7"
+          image: "bitnami/kubectl:1.18.8"
           volumeMounts:
             - name: cert-manager-setup-crds
               mountPath: /etc/cert-manager-setup-crds

--- a/staging/cert-manager-setup/templates/post-install-hook-job.yaml
+++ b/staging/cert-manager-setup/templates/post-install-hook-job.yaml
@@ -18,6 +18,6 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Chart.Name }}
-        image: bitnami/kubectl:1.18.8
+        image: bitnami/kubectl:1.18.8-debian-10-r15
         imagePullPolicy: IfNotPresent
         command: ["kubectl", "wait", "--for=condition=Available", "--timeout=360s", "apiservice", "v1beta1.webhook.certmanager.k8s.io"]

--- a/staging/cert-manager-setup/templates/post-install-hook-job.yaml
+++ b/staging/cert-manager-setup/templates/post-install-hook-job.yaml
@@ -18,6 +18,6 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Chart.Name }}
-        image: bitnami/kubectl:latest
+        image: bitnami/kubectl:1.18.8
         imagePullPolicy: IfNotPresent
         command: ["kubectl", "wait", "--for=condition=Available", "--timeout=360s", "apiservice", "v1beta1.webhook.certmanager.k8s.io"]

--- a/staging/flagger/Chart.yaml
+++ b/staging/flagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger
-version: 0.19.0
+version: 0.19.1
 appVersion: 0.19.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/staging/flagger/templates/job.yaml
+++ b/staging/flagger/templates/job.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: {{ template "flagger.fullname" . }}
       containers:
         - name: ns-labeler
-          image: "bitnami/kubectl:latest"
+          image: "bitnami/kubectl:1.18.8"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args: ["kubectl label --overwrite ns {{ .Release.Namespace }} istio-injection=enabled; kubectl label --overwrite ns {{ .Release.Namespace }} ca.istio.io/override=true"]

--- a/staging/flagger/templates/job.yaml
+++ b/staging/flagger/templates/job.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: {{ template "flagger.fullname" . }}
       containers:
         - name: ns-labeler
-          image: "bitnami/kubectl:1.18.8"
+          image: "bitnami/kubectl:1.18.8-debian-10-r15"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args: ["kubectl label --overwrite ns {{ .Release.Namespace }} istio-injection=enabled; kubectl label --overwrite ns {{ .Release.Namespace }} ca.istio.io/override=true"]

--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.4
+version: 1.87.5
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/tests/test-certificate.yaml
+++ b/staging/traefik/templates/tests/test-certificate.yaml
@@ -82,7 +82,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ template "traefik.fullname" . }}-konvoyconfig-kubeaddons-deploy-job-pod
-        image: bitnami/kubectl:1.18.8
+        image: bitnami/kubectl:1.18.8-debian-10-r15
         command:
         - kubectl
         - apply

--- a/staging/traefik/templates/tests/test-certificate.yaml
+++ b/staging/traefik/templates/tests/test-certificate.yaml
@@ -82,7 +82,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ template "traefik.fullname" . }}-konvoyconfig-kubeaddons-deploy-job-pod
-        image: bitnami/kubectl:latest
+        image: bitnami/kubectl:1.18.8
         command:
         - kubectl
         - apply

--- a/staging/traefik/templates/tests/test-customCertificate.yaml
+++ b/staging/traefik/templates/tests/test-customCertificate.yaml
@@ -84,7 +84,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ template "traefik.fullname" . }}-konvoy-company-cert-deploy-job-pod
-        image: bitnami/kubectl:1.18.8
+        image: bitnami/kubectl:1.18.8-debian-10-r15
         command:
         - kubectl
         - apply

--- a/staging/traefik/templates/tests/test-customCertificate.yaml
+++ b/staging/traefik/templates/tests/test-customCertificate.yaml
@@ -84,7 +84,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ template "traefik.fullname" . }}-konvoy-company-cert-deploy-job-pod
-        image: bitnami/kubectl:latest
+        image: bitnami/kubectl:1.18.8
         command:
         - kubectl
         - apply


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug
**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Generally, we should NOT use `latest` tag due to multiple reason. But today, the `latest` tag is breaking the Konvoy airgapped bundle generation due to the lack of repository tags when pulling it. Latest tag is 1.18.8 but 1.18.4 doesn't have that problem and should work as well.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
