### PR TITLE
kubecost: Include new savings rule

### DIFF
--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.65.0
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.1.14
+version: 0.1.15
 maintainers:
   - name: gracedo

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -175,20 +175,6 @@ cost-analyzer:
       persistentVolume:
         enabled: false
     serverFiles:
-      rules:
-        groups:
-          - name: CPU
-            rules:
-              - expr: sum(rate(container_cpu_usage_seconds_total{container_name!=""}[5m]))
-                record: cluster:cpu_usage:rate5m
-              - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
-                record: cluster:cpu_usage_nosum:rate5m
-              - expr: avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m])) by (container_name,pod_name,namespace)
-                record: kubecost_container_cpu_usage_irate
-              - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""}) by (container_name,pod_name,namespace)
-                record: kubecost_container_memory_working_set_bytes
-              - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})
-                record: kubecost_cluster_memory_working_set_bytes
       alerts:
         groups:
           - name: Kubecost

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -114,11 +114,6 @@ cost-analyzer:
         log.format: json
         storage.tsdb.min-block-duration: 2h
         storage.tsdb.max-block-duration: 2h
-      # extraVolumes: # TODO
-      # - name: object-store-volume
-      #   secret:
-      #     # Ensure this secret name matches thanos.storeSecretName
-      #     secretName: kubecost-thanos
       enableAdminApi: true
       service:
         gRPC:
@@ -132,7 +127,6 @@ cost-analyzer:
         - --tsdb.path=/data/
         - --prometheus.url=http://127.0.0.1:9090
         - --reloader.config-file=/etc/config/prometheus.yml
-        # - --objstore.config-file=/etc/config/object-store.yaml # TODO
         # Start of time range limit to serve. Thanos sidecar will serve only metrics, which happened
         # later than this value. Option can be a constant time in RFC3339 format or time duration
         # relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.
@@ -155,8 +149,6 @@ cost-analyzer:
         - name: storage-volume
           mountPath: /data
           subPath: ""
-        # - name: object-store-volume # TODO
-        #   mountPath: /etc/config
     alertmanager:
       enabled: true
       image:
@@ -250,6 +242,3 @@ cost-analyzer:
       enabled: false
     compact:
       enabled: false
-    # This secret name should match the sidecar configured secret name volume
-    # in the prometheus.server.extraVolumes entry
-    # storeSecretName: kubecost-thanos # TODO


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Latest version of kubecost added a new prom recordingrule to values file. I originally included the block in our parent values, so this overwrote the block in the updated kubecost base values, excluding the new rule. Instead here I remove our block altogether since we don't need to customize on top of the base chart.

Excluding the extra rule had resulted in error messages in the kubecost UI:
![image](https://user-images.githubusercontent.com/5897740/93638683-92c07900-f9ac-11ea-9962-552504c65632.png)
![image](https://user-images.githubusercontent.com/5897740/93638736-ae2b8400-f9ac-11ea-97d2-bb8e7b94e620.png)


**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
no issue

**Special notes for your reviewer**:

Verified that new rule is included in the configmap
```

  rules: |
    groups:
    - name: CPU
      rules:
      - expr: sum(rate(container_cpu_usage_seconds_total{container_name!=""}[5m]))
        record: cluster:cpu_usage:rate5m
      - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
        record: cluster:cpu_usage_nosum:rate5m
      - expr: avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m])) by (container_name,pod_name,namespace)
        record: kubecost_container_cpu_usage_irate
      - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""}) by (container_name,pod_name,namespace)
        record: kubecost_container_memory_working_set_bytes
      - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})
        record: kubecost_cluster_memory_working_set_bytes
    - name: Savings
      rules:
      - expr: sum(avg(kube_pod_owner{owner_kind!="DaemonSet"}) by (pod) * sum(container_cpu_allocation) by (pod))
        labels:
          daemonset: "false"
        record: kubecost_savings_cpu_allocation
      - expr: sum(avg(kube_pod_owner{owner_kind="DaemonSet"}) by (pod) * sum(container_cpu_allocation) by (pod)) / sum(kube_node_info)
        labels:
          daemonset: "true"
        record: kubecost_savings_cpu_allocation
      - expr: sum(avg(kube_pod_owner{owner_kind!="DaemonSet"}) by (pod) * sum(container_memory_allocation_bytes) by (pod))
        labels:
          daemonset: "false"
        record: kubecost_savings_memory_allocation_bytes
      - expr: sum(avg(kube_pod_owner{owner_kind="DaemonSet"}) by (pod) * sum(container_memory_allocation_bytes) by (pod)) / sum(kube_node_info)
        labels:
          daemonset: "true"
        record: kubecost_savings_memory_allocation_bytes
      - expr: label_replace(sum(kube_pod_status_phase{phase="Running",namespace!="kube-system"} > 0) by (pod, namespace), "pod_name", "$1", "pod", "(.+)")
        record: kubecost_savings_running_pods
      - expr: sum(rate(container_cpu_usage_seconds_total{container_name!="",container_name!="POD",instance!=""}[5m])) by (namespace, pod_name, container_name, instance)
        record: kubecost_savings_container_cpu_usage_seconds
      - expr: sum(container_memory_working_set_bytes{container_name!="",container_name!="POD",instance!=""}) by (namespace, pod_name, container_name, instance)
        record: kubecost_savings_container_memory_usage_bytes
      - expr: avg(sum(kube_pod_container_resource_requests_cpu_cores{namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
        record: kubecost_savings_pod_requests_cpu_cores
      - expr: avg(sum(kube_pod_container_resource_requests_memory_bytes{namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
        record: kubecost_savings_pod_requests_memory_bytes
```
![image](https://user-images.githubusercontent.com/5897740/93638774-ba174600-f9ac-11ea-90e0-7370bedec4ac.png)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
