### PR TITLE
kommander: Fix cost analyzer ingress path

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.12.10
+version: 0.12.11

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -219,17 +219,14 @@ kubecost:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: traefik
+        traefik.frontend.rule.type: PathPrefixStrip
         ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
-        traefik.frontend.rule.type: "PathPrefix"
-        traefik.frontend.redirect.regex: "^(.*)/ops/portal/kommander/kubecost/frontend$"
-        traefik.frontend.redirect.replacement: "$1/ops/portal/kommander/kubecost/frontend/"
-        traefik.ingress.kubernetes.io/request-modifier: 'ReplacePathRegex: ^/ops/portal/kommander/kubecost/frontend/(.*) /$1'
         traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
         traefik.ingress.kubernetes.io/auth-type: forward
         traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
         traefik.ingress.kubernetes.io/priority: "4"
       paths:
-        - "/ops/portal/kommander/kubecost/frontend"
+        - "/ops/portal/kommander/kubecost/frontend/"
       hosts:
         - ""
       tls: []


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This simplifies the ingress by removing path rewrites that are no longer
necessary due to a fix in the cost analyzer. It also fixes a possible
authz error that may be encountered if a user with a role that includes
any restrictions on authorized URLs tries to browse to the cost
analyzer UI.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-71985

**Special notes for your reviewer**:

I tested this by browsing to `/ops/portal/kommander/kubecost/frontend` (no trailing slash) and observing that I was redirected to `/ops/portal/kommander/kubecost/frontend/` (with trailing slash) and that the UI loaded with no errors. Here's a screenshot from Chrome's dev tools to demonstrate:

<img width="576" alt="Screen Shot 2020-11-10 at 5 48 06 PM" src="https://user-images.githubusercontent.com/42242/98755402-4dea0a80-237d-11eb-87ee-da34579a9aae.png">


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kommander] Fixes an authz error that may be encountered if a user bound to a role with any restrictions on authorized URLs tries to access the cost analyzer UI.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
