### PR TITLE
defaultstorageclass: Enable metrics collection

### DIFF
--- a/stable/defaultstorageclass/Chart.yaml
+++ b/stable/defaultstorageclass/Chart.yaml
@@ -4,7 +4,7 @@ description: Webhooks and controllers relating to default storage classes
 name: defaultstorageclass
 maintainers:
   - name: joejulian
-version: 0.0.3
+version: 0.0.4
 kubeVersion: ">=1.15.0"
 home: https://github.com/mesosphere/defaultstorageclass
 sources:

--- a/stable/defaultstorageclass/templates/service.yaml
+++ b/stable/defaultstorageclass/templates/service.yaml
@@ -5,7 +5,8 @@ metadata:
   creationTimestamp: null
   labels:
     control-plane: controller-manager
-    servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+    servicemonitor.kubeaddons.mesosphere.io/path: metrics
+    kubeaddons.mesosphere.io/name: defaultstorageclass
   name: dstorageclass-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:

--- a/stable/defaultstorageclass/templates/service.yaml
+++ b/stable/defaultstorageclass/templates/service.yaml
@@ -2,13 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/port: "8443"
-    prometheus.io/scheme: https
-    prometheus.io/scrape: "true"
   creationTimestamp: null
   labels:
     control-plane: controller-manager
+    servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
   name: dstorageclass-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Annotation-based service discovery has been deprecated in prometheus-operator so these metrics were no longer getting collected. Switch to use the service monitor model by adding this label to allow it to get scraped by Prometheus. This requires a change to the Prometheus addon config to add this metrics endpoint (will put up kba pr for this later after including all other necessary prom config changes to get metrics collected from other components):

```diff
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -100,6 +100,24 @@ spec:
               # configuration.
               - targetPort: 10902
                 interval: 30s
+          - name: kubeaddons-service-monitor-metrics-defaultstorageclass
+            selector:
+              matchLabels:
+                servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+                kubeaddons.mesosphere.io/name: "defaultstorageclass"
+            namespaceSelector:
+              matchNames:
+                - kubeaddons
+            endpoints:
+              - port: https
+                interval: 30s
+                scheme: https
+                bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+                tlsConfig:
+                  caFile: "/etc/prometheus/secrets/dstorageclass-webhook-server-cert/ca.crt"
+                  certFile: "/etc/prometheus/secrets/dstorageclass-webhook-server-cert/tls.crt"
+                  keyFile: "/etc/prometheus/secrets/dstorageclass-webhook-server-cert/tls.key"
+                  insecureSkipVerify: true
           - name: kubeaddons-service-monitor-api-v1-metrics-prometheus
             selector:
               matchLabels:
@@ -243,6 +261,7 @@ spec:
           walCompression: true
           secrets:
             - etcd-certs
+            - dstorageclass-webhook-server-cert
           externalUrl: "/ops/portal/prometheus"
           storageSpec:
             volumeClaimTemplate:
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72691

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
