### PR TITLE
Fix for cleanup job failure when configmap not present

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -14,7 +14,6 @@ sources:
   - https://coreos.com/operators/prometheus
 version: 9.3.2
 appVersion: 0.38.1
-tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator

--- a/staging/prometheus-operator/templates/mesosphere-hooks/prometheus-cluster-id-hooks.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/prometheus-cluster-id-hooks.yaml
@@ -103,6 +103,6 @@ spec:
           command:
             - /bin/sh
             - -c
-            - kubectl delete configmap {{ .Values.mesosphereResources.hooks.prometheus.configmapName }} -n {{ .Release.Namespace }}
+            - kubectl delete --ignore-not-found=true configmap {{ .Values.mesosphereResources.hooks.prometheus.configmapName }} -n {{ .Release.Namespace }}
       restartPolicy: OnFailure
 {{- end }}

--- a/staging/prometheus-operator/templates/prometheus/rules/mesosphere-rules/etcd-rules.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules/mesosphere-rules/etcd-rules.yaml
@@ -1,10 +1,10 @@
+{{- if and .Values.mesosphereResources.create .Values.mesosphereResources.rules.etcd }}
 # Rules for alerting against etcd, without the etcd alerts: etcdHighNumberOfFailedGRPCRequests
 # Which at the moment are false positives at a rate of 100%
-{{- if and .Values.mesosphereResources.create .Values.mesosphereResources.rules.etcd }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" .) "etcd" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" "etcd" (include "prometheus-operator.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
     app: {{ template "prometheus-operator.name" . }}
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/staging/prometheus-operator/templates/prometheus/rules/mesosphere-rules/etcd-rules.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules/mesosphere-rules/etcd-rules.yaml
@@ -4,7 +4,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ printf "%s-%s" "etcd" (include "prometheus-operator.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" .) "etcd" | trunc 63 | trimSuffix "-" }}
   labels:
     app: {{ template "prometheus-operator.name" . }}
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/staging/prometheus-operator/templates/prometheus/rules/mesosphere-rules/velero-rules.yaml
+++ b/staging/prometheus-operator/templates/prometheus/rules/mesosphere-rules/velero-rules.yaml
@@ -1,5 +1,5 @@
-# Rules for alerting against velero
 {{- if and .Values.mesosphereResources.create .Values.mesosphereResources.rules.velero }}
+# Rules for alerting against velero
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Cleanup job fails if configmap doesn't exist. Don't fail, we didn't want it to exist anyway.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72743

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
