### PR TITLE
WIP: Update helm/ct version in CI (and fix charts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash -euo pipefail
 
-HELM_VERSION ?= v3.3.4
+HELM_VERSION ?= v3.4.1
 
 STABLE_CHARTS = $(wildcard stable/*/Chart.yaml)
 STABLE_TARGETS = $(shell hack/chart_destination.sh $(STABLE_CHARTS))
@@ -18,7 +18,7 @@ GIT_REMOTE_URL ?= $(shell git remote get-url ${GIT_REMOTE_NAME})
 GITHUB_USER := $(shell git remote get-url ${GIT_REMOTE_NAME} | sed -E 's|.*github.com[/:]([^/]+)/charts.*|\1|')
 
 GIT_REF ?= $(shell git rev-parse HEAD)
-CT_VERSION ?= v3.1.1
+CT_VERSION ?= v3.3.1
 
 PLATFORM = $(shell uname | tr [A-Z] [a-z])
 

--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
   - name: jimmidyson
   - name: gracedo
 name: kommander
-version: 0.13.3
+version: 0.13.4

--- a/stable/kommander/requirements.lock
+++ b/stable/kommander/requirements.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 0.1.15
 - name: kommander-federation
   repository: https://mesosphere.github.io/yakcl/charts
-  version: 0.6.9
+  version: v0.6.9
 - name: kommander-licensing
   repository: https://mesosphere.github.io/yakcl/charts
-  version: 0.6.9
+  version: v0.6.9
 - name: kommander-ui
   repository: https://mesosphere.github.io/kommander/charts
   version: 6.55.0
@@ -17,5 +17,11 @@ dependencies:
 - name: grafana
   repository: https://mesosphere.github.io/charts/stable
   version: 4.6.3
-digest: sha256:1c514ccca0ccb1dad98642f2a762a406a54c4108da927abbd7588e0cf290ae0c
-generated: "2020-11-18T11:37:18.53568-08:00"
+- name: kommander-karma
+  repository: ""
+  version: 0.3.12
+- name: kommander-thanos
+  repository: ""
+  version: 0.1.16
+digest: sha256:3548c0fdde1926275f41705f31fcef91a3b9eb9892f957282604e097e0a5fd34
+generated: "2020-12-04T10:55:22.31144+01:00"

--- a/stable/kommander/requirements.yaml
+++ b/stable/kommander/requirements.yaml
@@ -23,3 +23,9 @@ dependencies:
     version: 4.6.3
     repository: https://mesosphere.github.io/charts/stable
     condition: grafana.enabled
+  - name: kommander-karma
+    version: 0.3.12
+    condition: kommander-karma.enabled
+  - name: kommander-thanos
+    version: 0.1.16
+    condition: kommander-thanos.enabled

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -12,7 +12,7 @@ chart-repos:
   - kubefed-charts=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
   - jetstack-charts=https://charts.jetstack.io
   - banzaicloud=https://kubernetes-charts.banzaicloud.com
-  - helm-stable=https://kubernetes-charts.storage.googleapis.com/
+  - helm-stable=https://charts.helm.sh/stable
   - dex-controller=https://mesosphere.github.io/dex-controller/charts
   - kommander=https://mesosphere.github.io/kommander/charts
   - kubecost=https://kubecost.github.io/cost-analyzer

--- a/test/helm2/ct-e2e.yaml
+++ b/test/helm2/ct-e2e.yaml
@@ -6,36 +6,36 @@ chart-dirs:
 excluded-charts:
   - common
   - dex-controller # Moved to a different helm repo
-  - azuredisk-csi-driver  # DCOS-62804
-  - defaultstorageclass   # DCOS-62803
-  - dispatch              # DCOS-62802
-  - gcpdisk-csi-driver    # D2IQ-65765
-  - gcpdiskprovisioner    # DCOS-62801
-  - kommander             # DCOS-62800
-  - kommander-karma       # DCOS-62799
-  - kommander-thanos      # DCOS-62798
-  - mtls-proxy            # DCOS-62805
+  - azuredisk-csi-driver # DCOS-62804
+  - defaultstorageclass # DCOS-62803
+  - dispatch # DCOS-62802
+  - gcpdisk-csi-driver # D2IQ-65765
+  - gcpdiskprovisioner # DCOS-62801
+  - kommander # DCOS-62800
+  - kommander-karma # DCOS-62799
+  - kommander-thanos # DCOS-62798
+  - mtls-proxy # DCOS-62805
   - dex-k8s-authenticator # DCOS-62806
-  - flagger               # DCOS-62809
-  - gatekeeper            # DCOS-62810
-  - generic-ingress       # DCOS-62811
-  - istio                 # DCOS-62812
-  - knative               # DCOS-62813
-  - kube-oidc-proxy       # DCOS-62814
-  - kudo                  # DCOS-62815
-  - nvidia                # DCOS-62816
-  - prometheus-operator   # DCOS-62817
-  - traefik-forward-auth  # DCOS-62819
+  - flagger # DCOS-62809
+  - gatekeeper # DCOS-62810
+  - generic-ingress # DCOS-62811
+  - istio # DCOS-62812
+  - knative # DCOS-62813
+  - kube-oidc-proxy # DCOS-62814
+  - kudo # DCOS-62815
+  - nvidia # DCOS-62816
+  - prometheus-operator # DCOS-62817
+  - traefik-forward-auth # DCOS-62819
   - local-path-provisioner
   - vsphere-csi-driver
-  - cert-manager          # cert-manager is no longer compatible with helmv2
+  - cert-manager # cert-manager is no longer compatible with helmv2
 chart-repos:
   - mesosphere-staging=https://mesosphere.github.io/charts/staging
   - mesosphere-stable=https://mesosphere.github.io/charts/stable
   - kubefed-charts=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
   - jetstack-charts=https://charts.jetstack.io
   - banzaicloud=https://kubernetes-charts.banzaicloud.com
-  - helm-stable=https://kubernetes-charts.storage.googleapis.com/
+  - helm-stable=https://charts.helm.sh/stable
   - dex-controller=https://mesosphere.github.io/dex-controller/charts
   - kommander=https://mesosphere.github.io/kommander/charts
   - kubecost=https://kubecost.github.io/cost-analyzer

--- a/test/helm2/ct.yaml
+++ b/test/helm2/ct.yaml
@@ -12,7 +12,7 @@ chart-repos:
   - kubefed-charts=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
   - jetstack-charts=https://charts.jetstack.io
   - banzaicloud=https://kubernetes-charts.banzaicloud.com
-  - helm-stable=https://kubernetes-charts.storage.googleapis.com/
+  - helm-stable=https://charts.helm.sh/stable
   - dex-controller=https://mesosphere.github.io/dex-controller/charts
   - kommander=https://mesosphere.github.io/kommander/charts
   - kubecost=https://kubecost.github.io/cost-analyzer

--- a/test/helm3/ct-e2e.yaml
+++ b/test/helm3/ct-e2e.yaml
@@ -6,26 +6,26 @@ chart-dirs:
 excluded-charts:
   - common
   - dex-controller # Moved to a different helm repo
-  - azuredisk-csi-driver  # DCOS-62804
-  - defaultstorageclass   # DCOS-62803
-  - dispatch              # DCOS-62802
-  - gcpdisk-csi-driver    # D2IQ-65765
-  - gcpdiskprovisioner    # DCOS-62801
-  - kommander             # DCOS-62800
-  - kommander-karma       # DCOS-62799
-  - kommander-thanos      # DCOS-62798
-  - mtls-proxy            # DCOS-62805
+  - azuredisk-csi-driver # DCOS-62804
+  - defaultstorageclass # DCOS-62803
+  - dispatch # DCOS-62802
+  - gcpdisk-csi-driver # D2IQ-65765
+  - gcpdiskprovisioner # DCOS-62801
+  - kommander # DCOS-62800
+  - kommander-karma # DCOS-62799
+  - kommander-thanos # DCOS-62798
+  - mtls-proxy # DCOS-62805
   - dex-k8s-authenticator # DCOS-62806
-  - flagger               # DCOS-62809
-  - gatekeeper            # DCOS-62810
-  - generic-ingress       # DCOS-62811
-  - istio                 # DCOS-62812
-  - knative               # DCOS-62813
-  - kube-oidc-proxy       # DCOS-62814
-  - kudo                  # DCOS-62815
-  - nvidia                # DCOS-62816
-  - prometheus-operator   # DCOS-62817
-  - traefik-forward-auth  # DCOS-62819
+  - flagger # DCOS-62809
+  - gatekeeper # DCOS-62810
+  - generic-ingress # DCOS-62811
+  - istio # DCOS-62812
+  - knative # DCOS-62813
+  - kube-oidc-proxy # DCOS-62814
+  - kudo # DCOS-62815
+  - nvidia # DCOS-62816
+  - prometheus-operator # DCOS-62817
+  - traefik-forward-auth # DCOS-62819
   - local-path-provisioner
   - vsphere-csi-driver
 chart-repos:
@@ -34,7 +34,7 @@ chart-repos:
   - kubefed-charts=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
   - jetstack-charts=https://charts.jetstack.io
   - banzaicloud=https://kubernetes-charts.banzaicloud.com
-  - helm-stable=https://kubernetes-charts.storage.googleapis.com/
+  - helm-stable=https://charts.helm.sh/stable
   - dex-controller=https://mesosphere.github.io/dex-controller/charts
   - kommander=https://mesosphere.github.io/kommander/charts
   - kubecost=https://kubecost.github.io/cost-analyzer

--- a/test/helm3/ct.yaml
+++ b/test/helm3/ct.yaml
@@ -12,7 +12,7 @@ chart-repos:
   - kubefed-charts=https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
   - jetstack-charts=https://charts.jetstack.io
   - banzaicloud=https://kubernetes-charts.banzaicloud.com
-  - helm-stable=https://kubernetes-charts.storage.googleapis.com/
+  - helm-stable=https://charts.helm.sh/stable
   - dex-controller=https://mesosphere.github.io/dex-controller/charts
   - kommander=https://mesosphere.github.io/kommander/charts
   - kubecost=https://kubecost.github.io/cost-analyzer


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
CI version update.

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

running `helm lint .` locally for kommander chart, I ran into:
```
➜  helm lint .
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] /Users/Julian/Code/mesosphere/charts/stable/kommander: chart metadata is missing these dependencies: kommander-karma,kommander-thanos

Error: 1 chart(s) linted, 1 chart(s) failed
```

this PR tries to fix that - things escalated a bit 🤷  (see below)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
No JIRA

**Special notes for your reviewer**:
~Its interesting how we have a CI check thats called `lint` but it doesnt seem to actually lint~
^ not true, we got `ct lint` in our makefile, ~either this is a newly introduced check (im running helm 3.4.1, CI is running 3.3.4) or something else is wrong. creating a new PR updating CI to check whats going on.~

turns out that the thing I ran into was added in a recent version (who cares about semver, he?) - I did some digging in #916 and we need to update a couple things. 

Also, trying `helm lint . --with-subcharts` reveals even more issues (that im not trying to fix here and now - but we should add that flag eventually IMHO)


there are _a ton_ of other necessary fixes in a lot of charts - which I cant fix on my own :( 

in `stable` folder:
```
➜  stable git:(jg/fix-kommander-lint) helm lint *
engine.go:167: [INFO] Missing required value: must provide target
engine.go:167: [INFO] Missing required value: certificate secret must have a name
[not sure where these come from]

…

==> Linting cert-manager-setup
[INFO] Chart.yaml: icon is recommended
[WARNING] templates/certificaterequests-crd-cm.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/certificates-crd-cm.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/challenges-acme-crd-cm.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/clusterissuers-crd-cm.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/issuers-crd-cm.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/orders-acme-crd-cm.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart

==> Linting cluster-autoscaler
[ERROR] templates/clusterrole.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRole" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRole"
[ERROR] templates/clusterrolebinding.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRoleBinding"
[ERROR] templates/role.yaml: the kind "rbac.authorization.k8s.io/v1beta1 Role" is deprecated in favor of "rbac.authorization.k8s.io/v1 Role"
[ERROR] templates/rolebinding.yaml: the kind "rbac.authorization.k8s.io/v1beta1 RoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 RoleBinding"

…

==> Linting dex-controller
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/crd_clients.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/crd_connectors.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"

…

==> Linting grafana
[ERROR] templates/role.yaml: the kind "rbac.authorization.k8s.io/v1beta1 Role" is deprecated in favor of "rbac.authorization.k8s.io/v1 Role"
[ERROR] templates/rolebinding.yaml: the kind "rbac.authorization.k8s.io/v1beta1 RoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 RoleBinding"

…

==> Linting konvoysoaktests
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/clusterrole.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRole" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRole"
[ERROR] templates/clusterrolebinding.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRoleBinding"

==> Linting kube-state-metrics
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/clusterrole.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRole" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRole"
[ERROR] templates/clusterrolebinding.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRoleBinding"

…

Error: 30 chart(s) linted, 5 chart(s) failed
```


in `staging` folder:
```
➜  staging git:(jg/fix-kommander-lint) helm lint *

…

==> Linting flagger
[ERROR] templates/crd.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/rbac.yaml: the kind "rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding" is deprecated in favor of "rbac.authorization.k8s.io/v1 ClusterRoleBinding"
[ERROR] /Users/Julian/Code/mesosphere/charts/staging/flagger: chart metadata is missing these dependencies: flagger-loadtester

==> Linting gatekeeper
[ERROR] templates/install-crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/install-crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"

…

==> Linting istio
[ERROR] templates/crd.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/jaeger-ingress.yaml: the kind "extensions/v1beta1 Ingress" is deprecated in favor of "networking.k8s.io/v1beta1 Ingress"
[ERROR] templates/kiali-ingress.yaml: the kind "extensions/v1beta1 Ingress" is deprecated in favor of "networking.k8s.io/v1beta1 Ingress"

…

==> Linting kubeaddons-catalog
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"

…

==> Linting kudo
[ERROR] templates/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"

…

==> Linting nvidia
[INFO] Chart.yaml: icon is recommended
[WARNING] templates/: directory not found

==> Linting prometheus-operator
[ERROR] templates/prometheus-operator/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/prometheus-operator/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/prometheus-operator/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/prometheus-operator/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/prometheus-operator/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/prometheus-operator/crds.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"

…

==> Linting traefik2
[ERROR] templates/crd/ingressroute.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/crd/ingressroutetcp.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/crd/middlewares.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/crd/tlsoptions.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[ERROR] templates/crd/traefikservices.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"

==> Linting velero
[ERROR] templates/: template: velero/charts/minio/templates/deployment.yaml:204:20: executing "velero/charts/minio/templates/deployment.yaml" at <(not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) (not .Values.b2gateway.enabled)>: can't give argument to non-function not .Values.gcsgateway.enabled

Error: 19 chart(s) linted, 8 chart(s) failed
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
