### PR TITLE
create the serviceaccount needed for deletion jobs on delete

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.12.12
+version: 0.12.13

--- a/stable/kommander/templates/hooks-roles.yaml
+++ b/stable/kommander/templates/hooks-roles.yaml
@@ -10,5 +10,5 @@ metadata:
     release: "{{ .Release.name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-delete
     helm.sh/hook-delete-policy: "before-hook-creation"


### PR DESCRIPTION


**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
When trying to delete kommander, it failed with:

```
Error creating: pods "cleanup-kommander-kubeaddons-ops-portal-username-" is forbidden: error looking up service account kommander/kommander-kubeaddons: serviceaccount "kommander-kubeaddons" not found
```

This was because the install failed (for k8s envioronmental reasons)
which left the helm release in an error state and the service account
not installed.

By adding this hook to the delete phase, this will prevent the cleanup
job from not having its service account.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:
A friend told my wife she drew her eyebrows too high. She seemed surprised.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
