### PR TITLE
flagger: Revert CRD version upgrade

### DIFF
--- a/staging/flagger/Chart.yaml
+++ b/staging/flagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger
-version: 0.20.0
+version: 0.20.1
 appVersion: 0.19.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/staging/flagger/templates/crd.yaml
+++ b/staging/flagger/templates/crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: canaries.flagger.app


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This reverts a change from #860 that breaks installation of this chart. See https://jira.d2iq.com/browse/D2IQ-72803 for more information on why this PR is necessary.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72694

**Special notes for your reviewer**:

Lint is failing because it's complaining about the deprecated resource version:

```
[ERROR] templates/crd.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
flagger: Fix chart install
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
