### PR TITLE
kommander: Clean up SAs/roles

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -6,5 +6,6 @@ maintainers:
   - name: hectorj2f
   - name: alejandroEsc
   - name: jimmidyson
+  - name: gracedo
 name: kommander
-version: 0.13.2
+version: 0.13.3

--- a/stable/kommander/charts/kommander-karma/Chart.yaml
+++ b/stable/kommander/charts/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.11
+version: 0.3.12
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander/charts/kommander-karma/templates/_helpers.tpl
+++ b/stable/kommander/charts/kommander-karma/templates/_helpers.tpl
@@ -46,6 +46,13 @@ Create a service account name for hooks running in the chart.
 {{- end -}}
 
 {{/*
+Generate the karma configmap name.
+*/}}
+{{- define "kommander-karma.configmap-name" -}}
+{{ .Release.Name }}-config
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "kommander-karma.labels" -}}

--- a/stable/kommander/charts/kommander-karma/templates/_helpers.tpl
+++ b/stable/kommander/charts/kommander-karma/templates/_helpers.tpl
@@ -39,6 +39,13 @@ Create a truncated name suitable for resources that need shorter names, such as 
 {{- end -}}
 
 {{/*
+Create a service account name for hooks running in the chart.
+*/}}
+{{- define "kommander-karma.sa-name" -}}
+{{- include "kommander-karma.fullname" . -}}-hook
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "kommander-karma.labels" -}}

--- a/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
@@ -22,6 +22,6 @@ spec:
           command:
             - /bin/sh
             - -c
-            - kubectl delete configmap --ignore-not-found {{ .Values.kommanderKarmaConfigMap }}
+            - kubectl delete configmap --ignore-not-found {{ template "kommander-karma.configmap-name" . }}
       restartPolicy: OnFailure
 {{- end }}

--- a/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       name: karma-configmap-cleanup
     spec:
-      serviceAccountName: {{ .Values.kommanderServiceAccount }}
+      serviceAccountName: {{ template "kommander-karma.sa-name" . }}
       containers:
         - name: kubectl
           image: bitnami/kubectl:1.16.2
@@ -22,6 +22,6 @@ spec:
           command:
             - /bin/sh
             - -c
-            - kubectl delete configmap {{ .Values.kommanderKarmaConfigMap }}
+            - kubectl delete configmap --ignore-not-found {{ .Values.kommanderKarmaConfigMap }}
       restartPolicy: OnFailure
 {{- end }}

--- a/stable/kommander/charts/kommander-karma/templates/hooks-roles.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/hooks-roles.yaml
@@ -11,12 +11,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     helm.sh/hook: pre-install,pre-upgrade,pre-delete
+    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: "before-hook-creation"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{.Release.Name}}-hooks
+  name: {{ template "kommander-karma.fullname" . }}-hooks
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kommander-karma.labels" . | indent 4 }}
@@ -32,7 +33,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Release.Name}}-hooks
+  name: {{ template "kommander-karma.fullname" . }}-hooks
   labels:
 {{ include "kommander-karma.labels" . | indent 4 }}
   annotations:
@@ -42,7 +43,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{.Release.Name}}-hooks
+  name: {{ template "kommander-karma.fullname" . }}-hooks
 subjects:
 - kind: ServiceAccount
   name: {{ template "kommander-karma.sa-name" . }}

