### PR TITLE
flagger-loadtester: Add chart value service.labels

### DIFF
--- a/staging/flagger/Chart.yaml
+++ b/staging/flagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger
-version: 0.19.1
+version: 0.19.2
 appVersion: 0.19.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/staging/flagger/Chart.yaml
+++ b/staging/flagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger
-version: 0.19.2
+version: 0.20.0
 appVersion: 0.19.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/staging/flagger/charts/flagger-loadtester/Chart.yaml
+++ b/staging/flagger/charts/flagger-loadtester/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger-loadtester
-version: 0.9.1
+version: 0.10.0
 appVersion: 0.9.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/staging/flagger/charts/flagger-loadtester/Chart.yaml
+++ b/staging/flagger/charts/flagger-loadtester/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger-loadtester
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.9.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/staging/flagger/charts/flagger-loadtester/README.md
+++ b/staging/flagger/charts/flagger-loadtester/README.md
@@ -56,6 +56,7 @@ Parameter | Description | Default
 `nodeSelector` | Node labels for pod assignment | `{}`
 `service.type` | Type of service | `ClusterIP`
 `service.port` | ClusterIP port | `80`
+`service.labels` | Extra service labels | `{}`
 `cmd.timeout` | Command execution timeout | `1h`
 `logLevel` | Log level can be debug, info, warning, error or panic | `info`
 `meshName` | AWS App Mesh name | `none`

--- a/staging/flagger/charts/flagger-loadtester/templates/service.yaml
+++ b/staging/flagger/charts/flagger-loadtester/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "loadtester.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/staging/flagger/charts/flagger-loadtester/values.yaml
+++ b/staging/flagger/charts/flagger-loadtester/values.yaml
@@ -19,6 +19,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 80
+  labels: {}
 
 resources:
   requests:

--- a/staging/flagger/templates/crd.yaml
+++ b/staging/flagger/templates/crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: canaries.flagger.app

--- a/staging/flagger/templates/rbac.yaml
+++ b/staging/flagger/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "flagger.fullname" . }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This adds a chart value that can be used to apply labels to the service created by the flagger-loadtester chart. This is done to enable applying labels that allow Prometheus to discover flagger-loadtester's metrics endpoint.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72693

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
flagger-loadtester: Adds chart value `service.labels`.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
