### PR TITLE
D2IQ-72789: move kubeaddons-kommander values into kommander chart

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.12.16
+version: 0.13.0

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -10,25 +10,60 @@ global:
       enabled: false
       chartRepo: http://konvoy-addons-chart-repo.kubeaddons.svc:8879
 
+ingress:
+  extraAnnotations:
+    traefik.ingress.kubernetes.io/priority: "2"
+
 kommander-federation:
   enabled: true
+  utilityApiserver:
+    minimumKubernetesVersion: 1.16.0
+  certificates:
+    issuer:
+      name: kubernetes-ca
+      kind: ClusterIssuer
+  konvoy:
+    allowUnofficialReleases: false
+  kubefed:
+    controllermanager:
+      annotations:
+        secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+      webhook:
+        annotations:
+          secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
 
 kommander-licensing:
   enabled: true
+  certificates:
+    issuer:
+      name: kubernetes-ca
+      kind: ClusterIssuer
 
 kommander-thanos:
   enabled: true
   thanosAddress: "prometheus-kubeaddons-prom-prometheus.kubeaddons.svc.cluster.local:10901"
   kommanderServiceAccount: kommander-kubeaddons
+  thanos:
+    query:
+      deploymentAnnotations:
+        secret.reloader.stakater.com/reload: kommander-thanos-client-tls
 
 kommander-karma:
   enabled: true
   alertmanagerAddress: "prometheus-kubeaddons-prom-alertmanager.kubeaddons.svc.cluster.local:9093"
   kommanderServiceAccount: kommander-kubeaddons
   kommanderKarmaConfigMap: kommander-kubeaddons-config
+  karma:
+    deployment:
+      annotations:
+        configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
 
 kubeaddons-catalog:
   enabled: true
+  ingress:
+    enable: false
+    hostName: catalog.kubeaddons.localhost
+    annotations: {}
 
 grafana:
   enabled: true
@@ -179,6 +214,8 @@ kommander-ui:
       traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Impersonate-User,Impersonate-Group
     path: /ops/portal/kommander/ui
     graphqlPath: /ops/portal/kommander/ui/graphql
+  podAnnotations: {}
+  #  iam.amazonaws.com/role: xyz
 
 portalRBAC:
   grafana:
@@ -197,6 +234,7 @@ kubecost:
 
   cost-analyzer:
     enabled: true
+
     fullnameOverride: "kommander-kubecost-cost-analyzer"
     global:
       prometheus:
@@ -208,6 +246,9 @@ kubecost:
         queryService: http://kommander-kubecost-thanos-query-http.kommander:10902
         # The wait time before Kommander begins querying cost data for all attached clusters
         queryOffset: 5m
+        query:
+          deploymentAnnotations:
+            secret.reloader.stakater.com/reload: kommander-kubecost-thanos-client-tls
 
       grafana:
         # If false, Grafana will not be installed
@@ -287,7 +328,7 @@ kubecost:
         sidecarDNSDiscovery: false
         # Names of configmaps that contain addresses of store API servers, used for file service discovery.
         serviceDiscoveryFileConfigMaps:
-        - kubecost-thanos-query-stores
+          - kubecost-thanos-query-stores
         # Refresh interval to re-read file SD files. It is used as a resync fallback.
         serviceDiscoveryInterval: 5m
         extraArgs:


### PR DESCRIPTION


Closes  D2IQ-72789

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

Refactoring (if you think about the addon and chart as a union)

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This enables us to install the chart directly without the addon indirection and therefore we can test the chart as the product

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

D2IQ-72789

**Special notes for your reviewer**:

I'm a bit unsure if the ingress part needs to be nested under global 🤔 Currently I just merged it all on the respective level 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
