### PR TITLE
chore: use /bin/sh in kommander-set-grafana job

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -7,5 +7,6 @@ maintainers:
   - name: alejandroEsc
   - name: jimmidyson
   - name: gracedo
+  - name: dkoshkin
 name: kommander
-version: 0.13.27
+version: 0.13.28

--- a/stable/kommander/templates/grafana/cronjob-home-dashboard.yaml
+++ b/stable/kommander/templates/grafana/cronjob-home-dashboard.yaml
@@ -32,7 +32,7 @@ spec:
               - sh
               - "-c"
               - |
-                /bin/bash <<'EOF' 
+                /bin/sh <<'EOF' 
                 set -o nounset
                 set -o errexit
                 set -o pipefail


### PR DESCRIPTION
Signed-off-by: Dimitri Koshkin <dimitri.koshkin@gmail.com>

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Similar change as https://github.com/mesosphere/charts/pull/964/files

```
k logs -n kommander      kommander-kubeaddons-set-grafana-home-dashboard-trigger-7gs2h
sh: /bin/bash: not found
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kommander: fix set-grafana-home-dashboard after it was updated to a new jq image.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