--- a/stable/kommander/charts/kommander-karma/templates/hooks-roles.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/hooks-roles.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "kommander.sa-name" . }}
+  name: {{ template "kommander-karma.sa-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "kommander.fullname" . }}
+    app: {{ template "kommander-karma.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.name }}"
     heritage: "{{ .Release.Service }}"
@@ -16,28 +16,25 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "kommander.labels" . | indent 4 }}
+{{ include "kommander-karma.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["secrets", "configmaps"]
+  resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
   labels:
-{{ include "kommander.labels" . | indent 4 }}
+{{ include "kommander-karma.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,pre-delete
     "helm.sh/hook-weight": "2"
@@ -45,8 +42,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
 subjects:
 - kind: ServiceAccount
-  name: {{ template "kommander.sa-name" . }}
+  name: {{ template "kommander-karma.sa-name" . }}
   namespace: {{ .Release.Namespace }}

--- a/stable/kommander/charts/kommander-karma/values.yaml
+++ b/stable/kommander/charts/kommander-karma/values.yaml
@@ -5,12 +5,6 @@
 # Internal address for the cluster's alertmanager.
 # alertmanagerAddress: "HOST:PORT"
 alertmanagerAddress: ""
-# Kommander service account used to delete the karma configmap
-# Do not use, this will be deprecated
-kommanderServiceAccount: kommander-kubeaddons
-# Name of the karma configmap
-# Do not use, this will be deprecated
-kommanderKarmaConfigMap: kommander-kubeaddons-config
 
 federate:
   addons: true

--- a/stable/kommander/charts/kommander-karma/values.yaml
+++ b/stable/kommander/charts/kommander-karma/values.yaml
@@ -6,8 +6,10 @@
 # alertmanagerAddress: "HOST:PORT"
 alertmanagerAddress: ""
 # Kommander service account used to delete the karma configmap
+# Do not use, this will be deprecated
 kommanderServiceAccount: kommander-kubeaddons
 # Name of the karma configmap
+# Do not use, this will be deprecated
 kommanderKarmaConfigMap: kommander-kubeaddons-config
 
 federate:

--- a/stable/kommander/charts/kommander-thanos/Chart.yaml
+++ b/stable/kommander/charts/kommander-thanos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.10.1
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.15
+version: 0.1.16
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander/charts/kommander-thanos/templates/_helpers.tpl
+++ b/stable/kommander/charts/kommander-thanos/templates/_helpers.tpl
@@ -39,6 +39,13 @@ Create a truncated name suitable for resources that need shorter names, such as 
 {{- end -}}
 
 {{/*
+Create a service account name for hooks running in the chart.
+*/}}
+{{- define "kommander-thanos.sa-name" -}}
+{{- include "kommander-thanos.fullname" . -}}-hook
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "kommander-thanos.labels" -}}

--- a/stable/kommander/charts/kommander-thanos/templates/hooks-roles.yaml
+++ b/stable/kommander/charts/kommander-thanos/templates/hooks-roles.yaml
@@ -11,12 +11,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     helm.sh/hook: pre-install,pre-upgrade,pre-delete
+    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: "before-hook-creation"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{.Release.Name}}-hooks
+  name: {{ template "kommander-thanos.fullname" . }}-hooks
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kommander-thanos.labels" . | indent 4 }}
@@ -32,7 +33,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Release.Name}}-hooks
+  name: {{ template "kommander-thanos.fullname" . }}-hooks
   labels:
 {{ include "kommander-thanos.labels" . | indent 4 }}
   annotations:
@@ -42,7 +43,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{.Release.Name}}-hooks
+  name: {{ template "kommander-thanos.fullname" . }}-hooks
 subjects:
 - kind: ServiceAccount
   name: {{ template "kommander-thanos.sa-name" . }}

