### PR TITLE
[gatekeeper] chore: attempt to move to 3.1.1

### DIFF
--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "3.0.4-beta.1"
+appVersion: "3.3.1"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.4.2
+version: 0.5.0
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:
@@ -10,4 +10,3 @@ maintainers:
   name: jimmidyson
 sources:
 - https://github.com/open-policy-agent/gatekeeper
-tillerVersion: '>=2.10.0'

--- a/staging/gatekeeper/templates/deployment.yaml
+++ b/staging/gatekeeper/templates/deployment.yaml
@@ -30,10 +30,12 @@ spec:
       containers:
       - args:
         - --auditInterval=30
+        - --logtostderr
         - --port={{ .Values.port }}
+        - --exempt-namespace=kubeaddons
         - --enable-manual-deploy
         command:
-        - /root/manager
+        - /manager
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -21,9 +21,9 @@ commonLabels: {}
 
 image:
   # image.name is the name of the Gatekeeper container image.
-  name: quay.io/open-policy-agent/gatekeeper
+  name: openpolicyagent/gatekeeper
   # image.tag is the tag name of the Gatekeeper container image.
-  tag:
+  tag: v3.3.1
   # image.pullPolicy specifies when to pull the image.
   pullPolicy: IfNotPresent
 
@@ -105,4 +105,4 @@ webhook:
   # Webhook side effects
   sideEffects: None
 
-kubectlImage: bitnami/kubectl:1.15
+kubectlImage: bitnami/kubectl:1.19


### PR DESCRIPTION
gatekeeper has seen significant chart chages that deviates us from upstream. This is an attempt to get us closer.

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Attempting to get us to the latest version of the application

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-73506

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
