### PR TITLE
chore: Tweak helm2 and helm3 checks in Dispatchfile

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -169,12 +169,14 @@ do_bump_addon = bump_addon("bump-addon", kba_git)
 kommander_chart_path = "stable/kommander/Chart.yaml"
 
 # Robot Actions
-action(tasks=["test-helm2", "test-helm3"], on=pull_request())
+action(tasks=["test-helm3"], on=pull_request(targets=["master", "release/3"]))
+action(tasks=["test-helm2"], on=pull_request(targets=["release/2"]))
 action(tasks=["publish"], on=push(branches=["master"]))
 action(tasks=[do_bump_kommander], on=push(branches=["master"], paths=[kommander_chart_path]))
 action(tasks=[do_bump_addon], on=push(branches=["master"], paths=["!" + kommander_chart_path, "stable/*/Chart.yaml", "staging/*/Chart.yaml"]))
 
 # Chatops Actions
-action(tasks=["test-helm2", "test-helm3"], on=pull_request(chatops=["test"]))
+action(tasks=["test-helm3"], on=pull_request(targets=["master", "release/3"], chatops=["test"]))
+action(tasks=["test-helm2"], on=pull_request(targets=["release/2"], chatops=["test"]))
 action(tasks=["test-helm2"], on=pull_request(chatops=["test-helm2"]))
 action(tasks=["test-helm3"], on=pull_request(chatops=["test-helm3"]))


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
This PR updates Dispatchfile to only run helm3 tests for PRs targeting `release/3` and `master` branches, and helm2 tests for PRs targeting `release/2`.

**Which issue(s) this PR fixes**:
No issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