--- a/stable/kommander/charts/kommander-thanos/templates/hooks-roles.yaml
+++ b/stable/kommander/charts/kommander-thanos/templates/hooks-roles.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "kommander.sa-name" . }}
+  name: {{ template "kommander-thanos.sa-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "kommander.fullname" . }}
+    app: {{ template "kommander-thanos.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.name }}"
     heritage: "{{ .Release.Service }}"
@@ -16,28 +16,25 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "kommander.labels" . | indent 4 }}
+{{ include "kommander-thanos.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["secrets", "configmaps"]
+  resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
   labels:
-{{ include "kommander.labels" . | indent 4 }}
+{{ include "kommander-thanos.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,pre-delete
     "helm.sh/hook-weight": "2"
@@ -45,8 +42,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
 subjects:
 - kind: ServiceAccount
-  name: {{ template "kommander.sa-name" . }}
+  name: {{ template "kommander-thanos.sa-name" . }}
   namespace: {{ .Release.Namespace }}

--- a/stable/kommander/charts/kommander-thanos/templates/query-stores-configmap.yaml
+++ b/stable/kommander/charts/kommander-thanos/templates/query-stores-configmap.yaml
@@ -1,6 +1,6 @@
 {{ $ns := .Release.Namespace }}
 {{ $labels := include "kommander-thanos.labels" . | indent 4  }}
-{{ $sa := .Values.kommanderServiceAccount }}
+{{ $sa := include "kommander-thanos.sa-name" . }}
 {{- if .Values.thanos.query.enabled }}
 {{- range .Values.thanos.query.serviceDiscoveryFileConfigMaps }}
 ---
@@ -71,7 +71,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - kubectl delete configmap {{ . }}
+            - kubectl delete configmap --ignore-not-found {{ . }}
       restartPolicy: OnFailure
 {{- end }}
 {{- end }}

--- a/stable/kommander/charts/kommander-thanos/values.yaml
+++ b/stable/kommander/charts/kommander-thanos/values.yaml
@@ -5,9 +5,6 @@
 # Internal address for the cluster's Thanos gRPC service.
 # thanosAddress: "HOST:PORT"
 thanosAddress: ""
-# Kommander service account used to delete Thanos store configmaps
-# Do not use, this will be deprecated
-kommanderServiceAccount: kommander-kubeaddons
 
 federate:
   addons: true

--- a/stable/kommander/charts/kommander-thanos/values.yaml
+++ b/stable/kommander/charts/kommander-thanos/values.yaml
@@ -6,6 +6,7 @@
 # thanosAddress: "HOST:PORT"
 thanosAddress: ""
 # Kommander service account used to delete Thanos store configmaps
+# Do not use, this will be deprecated
 kommanderServiceAccount: kommander-kubeaddons
 
 federate:

--- a/stable/kommander/templates/_helpers.tpl
+++ b/stable/kommander/templates/_helpers.tpl
@@ -39,6 +39,13 @@ Create a truncated name suitable for resources that need shorter names, such as 
 {{- end -}}
 
 {{/*
+Create a service account name for hooks running in the chart.
+*/}}
+{{- define "kommander.sa-name" -}}
+{{- include "kommander.fullname" . -}}-hook
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "kommander.labels" -}}

--- a/stable/kommander/templates/grafana/opsportal-username-secret.yaml
+++ b/stable/kommander/templates/grafana/opsportal-username-secret.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       name: copy-{{ .Release.Name }}-{{ .Values.grafana.hooks.secretKeyRef }}
     spec:
-      serviceAccountName: {{ template "kommander.fullname" . }}
+      serviceAccountName: {{ template "kommander.sa-name" . }}
       containers:
         - name: kubectl
           # --export flag is deprecated so we need to stick with this kubectl version
@@ -43,7 +43,7 @@ spec:
     metadata:
       name: cleanup-{{ .Release.Name }}-{{ .Values.grafana.hooks.secretKeyRef }}
     spec:
-      serviceAccountName: {{ template "kommander.fullname" . }}
+      serviceAccountName: {{ template "kommander.sa-name" . }}
       containers:
         - name: kubectl
           image: bitnami/kubectl:1.16.2

--- a/stable/kommander/templates/hooks-kubeaddons.yaml
+++ b/stable/kommander/templates/hooks-kubeaddons.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
     spec:
       restartPolicy: Never
+      serviceAccountName: {{ template "kommander.sa-name" . }}
       containers:
         - name: {{.Release.Name}}-kubeaddons-ns
           image: "{{.Values.federate.kubeaddonsInitializer.repository}}:{{.Values.federate.kubeaddonsInitializer.tag}}"

--- a/stable/kommander/templates/hooks-kubeaddons.yaml
+++ b/stable/kommander/templates/hooks-kubeaddons.yaml
@@ -1,47 +1,4 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "kommander.labels" . | indent 4 }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-rules:
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-{{- if .Values.grafana.enabled }}
-- apiGroups: [""]
-  resources: ["secrets", "configmaps"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-{{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
-  labels:
-{{ include "kommander.labels" . | indent 4 }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
-    "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{.Release.Name}}-kubeaddons-ns
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: {{ .Release.Namespace }}
-- kind: ServiceAccount
-  name: {{ template "kommander.fullname" . }}
-  namespace: {{ .Release.Namespace }}
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -59,7 +16,7 @@ spec:
       name: {{.Release.Name}}-kubeaddons-ns
       labels:
         app.kubernetes.io/managed-by: {{.Release.Service | quote }}
-        app.kubernetes.io/instance: {{.Release.Name | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
     spec:
       restartPolicy: Never
       containers:

--- a/stable/kommander/templates/hooks-kubecost.yaml
+++ b/stable/kommander/templates/hooks-kubecost.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/instance: {{.Release.Name | quote }}
     spec:
       restartPolicy: Never
+      serviceAccountName: {{ template "kommander.sa-name" . }}
       containers:
         - name: {{.Release.Name}}-kubecost-ns
           image: "{{.Values.federate.kubeaddonsInitializer.repository}}:{{.Values.federate.kubeaddonsInitializer.tag}}"

--- a/stable/kommander/templates/hooks-roles.yaml
+++ b/stable/kommander/templates/hooks-roles.yaml
@@ -11,12 +11,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     helm.sh/hook: pre-install,pre-upgrade,pre-delete
+    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: "before-hook-creation"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kommander.labels" . | indent 4 }}
@@ -35,7 +36,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
   labels:
 {{ include "kommander.labels" . | indent 4 }}
   annotations:
@@ -45,7 +46,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{.Release.Name}}-kubeaddons-ns
+  name: {{.Release.Name}}-hooks
 subjects:
 - kind: ServiceAccount
   name: {{ template "kommander.sa-name" . }}

--- a/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
+++ b/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
@@ -1,6 +1,6 @@
 {{ $ns := .Release.Namespace }}
 {{ $labels := include "kommander.labels" . | indent 4  }}
-{{ $sa := include "kommander.fullname" . }}
+{{ $sa := include "kommander.sa-name" . }}
 {{- if index .Values "kubecost" "cost-analyzer" "thanos" "query" "enabled" }}
 {{- range index .Values "kubecost" "cost-analyzer" "thanos" "query" "serviceDiscoveryFileConfigMaps" }}
 ---
@@ -71,7 +71,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - kubectl delete configmap {{ . }} --ignore-not-found
+            - kubectl delete configmap --ignore-not-found {{ . }}
       restartPolicy: OnFailure
 {{- end }}
 {{- end }}

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -42,8 +42,6 @@ kommander-licensing:
 kommander-thanos:
   enabled: true
   thanosAddress: "prometheus-kubeaddons-prom-prometheus.kubeaddons.svc.cluster.local:10901"
-  # Do not use, this will be deprecated
-  kommanderServiceAccount: kommander-kubeaddons
   thanos:
     query:
       deploymentAnnotations:
@@ -52,10 +50,6 @@ kommander-thanos:
 kommander-karma:
   enabled: true
   alertmanagerAddress: "prometheus-kubeaddons-prom-alertmanager.kubeaddons.svc.cluster.local:9093"
-  # Do not use, this will be deprecated
-  kommanderServiceAccount: kommander-kubeaddons
-  # Do not use, this will be deprecated
-  kommanderKarmaConfigMap: kommander-kubeaddons-config
   karma:
     deployment:
       annotations:
@@ -84,10 +78,6 @@ grafana:
   hooks:
     image: dwdraju/alpine-curl-jq
     secretKeyRef: ops-portal-username
-    # Do not use, this will be deprecated
-    serviceURL: http://kommander-kubeaddons-grafana.kommander
-    # Do not use, this will be deprecated
-    kommanderServiceAccount: kommander-kubeaddons
 
   ## Do not deploy default dashboards.
   ##
@@ -228,8 +218,6 @@ portalRBAC:
 
 kubecost:
   thanosAddress: "kubecost-kubeaddons-prometheus-server.kubecost.svc.cluster.local:10901"
-  # Do not use, this will be deprecated
-  kommanderServiceAccount: kommander-kubeaddons
   federate:
     addons: true
     systemNamespace:

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -42,6 +42,7 @@ kommander-licensing:
 kommander-thanos:
   enabled: true
   thanosAddress: "prometheus-kubeaddons-prom-prometheus.kubeaddons.svc.cluster.local:10901"
+  # Do not use, this will be deprecated
   kommanderServiceAccount: kommander-kubeaddons
   thanos:
     query:
@@ -51,7 +52,9 @@ kommander-thanos:
 kommander-karma:
   enabled: true
   alertmanagerAddress: "prometheus-kubeaddons-prom-alertmanager.kubeaddons.svc.cluster.local:9093"
+  # Do not use, this will be deprecated
   kommanderServiceAccount: kommander-kubeaddons
+  # Do not use, this will be deprecated
   kommanderKarmaConfigMap: kommander-kubeaddons-config
   karma:
     deployment:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Create SAs/roles per chart instead of reusing SA's created in parent charts (new SA/roles per subchart, create new SA for kommander chart instead of using the same one also defined in kommander-ui). This also allows us to finally get rid of the hardcoded SA names we were passing into the subcharts.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
no issue

**Special notes for your reviewer**:

I tested this by hosting it on my GH - config branch `gracedo/kommander_0132`. Tested upgrade from prev version + fresh install on kommander cluster

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
