### PR TITLE
[release/kubecost-0.5.x] kubecost: Bump grafana sidecar image

### DIFF
--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.71.0
+appVersion: 1.71.1
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.5.2
+version: 0.5.3
 maintainers:
   - name: gracedo

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -197,6 +197,7 @@ cost-analyzer:
 
   grafana:
     sidecar:
+      image: kiwigrid/k8s-sidecar:1.3.0
       dashboards:
         enabled: true
         label: kubecost_grafana_dashboard


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Patch kubecost 0.5.x chart to use older functioning kubecost release + add cve fix on top (https://github.com/mesosphere/charts/commit/6e3d7be63b4dc41c094cda249d741cb256c542f1#diff-478557e8a9ca4fd77b8f3ac5c7e109a7670090e32c03464ec2804a0b54abe1b3)

When this is merged to the release branch `release/kubecost-0.5.x` I will run the publish job to get this patched chart published, then update kommander chart and yakcl to downgrade kubecost to this version instead.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-74109

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
