### PR TITLE
kommander: Fix wrong config block location

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
 name: kommander
-version: 0.13.1
+version: 0.13.2

--- a/stable/kommander/values.yaml
+++ b/stable/kommander/values.yaml
@@ -250,6 +250,12 @@ kubecost:
           deploymentAnnotations:
             secret.reloader.stakater.com/reload: kommander-kubecost-thanos-client-tls
 
+      grafana:
+        # If false, Grafana will not be installed
+        enabled: false
+        # Use kommander monitoring Grafana instance
+        domainName: kommander-kubeaddons-grafana.kommander.svc.cluster.local
+
     # For Thanos Installs, Allow Higher Concurrency from Cost-Model
     # Still may require tweaking for some installs, but the thanos-query-frontend
     # will greatly assist in reduction memory bloat in query.
@@ -258,12 +264,6 @@ kubecost:
       # This configuration is applied to thanos only. Expresses the resolution to
       # use for longer query ranges. Options: raw, 5m, 1h - Default: raw
       maxSourceResolution: 5m
-
-      grafana:
-        # If false, Grafana will not be installed
-        enabled: false
-        # Use kommander monitoring Grafana instance
-        domainName: kommander-kubeaddons-grafana.kommander.svc.cluster.local
 
     ingress:
       enabled: true


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
new config block was added to the wrong location and caused the below grafana block to be put in the wrong location (bug intro'd in previous version https://github.com/mesosphere/charts/pull/904/files#diff-27ff036ff511571cd28603ccf34d46b315397788280fb0b35d6aaae9c451080eR253). this ended up with another grafana instance installation attempt which caused issues

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
