### PR TITLE
external-dns: Add service.labels option

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.20.4
+version: 2.20.5
 appVersion: 0.7.0
 # The external-dns chart is deprecated and no longer maintained. For details deprecation, see the PROCESSES.md file.
 deprecated: true

--- a/stable/external-dns/templates/service.yaml
+++ b/stable/external-dns/templates/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: {{ template "external-dns.fullname" . }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+  {{- if .Values.service.labels -}}
+  {{ toYaml .Values.service.labels | nindent 4 }}
+  {{- end }}
   {{- if .Values.service.annotations }}
   annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
   {{- end }}

--- a/stable/external-dns/templates/service.yaml
+++ b/stable/external-dns/templates/service.yaml
@@ -30,5 +30,12 @@ spec:
     {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
     nodePort: {{ .Values.service.nodePort  }}
     {{- end }}
+  - name: metrics
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: http
+    {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
+    nodePort: {{ .Values.service.nodePort  }}
+    {{- end }}    
   selector: {{ include "external-dns.matchLabels" . | nindent 6 }}
   type: {{ .Values.service.type }}

--- a/stable/external-dns/templates/service.yaml
+++ b/stable/external-dns/templates/service.yaml
@@ -30,12 +30,5 @@ spec:
     {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
     nodePort: {{ .Values.service.nodePort  }}
     {{- end }}
-  - name: metrics
-    port: {{ .Values.service.port }}
-    protocol: TCP
-    targetPort: http
-    {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
-    nodePort: {{ .Values.service.nodePort  }}
-    {{- end }}    
   selector: {{ include "external-dns.matchLabels" . | nindent 6 }}
   type: {{ .Values.service.type }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -403,6 +403,12 @@ service:
   ##
   annotations: {}
 
+  ## Provide any additional labels which may be required. This can be used to
+  ## have external-dns show up in `kubectl cluster-info`
+  ##  kubernetes.io/cluster-service: "true"
+  ##  kubernetes.io/name: "external-dns"
+  labels: {}
+
 ## RBAC parameteres
 ## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -414,6 +414,12 @@ service:
   ##
   annotations: {}
 
+  ## Provide any additional labels which may be required. This can be used to
+  ## have external-dns show up in `kubectl cluster-info`
+  ##  kubernetes.io/cluster-service: "true"
+  ##  kubernetes.io/name: "external-dns"
+  labels: {}
+
 ## RBAC parameteres
 ## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature/chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Add option to define service labels, mainly so we can use a label to get its metrics discovered and scraped by prom. This func was already added to a later version in the upstream chart (https://github.com/bitnami/charts/commit/41d917aba5946d290580c96afb295b9b9207dc59#diff-b37fd4e4217d56abe479147564c4c1afc64d680c8c0612701f6e14ba7e3a8ef7) but we should not jump a major version so close to the release date in case something breaks. So, since we already have this fork, I've ported over this func here and will point us to this fork in KBA.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72698

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
