### PR TITLE
chore(vsphere-csi-driver): storageclass addition + driver version update

### DIFF
--- a/stable/vsphere-csi-driver/Chart.yaml
+++ b/stable/vsphere-csi-driver/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-appVersion: 2.0.0
+appVersion: 2.0.1
 description: vSphere Container Storage Interface (CSI) driver
 name: vsphere-csi-driver
 maintainers:
   - name: sebbrandt87
-version: 1.0.0
+version: 1.1.0
 kubeVersion: ">=1.16.0"
 home: https://vsphere-csi-driver.sigs.k8s.io
 sources:

--- a/stable/vsphere-csi-driver/templates/storageclass.yaml
+++ b/stable/vsphere-csi-driver/templates/storageclass.yaml
@@ -11,3 +11,7 @@ provisioner: csi.vsphere.vmware.com
 allowVolumeExpansion: true
 volumeBindingMode: {{ .Values.storageclass.volumeBindingMode | quote }}
 reclaimPolicy: {{ .Values.storageclass.reclaimPolicy | quote }}
+{{- if .Values.storageclass.parameters }}
+parameters:
+{{ toYaml .Values.storageclass.parameters | indent 2 }}
+{{- end }}

--- a/stable/vsphere-csi-driver/values.yaml
+++ b/stable/vsphere-csi-driver/values.yaml
@@ -63,3 +63,8 @@ storageclass:
   isDefault: true
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
+  # parameters to set for storageclass
+  # e.g.
+  # parameters:
+  #   storagepolicyname: Bronze NFS
+  parameters: {}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- Added `storageclass.parameters` to values. Needed e.g. for vSphere storagepolicy usage, where a customer would define a storage policy like `bronze-nfs` on vSphere and must tell the storageclass to use it. The only situation where it is not needed is in a default vSAN setup, which may not all customers have.
- raised appVersion to get bugfix for vSphere 6.7U3
(https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.0.1)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
[D2IQ-71493]

[D2IQ-71493]: https://jira.d2iq.com/browse/D2IQ-71493


**Special notes for your reviewer**:
https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.storage.doc/GUID-89091D59-D844-46B2-94C2-35A3961D23E7.html

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.