### PR TITLE
defaultstorageclass: use better selectors

### DIFF
--- a/stable/defaultstorageclass/Chart.yaml
+++ b/stable/defaultstorageclass/Chart.yaml
@@ -4,7 +4,8 @@ description: Webhooks and controllers relating to default storage classes
 name: defaultstorageclass
 maintainers:
   - name: joejulian
-version: 0.0.4
+  - name: dkoshkin
+version: 0.0.5
 kubeVersion: ">=1.15.0"
 home: https://github.com/mesosphere/defaultstorageclass
 sources:

--- a/stable/defaultstorageclass/templates/deployment.yaml
+++ b/stable/defaultstorageclass/templates/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    app: dstorageclass-controller-manager  
+    app: defaultstorageclass  
     control-plane: controller-manager
   name: dstorageclass-controller-manager
   namespace: {{ .Release.Namespace }}
@@ -12,14 +12,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dstorageclass-controller-manager    
+      app: defaultstorageclass    
       control-plane: controller-manager
   strategy: {}
   template:
     metadata:
       creationTimestamp: null
       labels:
-        app: dstorageclass-controller-manager      
+        app: defaultstorageclass      
         control-plane: controller-manager
     spec:
       containers:

--- a/stable/defaultstorageclass/templates/deployment.yaml
+++ b/stable/defaultstorageclass/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
+    app: dstorageclass-controller-manager  
     control-plane: controller-manager
   name: dstorageclass-controller-manager
   namespace: {{ .Release.Namespace }}
@@ -11,12 +12,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app: dstorageclass-controller-manager    
       control-plane: controller-manager
   strategy: {}
   template:
     metadata:
       creationTimestamp: null
       labels:
+        app: dstorageclass-controller-manager      
         control-plane: controller-manager
     spec:
       containers:

--- a/stable/defaultstorageclass/templates/service.yaml
+++ b/stable/defaultstorageclass/templates/service.yaml
@@ -15,6 +15,7 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app: dstorageclass-controller-manager
     control-plane: controller-manager
 status:
   loadBalancer: {}
@@ -31,6 +32,7 @@ spec:
   - port: 443
     targetPort: 443
   selector:
+    app: dstorageclass-controller-manager  
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/stable/defaultstorageclass/templates/service.yaml
+++ b/stable/defaultstorageclass/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app: dstorageclass-controller-manager
+    app: defaultstorageclass
     control-plane: controller-manager
 status:
   loadBalancer: {}
@@ -32,7 +32,7 @@ spec:
   - port: 443
     targetPort: 443
   selector:
-    app: dstorageclass-controller-manager  
+    app: defaultstorageclass  
     control-plane: controller-manager
 status:
   loadBalancer: {}


### PR DESCRIPTION
Signed-off-by: Dimitri Koshkin <dimitri.koshkin@gmail.com>

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
[Recent gatekeeper PR](https://github.com/mesosphere/charts/pull/956) made this chart flaky.

See [JIRA](https://jira.d2iq.com/browse/D2IQ-73956) for the issue details.

Because the selectors are changing, the KBA addon resource will now need to use a `delete` strategy. (PR to follow)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-73956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
defaultstorageclass: use unique Service selectors to avoid selecting unwanted endpoints from other charts.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
