### PR TITLE
cert-manager: Use clusterissuers instead of deprecated clusterissuer

### DIFF
--- a/staging/cert-manager-setup/Chart.yaml
+++ b/staging/cert-manager-setup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager-setup
 home: https://github.com/mesosphere/charts
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.0.1
 description: Install cert-manager and optionally add a ClusterIssuer
 keywords:

--- a/staging/cert-manager-setup/README.md
+++ b/staging/cert-manager-setup/README.md
@@ -28,11 +28,11 @@ certificates:
 # Supported values format
 
 ```yaml
-clusterissuer:
-  name: clusterissuer-name
-  spec:
-    ca:
-      secretName: clusterissuer-secret
+clusterissuers:
+  - name: clusterissuer-name
+    spec:
+      ca:
+        secretName: clusterissuer-secret
 ```
 
 In the given example we create a `ClusterIssuer` named `clusterissuer-name` with the `ca` type. The `ca` type expects a secret that contains the Certificate Authority (CA) to be used by this `ClusterIssuer`. The spec follows the original `cert-manager` [spec](https://docs.cert-manager.io/en/latest/tasks/issuers/setup-ca.html#creating-an-issuer-referencing-the-secret).

--- a/staging/cert-manager-setup/ci/test-values.yaml
+++ b/staging/cert-manager-setup/ci/test-values.yaml
@@ -1,7 +1,7 @@
 # These test values are used for chart testing
 # DO NOT EDIT unless you know what you are doing
-clusterissuer:
-  name: kubernetes-ca
-  spec:
-    ca:
-      secretName: kubernetes-intermediate-ca
+clusterissuers:
+  - name: kubernetes-ca
+    spec:
+      ca:
+        secretName: kubernetes-intermediate-ca

--- a/staging/cert-manager-setup/values.yaml
+++ b/staging/cert-manager-setup/values.yaml
@@ -66,13 +66,6 @@ clusterissuers: []
 #      ca:
 #        secretName: my-certificate-secret
 
-# DEPRECATED, please use the above issuers, certificates and clusterissuers
-clusterissuer: {}
-  # name: kubernetes-ca
-  # spec:
-  #   ca:
-  #     secretName: kubernetes-intermediate-ca
-
 # When installing addons on a cluster that already has cert-manager
 # installed with webhook validation enabled this value should be set to
 # false. This is necessary because CRDs and Webhook (APIService) objects


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug (CI)

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
`clusterissuer` value is deprecated, but the test-values.yaml is still using it instead of `clusterissuers`, which is causing downstream chart tests dependent on this clusterissuer to fail (e.g. traefik).

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
