### PR TITLE
fix:[nvidia] Add Centos 7.7 Vault Repo for Konvoy 1.5 support

### DIFF
--- a/staging/nvidia/Chart.yaml
+++ b/staging/nvidia/Chart.yaml
@@ -4,7 +4,7 @@ description: Nvidia GPU driver and device plugin for running Nvidia GPU
 keywords:
   - gpu
   - nvidia
-version: 0.3.4
+version: 0.3.5
 appVersion: "0.2.0"
 home: http://github.com/mesosphere/charts/staging
 sources:

--- a/staging/nvidia/charts/nvidia-driver/Chart.yaml
+++ b/staging/nvidia/charts/nvidia-driver/Chart.yaml
@@ -3,7 +3,7 @@ name: nvidia-driver
 home: https://github.com/mesosphere/charts
 appVersion: "1.0"
 description: Nvidia Driver for konvoy
-version: 0.1.5
+version: 0.1.6
 maintainers:
   - name: gilbert88
   - name: joejulian

--- a/staging/nvidia/charts/nvidia-driver/templates/configmap.yaml
+++ b/staging/nvidia/charts/nvidia-driver/templates/configmap.yaml
@@ -23,6 +23,21 @@ data:
     gpgcheck=1
     gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
     enabled=1
+
+    # C7.7.1908
+    [C7.7.1908-base]
+    name=CentOS-7.7.1908 - Base
+    baseurl=http://vault.centos.org/7.7.1908/os/$basearch/
+    gpgcheck=1
+    gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+    enabled=1
+
+    [C7.7.1908-updates]
+    name=CentOS-7.7.1908 - Updates
+    baseurl=http://vault.centos.org/7.7.1908/updates/$basearch/
+    gpgcheck=1
+    gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+    enabled=1
 {{- end }}
 ---
 kind: ConfigMap

--- a/staging/nvidia/requirements.yaml
+++ b/staging/nvidia/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 0.1.2
     condition: nvidia-device-plugin.enabled
   - name: nvidia-driver
-    version: 0.1.5
+    version: 0.1.6
     condition: nvidia-driver.enabled


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
Konvoy 1.5 uses Centos 7.7 AMI be default. The kernel headers for the version used by Centos 7.7 AMI is not in standard Centos repos. This leads to nvidia driver container to fail on default install unless tagged with appropriate tag. I think we need this since this reduces friction for a default install.  

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/COPS-6483

**Special notes for your reviewer**:
@Gilbert88 @joejulian 
If this is merged I can send a PR for addons repo to use this version of chart.  
**Does this PR introduce a user-facing change?**:
Yes
```release-note
No need to specify nvidia-driver tag when using th default AMI for GPU nodes.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
