### PR TITLE
Dispatchfile: track kommander bumps

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -1,16 +1,19 @@
-#!mesosphere/dispatch-starlark:v0.5-beta2
+#!mesosphere/dispatch-starlark:v0.6
 # vi:syntax=python
 #
 
 
-load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.4", "gitResource", "pullRequest", "push", "secretVar")
+load("github.com/mesosphere/dispatch-catalog/starlark/stable/git@0.0.7", "git_resource")
 #TODO @faiq: once 0.0.5 of this package is released switch to that ref
+load("github.com/mesosphere/dispatch-catalog/starlark/stable/k8s@0.0.7", "secret_var")
+load("github.com/mesosphere/dispatch-catalog/starlark/stable/pipeline@0.0.7", "pull_request", "push")
 load("github.com/mesosphere/dispatch-catalog/starlark/stable/docker@dc4612e95b62ff8b744bda2e4d3c75cf2edeb694", "dind_task")
+load("github.com/mesosphere/dispatch-tasks/bump_charts/bump_charts@master", "bump_charts")
 
 git = "src-git"
 
-gitResource(git,
-    url="$(context.git.url)",
+git_resource(git,
+    url="https://github.com/mesosphere/charts",
     revision="$(context.git.commit)")
 
 dind_task("publish",
@@ -29,7 +32,7 @@ dind_task("publish",
               make publish
               """
             ],
-            env=[k8s.corev1.EnvVar(name="GITHUB_USER_TOKEN", valueFrom=secretVar("scmtoken", "password"))]
+            env=[k8s.corev1.EnvVar(name="GITHUB_USER_TOKEN", valueFrom=secret_var("scmtoken", "password"))]
         )
     ]
 )
@@ -99,7 +102,61 @@ dind_task("test-helm3",
   ]
 )
 
-action(tasks=["test-helm2","test-helm3"], on=pullRequest())
+def bump_addon(repo_name, task_name, addon_git_dir, chart_path):
+    """
+    Automatically creates PRs on the source repo to update helm charts within addon yaml definitions.
+    """
+    task(task_name, inputs=[git, addon_git_dir], steps=[
+        v1.Container(
+            name = task_name,
+            image = "mesosphere/bump-charts:master",
+            workingDir =  "/workspace/" + addon_git_dir,
+            command = ["/bin/sh", "-c"],
+            args = [
+                """
+                set -e
+                echo "$GPG_PRIVATE_KEY" > gpg_private_key
+                echo "$GPG_PUBLIC_KEY" > gpg_public_key
+                set -x
+                git fetch origin
+                gpg --import gpg_private_key
+                gpg --import gpg_public_key
+                git config --local commit.gpgsign true
+                git config --local user.signingkey $GPG_KEY_ID
+                git config --local user.name 'Dispatch CI'
+                git config --local user.email '56653984+d2iq-dispatch@users.noreply.github.com'
+                cp /bump_charts/update_single_addon.py /bump_charts/bump_charts.py .
+                python3 update_single_addon.py --addon-name {} --chart-file-path {} --repo-name {}
+                """.format("kommander", "/workspace/{}/{}".format(git, chart_path), repo_name)
+            ],
+            resources = k8s.corev1.ResourceRequirements(
+                limits = {
+                    "cpu": k8s.resource_quantity("1000m"),
+                    "memory": k8s.resource_quantity("4Gi")
+                }
+            ),
+            env=[k8s.corev1.EnvVar(name="GITHUB_TOKEN", valueFrom=secret_var("d2iq-dispatch-basic-auth", "password")),
+                k8s.corev1.EnvVar(name="GPG_PRIVATE_KEY", valueFrom=secret_var("d2iq-dispatch-gpg", "private_key")),
+                k8s.corev1.EnvVar(name="GPG_PUBLIC_KEY", valueFrom=secret_var("d2iq-dispatch-gpg", "public_key")),
+                k8s.corev1.EnvVar(name="GPG_KEY_ID", valueFrom=secret_var("d2iq-dispatch-gpg", "key_id"))
+            ]
+        )
+    ])
+
+    return task_name
+
+
+kommander_chart_path = "stable/kommander/Chart.yaml"
+kubeaddons_kommander_git = "kubeaddons-kommander"
+git_resource(
+  kubeaddons_kommander_git,
+  url="https://github.com/mesosphere/kubeaddons-kommander",
+  revision="master")
+do_bump_kommander = bump_addon('kubeaddons-kommander', "bump-kommander", kubeaddons_kommander_git, kommander_chart_path)
+
+
+action(tasks=["test-helm2","test-helm3"], on=pull_request())
 action(tasks=["publish"], on=push(branches=["master"]))
-action(tasks = ["test-helm2"], on = pullRequest(chatops = ["test-helm2"]))
-action(tasks = ["test-helm3"], on = pullRequest(chatops = ["test-helm3"]))
+action(tasks = ["test-helm2"], on = pull_request(chatops = ["test-helm2"]))
+action(tasks = ["test-helm3"], on = pull_request(chatops = ["test-helm3"]))
+action(tasks = [do_bump_kommander], on = pull_request(paths = [kommander_chart_path]))


### PR DESCRIPTION
**What this PR does/ why we need it**:
When the kommander chart gets updated, a PR will automatically be created on mesosphere/kubeaddons-kommander. The same logic will easily be applied to kubernetes-base-addons and kubeaddons-enterprise. I will add those in a future PR.
Proof it works: https://github.com/mesosphere/kubeaddons-kommander/pull/160

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-70923

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
