### PR TITLE
chore(vsphere-csi-driver): repository and image updates

### DIFF
--- a/stable/vsphere-csi-driver/Chart.yaml
+++ b/stable/vsphere-csi-driver/Chart.yaml
@@ -4,7 +4,7 @@ description: vSphere Container Storage Interface (CSI) driver
 name: vsphere-csi-driver
 maintainers:
   - name: sebbrandt87
-version: 1.1.0
+version: 1.1.1
 kubeVersion: ">=1.16.0"
 home: https://vsphere-csi-driver.sigs.k8s.io
 sources:

--- a/stable/vsphere-csi-driver/templates/controller.yaml
+++ b/stable/vsphere-csi-driver/templates/controller.yaml
@@ -48,7 +48,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-        {{- if semverCompare ">2.0.0"  (default .Chart.AppVersion .Values.image.version) }}
+        {{- if and (semverCompare ">2.0.0" (default .Chart.AppVersion .Values.image.version)) .Values.storageclass.allowVolumeExpansion }}
         - name: csi-resizer
           image: {{ .Values.resizer.image.repository }}:{{ .Values.resizer.image.tag }}
           args:
@@ -163,7 +163,8 @@ spec:
 ---
 apiVersion: v1
 data:
-  "volume-extend": "true"
+  "volume-extend": "{{ .Values.storageclass.allowVolumeExpansion }}"
+  "online-volume-extend": "{{ .Values.storageclass.allowVolumeExpansion }}"
   "volume-health": "true"
 kind: ConfigMap
 metadata:

--- a/stable/vsphere-csi-driver/templates/storageclass.yaml
+++ b/stable/vsphere-csi-driver/templates/storageclass.yaml
@@ -8,7 +8,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 provisioner: csi.vsphere.vmware.com
-allowVolumeExpansion: true
+allowVolumeExpansion: {{ .Values.storageclass.allowVolumeExpansion }}
 volumeBindingMode: {{ .Values.storageclass.volumeBindingMode | quote }}
 reclaimPolicy: {{ .Values.storageclass.reclaimPolicy | quote }}
 {{- if .Values.storageclass.parameters }}

--- a/stable/vsphere-csi-driver/values.yaml
+++ b/stable/vsphere-csi-driver/values.yaml
@@ -16,27 +16,29 @@ serviceAccount:
 enableTopologyZone: true
 
 tolerations:
-  - operator: "Exists"
+  - operator: Exists
     effect: NoSchedule
-  - operator: "Exists"
+  - operator: Exists
     effect: NoExecute
+  - key: CriticalAddonsOnly
+    operator: Exists
 
 liveness:
   image:
-    repository: quay.io/k8scsi/livenessprobe
+    repository: k8s.gcr.io/sig-storage/livenessprobe
     tag: v2.1.0
 
 registrar:
   node:
     image:
-      repository: quay.io/k8scsi/csi-node-driver-registrar
+      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
       tag: v2.0.1
   verbose: 5
 
 provisioner:
   image:
-    repository: quay.io/k8scsi/csi-provisioner
-    tag: v2.0.1
+    repository: k8s.gcr.io/sig-storage/csi-provisioner
+    tag: v2.0.4
   timeout: 300s
   retryIntervalStart: 1s
   retryIntervalMax: 5m
@@ -45,7 +47,7 @@ provisioner:
 
 attacher:
   image:
-    repository: quay.io/k8scsi/csi-attacher
+    repository: k8s.gcr.io/sig-storage/csi-attacher
     tag: v2.2.0
   timeout: 300s
   retryIntervalStart: 1s
@@ -55,14 +57,17 @@ attacher:
 
 resizer:
   image:
-    repository: quay.io/k8scsi/csi-resizer
-    tag: v1.0.0
+    repository: k8s.gcr.io/sig-storage/csi-resizer
+    tag: v1.0.1
   verbose: 4
 
 storageclass:
   isDefault: true
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
+  # Volume Expansion is available with vSphere >= 7, so we set the default to false
+  # https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/release-2.0/pkg/csi/service/vanilla/controller.go#L65-L80
+  allowVolumeExpansion: false
   # parameters to set for storageclass
   # e.g.
   # parameters:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- updated repositories to point to k8s.gcr.io instead of quay.io
- updated image versions
- set the extend / expanse volume to false as default
it is only available from vSphere 7 on, and we support initial v6.7U3

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
[D2IQ-71493]

[D2IQ-71493]: https://jira.d2iq.com/browse/D2IQ-71493

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.