### PR TITLE
chore: upgrade istio from 1.8.1 to 1.8.2

### DIFF
--- a/staging/istio/Chart.yaml
+++ b/staging/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio
-version: 1.8.3
-appVersion: 1.8.1
+version: 1.8.4
+appVersion: 1.8.2
 description: Helm chart for Istio
 keywords:
   - istio
@@ -13,6 +13,5 @@ sources:
 home: http://github.com/istio/istio
 maintainers:
   - name: goeldeepak
-  - name: shaneutt
 engine: gotpl
 icon: https://istio.io/favicons/android-192x192.png

--- a/staging/istio/templates/deployment.yaml
+++ b/staging/istio/templates/deployment.yaml
@@ -33,12 +33,7 @@ spec:
             runAsNonRoot: true
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              cpu: 200m
-              memory: 256Mi
-            requests:
-              cpu: 50m
-              memory: 128Mi
+{{ toYaml .Values.operator.resources | trim | indent 12 }}
           env:
             - name: WATCH_NAMESPACE
               value: {{.Release.Namespace | quote}}
@@ -51,4 +46,4 @@ spec:
             - name: OPERATOR_NAME
               value: {{.Release.Namespace | quote}}
             - name: WAIT_FOR_RESOURCES_TIMEOUT
-              value: {{.Values.global.waitForResourcesTimeout | quote}}
+              value: {{.Values.waitForResourcesTimeout | quote}}

--- a/staging/istio/templates/serviceaccount.yaml
+++ b/staging/istio/templates/serviceaccount.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: istio-operator
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}

--- a/staging/istio/values.yaml
+++ b/staging/istio/values.yaml
@@ -2,7 +2,21 @@ global:
   image: docker.io/bitnami/kubectl
   tag: 1.19.2
 
-  waitForResourcesTimeout: 300s
+# ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
+# used to pull operator image. Must be set for any cluster configured with private docker registry.
+imagePullSecrets: []
+
+waitForResourcesTimeout: 300s
+
+# Operator resource defaults
+operator:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
 
 grafana:
   enabled: true
@@ -15,7 +29,7 @@ istioOperator:
   profile: default
 
   hub: docker.io/istio
-  tag: 1.8.1
+  tag: 1.8.2
 
   components:
     cni:


### PR DESCRIPTION
**What type of PR is this?**
Chore 

**What this PR does/ why we need it**:
Bump istio from 1.8.1 to 1.8.2

**Which issue(s) this PR fixes**:
https://github.com/istio/istio/issues/29566

**Special notes for your reviewer**:
This PR brings a fix for the issue that blocks Kaptain from running on istio-1.8.1

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
