### PR TITLE
CVE-2017-14062: bump bitname/kubectl 1.16 images

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
   - name: jimmidyson
   - name: gracedo
 name: kommander
-version: 0.13.20
+version: 0.13.21

--- a/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ template "kommander-karma.sa-name" . }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.19.2
+          image: bitnami/kubectl:1.19.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/cleanup-configmap.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ template "kommander-karma.sa-name" . }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.19.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/charts/kommander-thanos/templates/query-stores-configmap.yaml
+++ b/stable/kommander/charts/kommander-thanos/templates/query-stores-configmap.yaml
@@ -24,7 +24,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.19.2
+          image: bitnami/kubectl:1.19.7
           command:
           - sh
           - "-c"
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: {{ $sa }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.19.2
+          image: bitnami/kubectl:1.19.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/charts/kommander-thanos/templates/query-stores-configmap.yaml
+++ b/stable/kommander/charts/kommander-thanos/templates/query-stores-configmap.yaml
@@ -24,7 +24,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.19.2
           command:
           - sh
           - "-c"
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: {{ $sa }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.19.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/templates/grafana/opsportal-username-secret.yaml
+++ b/stable/kommander/templates/grafana/opsportal-username-secret.yaml
@@ -18,13 +18,12 @@ spec:
       serviceAccountName: {{ template "kommander.sa-name" . }}
       containers:
         - name: kubectl
-          # --export flag is deprecated so we need to stick with this kubectl version
           image: bitnami/kubectl:1.19.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
-            - kubectl create secret generic {{ .Values.grafana.hooks.secretKeyRef }} -n {{ .Release.Namespace }} -oyaml --dry-run --from-literal=username=$(kubectl get secret ops-portal-credentials --namespace=kubeaddons --export -o jsonpath="{.data.username}" | base64 --decode) | kubectl apply -f -
+            - kubectl create secret generic {{ .Values.grafana.hooks.secretKeyRef }} -n {{ .Release.Namespace }} -oyaml --dry-run --from-literal=username=$(kubectl get secret ops-portal-credentials --namespace=kubeaddons -o jsonpath="{.data.username}" | base64 --decode) | kubectl apply -f -
       restartPolicy: OnFailure
 ---
 apiVersion: batch/v1

--- a/stable/kommander/templates/grafana/opsportal-username-secret.yaml
+++ b/stable/kommander/templates/grafana/opsportal-username-secret.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: kubectl
           # --export flag is deprecated so we need to stick with this kubectl version
-          image: bitnami/kubectl:1.19.2
+          image: bitnami/kubectl:1.19.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: {{ template "kommander.sa-name" . }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.19.2
+          image: bitnami/kubectl:1.19.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/templates/grafana/opsportal-username-secret.yaml
+++ b/stable/kommander/templates/grafana/opsportal-username-secret.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: kubectl
           # --export flag is deprecated so we need to stick with this kubectl version
-          image: bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.19.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: {{ template "kommander.sa-name" . }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.19.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
+++ b/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
@@ -24,7 +24,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.19.2
+          image: bitnami/kubectl:1.19.7
           command:
           - sh
           - "-c"
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: {{ $sa }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.19.2
+          image: bitnami/kubectl:1.19.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
+++ b/stable/kommander/templates/kubecost/kubecost-query-stores-configmap.yaml
@@ -24,7 +24,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.19.2
           command:
           - sh
           - "-c"
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: {{ $sa }}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.16.2
+          image: bitnami/kubectl:1.19.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/stable/kommander/templates/pre-deletion-purger.yaml
+++ b/stable/kommander/templates/pre-deletion-purger.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: purger
       containers:
         - name: purger
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: purger-config
               mountPath: /purge.sh

--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.71.0
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.5.1
+version: 0.5.2
 maintainers:
   - name: gracedo

--- a/stable/kubecost/README.md
+++ b/stable/kubecost/README.md
@@ -10,7 +10,7 @@ hooks:
   # Creates configmap to pass kube-system ns uid as envvar to kubecost.
   clusterID:
     enabled: true
-    kubectlImage: "bitnami/kubectl:1.19.2"
+    kubectlImage: "bitnami/kubectl:1.19.7"
 
 cost-analyzer:
   enabled: true

--- a/stable/kubecost/README.md
+++ b/stable/kubecost/README.md
@@ -10,7 +10,7 @@ hooks:
   # Creates configmap to pass kube-system ns uid as envvar to kubecost.
   clusterID:
     enabled: true
-    kubectlImage: "bitnami/kubectl:1.16.2"
+    kubectlImage: "bitnami/kubectl:1.19.2"
 
 cost-analyzer:
   enabled: true

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -8,7 +8,7 @@ hooks:
   # Creates configmap to pass kube-system ns uid as envvar to kubecost.
   clusterID:
     enabled: true
-    kubectlImage: "bitnami/kubectl:1.19.2"
+    kubectlImage: "bitnami/kubectl:1.19.7"
 
 cost-analyzer:
   enabled: true

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -8,7 +8,7 @@ hooks:
   # Creates configmap to pass kube-system ns uid as envvar to kubecost.
   clusterID:
     enabled: true
-    kubectlImage: "bitnami/kubectl:1.16.2"
+    kubectlImage: "bitnami/kubectl:1.19.2"
 
 cost-analyzer:
   enabled: true

--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.2.2"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.5.1
+version: 0.5.2
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:

--- a/staging/gatekeeper/templates/install-crds.yaml
+++ b/staging/gatekeeper/templates/install-crds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: gatekeeper-crds
       containers:
         - name: gatekeeper-crds
-          image: "bitnami/kubectl:1.16.2"
+          image: "bitnami/kubectl:1.19.2"
           volumeMounts:
             - name: gatekeeper-crds
               mountPath: /etc/gatekeeper-crds

--- a/staging/gatekeeper/templates/install-crds.yaml
+++ b/staging/gatekeeper/templates/install-crds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: gatekeeper-crds
       containers:
         - name: gatekeeper-crds
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: gatekeeper-crds
               mountPath: /etc/gatekeeper-crds

--- a/staging/kubeaddons-catalog/Chart.yaml
+++ b/staging/kubeaddons-catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.11.4"
 description: "A Catalog service for Kubeaddons"
 name: kubeaddons-catalog
-version: 0.1.15
+version: 0.1.16
 home: https://github.com/mesosphere/kommander-catalog-api
 sources:
 - https://github.com/mesosphere/kommander-catalog-api

--- a/staging/kubeaddons-catalog/templates/crds.yaml
+++ b/staging/kubeaddons-catalog/templates/crds.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: catalog-crds
       containers:
         - name: catalog-crds
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: catalog-crds
               mountPath: /etc/catalog-crds

--- a/staging/kubeaddons-catalog/templates/crds.yaml
+++ b/staging/kubeaddons-catalog/templates/crds.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: catalog-crds
       containers:
         - name: catalog-crds
-          image: "bitnami/kubectl:1.16.2"
+          image: "bitnami/kubectl:1.19.2"
           volumeMounts:
             - name: catalog-crds
               mountPath: /etc/catalog-crds

--- a/staging/local-path-provisioner/Chart.yaml
+++ b/staging/local-path-provisioner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: local-path-provisioner
-version: 0.0.12
+version: 0.0.13
 appVersion: 0.0.12
 description: Use HostPath for persistent local storage with Kubernetes
 keywords:

--- a/staging/local-path-provisioner/templates/post-install-job.yaml
+++ b/staging/local-path-provisioner/templates/post-install-job.yaml
@@ -43,7 +43,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: post-install-job
-        image: "bitnami/kubectl:1.16.2"
+        image: "bitnami/kubectl:1.19.2"
         command: ["/bin/bash"]
         args: ["/opt/scripts/setup.sh"]
         volumeMounts:

--- a/staging/local-path-provisioner/templates/post-install-job.yaml
+++ b/staging/local-path-provisioner/templates/post-install-job.yaml
@@ -43,7 +43,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: post-install-job
-        image: "bitnami/kubectl:1.19.2"
+        image: "bitnami/kubectl:1.19.7"
         command: ["/bin/bash"]
         args: ["/opt/scripts/setup.sh"]
         volumeMounts:

--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -18,7 +18,7 @@ name: prometheus-operator
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.11.4
+version: 12.11.5
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part1.yaml
+++ b/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part1.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part1
       containers:
         - name: v9-to-v11-crds-part1
-          image: "bitnami/kubectl:1.16.2"
+          image: "bitnami/kubectl:1.19.2"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part1.yaml
+++ b/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part1.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part1
       containers:
         - name: v9-to-v11-crds-part1
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part2.yaml
+++ b/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part2.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part2
       containers:
         - name: v9-to-v11-crds-part2
-          image: "bitnami/kubectl:1.16.2"
+          image: "bitnami/kubectl:1.19.2"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part2.yaml
+++ b/staging/prometheus-operator/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part2.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part2
       containers:
         - name: v9-to-v11-crds-part2
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/patch/patch_6_mesosphere_values.sh
+++ b/staging/prometheus-operator/patch/patch_6_mesosphere_values.sh
@@ -41,7 +41,7 @@ mesosphereResources:
       serviceURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
     prometheus:
       jobName: prom-get-cluster-id
-      kubectlImage: bitnami/kubectl:1.19.2
+      kubectlImage: bitnami/kubectl:1.19.7
       configmapName: cluster-info-configmap
   ingressRBAC:
     enabled: true

--- a/staging/prometheus-operator/patch/patch_6_mesosphere_values.sh
+++ b/staging/prometheus-operator/patch/patch_6_mesosphere_values.sh
@@ -41,7 +41,7 @@ mesosphereResources:
       serviceURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
     prometheus:
       jobName: prom-get-cluster-id
-      kubectlImage: bitnami/kubectl:1.16.2
+      kubectlImage: bitnami/kubectl:1.19.2
       configmapName: cluster-info-configmap
   ingressRBAC:
     enabled: true

--- a/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part1.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part1.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part1
       containers:
         - name: v9-to-v11-crds-part1
-          image: "bitnami/kubectl:1.16.2"
+          image: "bitnami/kubectl:1.19.2"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part1.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part1.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part1
       containers:
         - name: v9-to-v11-crds-part1
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part2.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part2.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part2
       containers:
         - name: v9-to-v11-crds-part2
-          image: "bitnami/kubectl:1.16.2"
+          image: "bitnami/kubectl:1.19.2"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part2.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/v9-to-v11-upgrade-part2.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: v9-to-v11-crds-part2
       containers:
         - name: v9-to-v11-crds-part2
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: crds
               mountPath: /etc/crds

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -2321,7 +2321,7 @@ mesosphereResources:
       serviceURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
     prometheus:
       jobName: prom-get-cluster-id
-      kubectlImage: bitnami/kubectl:1.16.2
+      kubectlImage: bitnami/kubectl:1.19.2
       configmapName: cluster-info-configmap
   ingressRBAC:
     enabled: true

--- a/staging/prometheus-operator/values.yaml
+++ b/staging/prometheus-operator/values.yaml
@@ -2321,7 +2321,7 @@ mesosphereResources:
       serviceURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
     prometheus:
       jobName: prom-get-cluster-id
-      kubectlImage: bitnami/kubectl:1.19.2
+      kubectlImage: bitnami/kubectl:1.19.7
       configmapName: cluster-info-configmap
   ingressRBAC:
     enabled: true

--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 3.1.0
+version: 3.1.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/staging/velero/templates/install-crds.yaml
+++ b/staging/velero/templates/install-crds.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: velero-crds
       containers:
         - name: velero-crds
-          image: "bitnami/kubectl:1.16.2"
+          image: "bitnami/kubectl:1.19.2"
           volumeMounts:
             - name: velero-crds
               mountPath: /etc/velero-crds

--- a/staging/velero/templates/install-crds.yaml
+++ b/staging/velero/templates/install-crds.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: velero-crds
       containers:
         - name: velero-crds
-          image: "bitnami/kubectl:1.19.2"
+          image: "bitnami/kubectl:1.19.7"
           volumeMounts:
             - name: velero-crds
               mountPath: /etc/velero-crds


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Fix
**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
In related to CVE-2017-14062, used in bitnami/kubectl@1.16 is normally used in one-liners to talk to the API. I am not sure how critical is the usage of libidn2 for those one-run calls. 

```
Integer overflow in the decode_digit function in puny_decode.c in Libidn2 before 2.0.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact.
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
