### PR TITLE
chore(vsphere-csi-driver): image updates

### DIFF
--- a/stable/vsphere-csi-driver/Chart.yaml
+++ b/stable/vsphere-csi-driver/Chart.yaml
@@ -4,7 +4,7 @@ description: vSphere Container Storage Interface (CSI) driver
 name: vsphere-csi-driver
 maintainers:
   - name: sebbrandt87
-version: 1.1.1
+version: 1.2.0
 kubeVersion: ">=1.16.0"
 home: https://vsphere-csi-driver.sigs.k8s.io
 sources:

--- a/stable/vsphere-csi-driver/templates/_helper.tpl
+++ b/stable/vsphere-csi-driver/templates/_helper.tpl
@@ -9,3 +9,14 @@ labels:
   chart: "{{ .Chart.Name }}"
   chartVersion: "{{ .Chart.Version }}"
 {{- end -}}
+
+{{/*
+To keep compability we need to set csi-attacher matching on kubernetes versions >= Minor 17
+*/}}
+{{- define "vsphere-csi-driver.csi-attacher.tag" -}}
+{{- if (or (gt (.Capabilities.KubeVersion.Minor | int) 17) (eq (.Capabilities.KubeVersion.Minor | int) 17)) -}}
+{{- .Values.attacher.image.tagK8sUpMinor17 -}}
+{{- else -}}
+{{- .Values.attacher.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/stable/vsphere-csi-driver/templates/controller.yaml
+++ b/stable/vsphere-csi-driver/templates/controller.yaml
@@ -30,7 +30,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: {{ .Values.attacher.image.repository }}:{{ .Values.attacher.image.tag }}
+          image: {{ .Values.attacher.image.repository }}:{{ include "vsphere-csi-driver.csi-attacher.tag" . }}
           args:
             - "--v={{ .Values.attacher.verbose }}"
             - "--csi-address=$(ADDRESS)"

--- a/stable/vsphere-csi-driver/values.yaml
+++ b/stable/vsphere-csi-driver/values.yaml
@@ -38,7 +38,7 @@ registrar:
 provisioner:
   image:
     repository: k8s.gcr.io/sig-storage/csi-provisioner
-    tag: v2.0.4
+    tag: v1.6.1
   timeout: 300s
   retryIntervalStart: 1s
   retryIntervalMax: 5m
@@ -48,7 +48,8 @@ provisioner:
 attacher:
   image:
     repository: k8s.gcr.io/sig-storage/csi-attacher
-    tag: v2.2.0
+    tag: v2.2.1
+    tagK8sUpMinor17: v3.0.2
   timeout: 300s
   retryIntervalStart: 1s
   retryIntervalMax: 5m


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- updated image versions
- downgraded csi-provisioner, as we seem to have the same issue with 
latest version as we had with AWS

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
[D2IQ-71493]

[D2IQ-71493]: https://jira.d2iq.com/browse/D2IQ-71493

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.