### PR TITLE
chore: bump kubeaddons-catalog chart to latest release

### DIFF
--- a/staging/kubeaddons-catalog/Chart.yaml
+++ b/staging/kubeaddons-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v0.11.3"
+appVersion: "v0.11.4"
 description: "A Catalog service for Kubeaddons"
 name: kubeaddons-catalog
-version: 0.1.14
+version: 0.1.15
 home: https://github.com/mesosphere/kommander-catalog-api
 sources:
 - https://github.com/mesosphere/kommander-catalog-api

--- a/staging/kubeaddons-catalog/values.yaml
+++ b/staging/kubeaddons-catalog/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: mesosphere/kubeaddons-catalog
-  tag: v0.11.3
+  tag: v0.11.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
bump kubeaddons-catalog chart to latest release

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72080

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fixed bug with catalog items not showing up
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
