### PR TITLE
kommander: Reset kubecost thanos loglevel to default (info)

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.11.10
+version: 0.11.11

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -266,7 +266,6 @@ kubecost:
         enabled: false
       query:
         enabled: true
-        logLevel: error
         timeout: 3m
         maxConcurrent: 10
         # Name of HTTP request header used for dynamic prefixing of UI links and redirects.


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
At some point the thanos loglevel was set to `error` but this has made debugging really difficult, as the log file is completely empty. I would like to reset the level back to the default value, which is `info`, and moving forward we should configure this value in the kubeaddons-kommander config layer instead.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
