### PR TITLE
chore(prometheus-operator): bump prometheus image tag to 2.20.0

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.3
+version: 9.3.4
 appVersion: 0.38.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -1611,7 +1611,7 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.18.2
+      tag: v2.20.0
       sha: ""
 
     ## Tolerations for use with node taints


### PR DESCRIPTION
**What type of PR is this?** Chore
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**: Default image tag needs updated to what we run in SOAK. This will also be used to ensure Prometheus image tag is updated for [federation](https://github.com/mesosphere/yakcl/pull/270). 
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**: D2IQ-73110
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
