### PR TITLE
chore: Add config to set svc labels for metric collection

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.12.1
+version: 0.12.2
 name: metallb
 deprecated: true
 appVersion: 0.8.1

--- a/stable/metallb/templates/service.yaml
+++ b/stable/metallb/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.serviceMonitor.enabled }}
+{{- if or .Values.prometheus.metrics.enabled .Values.prometheus.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "metallb.chart" . }}
     app: {{ template "metallb.name" . }}
     jobLabel: {{ .Values.prometheus.serviceMonitor.jobLabel }}
+{{- if .Values.prometheus.metrics.labels }}
+{{ toYaml .Values.prometheus.metrics.labels | indent 4 }}
+{{- end }}
     component: controller
 spec:
   type: ClusterIP
@@ -32,6 +35,9 @@ metadata:
     chart: {{ template "metallb.chart" . }}
     app: {{ template "metallb.name" . }}
     jobLabel: {{ .Values.prometheus.serviceMonitor.jobLabel }}
+{{- if .Values.prometheus.metrics.labels }}
+{{ toYaml .Values.prometheus.metrics.labels | indent 4 }}
+{{- end }}
     component: speaker
 spec:
   type: ClusterIP

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -38,6 +38,13 @@ prometheus:
   # can be left at false.
   scrapeAnnotations: false
 
+  ## Enable the /metrics endpoints, for now only supports prometheus
+  ## set to true to enable metric collection by prometheus
+  metrics:
+    enabled: true
+    # labels to apply to the service
+    labels: {}
+
   # Prometheus Operator service monitors
   serviceMonitor:
 


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Add option to set service labels for prom scraping. The only KBA change requires setting the label `servicemonitor.kubeaddons.mesosphere.io/path: "metrics"` and metallb metrics will automatically get scraped using an existing servicemonitor.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72697

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
feat: Add option to set service labels
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
