### PR TITLE
flagger: Add podLabels value

### DIFF
--- a/staging/flagger/Chart.yaml
+++ b/staging/flagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: flagger
-version: 0.20.1
+version: 0.21.0
 appVersion: 0.19.0
 kubeVersion: ">=1.11.0-0"
 engine: gotpl

--- a/staging/flagger/README.md
+++ b/staging/flagger/README.md
@@ -66,6 +66,7 @@ Parameter | Description | Default
 `image.repository` | image repository | `weaveworks/flagger`
 `image.tag` | image tag | `<VERSION>`
 `image.pullPolicy` | image pull policy | `IfNotPresent`
+`podLabels` | additional labels for Flagger pods | `{}`
 `prometheus.install` | if `true`, installs Prometheus configured to scrape all pods in the custer including the App Mesh sidecar | `false`
 `metricsServer` | Prometheus URL, used when `prometheus.install` is `false` | `http://prometheus.istio-system:9090`
 `slack.url` | Slack incoming webhook | None

--- a/staging/flagger/templates/deployment.yaml
+++ b/staging/flagger/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "flagger.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
       annotations:
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/staging/flagger/values.yaml
+++ b/staging/flagger/values.yaml
@@ -6,6 +6,8 @@ image:
   pullPolicy: IfNotPresent
   pullSecret:
 
+podLabels: {}
+
 podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "8080"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This adds a chart value for setting labels on Flagger pods. This is necessary in order to allow Prometheus to scrape Flagger metrics by defining a `PodMonitor` that can discover Flagger pods by their labels.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72693

**Special notes for your reviewer**:

I tested this chart by deploying it to a cluster with `podLabels` set and observing that the Flagger pods had those labels.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[flagger] Adds chart value `podLabels`.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
