### PR TITLE
kommander: Bump kommander to 0.16.0 following v1.3.0 release

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.3.1
+appVersion: 1.4.0
 description: Kommander
 home: https://github.com/mesosphere/charts
 maintainers:

--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: gracedo
   - name: dkoshkin
 name: kommander
-version: 0.15.0
+version: 0.16.0

--- a/stable/kommander/README.md
+++ b/stable/kommander/README.md
@@ -27,3 +27,17 @@ helm install --namespace "kommander" --name "kommander-kubeaddons" --set kommand
 ```bash
 helm install --namespace "kommander" --name "kommander-kubeaddons" --set kommander-cluster-lifecycle.certificates.issuer.selfSigned=true ./stable/kommander
 ```
+
+## Backporting / Patch Releases
+The minor version should be bumped following every Kommander release.
+
+- Kommander v1.4.x -> chart version v0.14.x
+- Kommander v1.3.x -> chart version v0.13.x
+
+This allows us to backport and create patch releases. When backporting, you should work off of the appropriate release branch for the chart. The release branch follows a `release/kommander-v0.13.x` convention for v0.13.x chart versions. If the release branch does not exist, you must create it. Browse the chart's git history until you find the commit before the chart was bumped to the next minor version. Branch off that commit to create the release branch, which will sit at the latest patch version of the chart before it was bumped to the next minor version (and release of Kommander).
+
+Push this release branch to the m/charts repo. Then, branch off the release branch to backport your changes. Open up a PR against the release branch. When the PR is merged, you are ready to publish the new patch chart version. There is a `make publish` target that runs the necessary `helm` commands to package and index the new chart. Making sure you are on the release branch, run `make publish`. This will push a commit to the `gh-pages` branch with the new chart tar file and the updated index.yaml. Double check this has been done properly by checking out the `gh-pages` branch, and that no other charts have been modified or deleted. It is expected to see timestamp changes across the yaml file as it is re-indexed.
+
+**Note**: If you have forked m/charts, it may be helpful to run through these steps on your fork first to double check that the process works as expected, for peace of mind and to lower the risk of something going wrong in our charts repo.
+
+Once the patched chart version is published, you can open up a PR in `kubeaddons-kommander` to bump the addon revision and pull in the patch. There are docs on how to patch the addon in the `kubeaddons-kommander` repo's `README`.

--- a/stable/kommander/README.md
+++ b/stable/kommander/README.md
@@ -31,10 +31,10 @@ helm install --namespace "kommander" --name "kommander-kubeaddons" --set kommand
 ## Backporting / Patch Releases
 The minor version should be bumped following every Kommander release.
 
-- Kommander v1.4.x -> chart version v0.14.x
-- Kommander v1.3.x -> chart version v0.13.x
+- Kommander v1.4.x -> chart version v0.16.x
+- Kommander v1.3.x patches should go into chart version v0.15.x
 
-This allows us to backport and create patch releases. When backporting, you should work off of the appropriate release branch for the chart. The release branch follows a `release/kommander-v0.13.x` convention for v0.13.x chart versions. If the release branch does not exist, you must create it. Browse the chart's git history until you find the commit before the chart was bumped to the next minor version. Branch off that commit to create the release branch, which will sit at the latest patch version of the chart before it was bumped to the next minor version (and release of Kommander).
+This allows us to backport and create patch releases. When backporting, you should work off of the appropriate release branch for the chart. The release branch follows a `release/kommander-v0.15.x` convention for v0.15.x chart versions. If the release branch does not exist, you must create it. Browse the chart's git history until you find the commit before the chart was bumped to the next minor version. Branch off that commit to create the release branch, which will sit at the latest patch version of the chart before it was bumped to the next minor version (and release of Kommander).
 
 Push this release branch to the m/charts repo. Then, branch off the release branch to backport your changes. Open up a PR against the release branch. When the PR is merged, you are ready to publish the new patch chart version. There is a `make publish` target that runs the necessary `helm` commands to package and index the new chart. Making sure you are on the release branch, run `make publish`. This will push a commit to the `gh-pages` branch with the new chart tar file and the updated index.yaml. Double check this has been done properly by checking out the `gh-pages` branch, and that no other charts have been modified or deleted. It is expected to see timestamp changes across the yaml file as it is re-indexed.
 

--- a/stable/kommander/README.md
+++ b/stable/kommander/README.md
@@ -40,4 +40,4 @@ Push this release branch to the m/charts repo. Then, branch off the release bran
 
 **Note**: If you have forked m/charts, it may be helpful to run through these steps on your fork first to double check that the process works as expected, for peace of mind and to lower the risk of something going wrong in our charts repo.
 
-Once the patched chart version is published, you can open up a PR in `kubeaddons-kommander` to bump the addon revision and pull in the patch. There are docs on how to patch the addon in the `kubeaddons-kommander` repo's `README`.
+Once the patched chart version is published, you can open up a PR in `kubeaddons-kommander` to bump the addon revision and pull in the patch. There are docs on how to patch the addon in the `kubeaddons-kommander` repo's [`README`](https://github.com/mesosphere/kubeaddons-kommander#dealing-with-previously-released-stable-versions).

--- a/stable/kommander/README.md
+++ b/stable/kommander/README.md
@@ -38,6 +38,12 @@ This allows us to backport and create patch releases. When backporting, you shou
 
 Push this release branch to the m/charts repo. Then, branch off the release branch to backport your changes. Open up a PR against the release branch. When the PR is merged, you are ready to publish the new patch chart version. There is a `make publish` target that runs the necessary `helm` commands to package and index the new chart. Making sure you are on the release branch, run `make publish`. This will push a commit to the `gh-pages` branch with the new chart tar file and the updated index.yaml. Double check this has been done properly by checking out the `gh-pages` branch, and that no other charts have been modified or deleted. It is expected to see timestamp changes across the yaml file as it is re-indexed.
 
+If for any reason the publish results in a bad commit, you can revert the commit by getting the SHA of the previous commit on `gh-pages` prior to the latest push and running:
+```bash
+git reset --hard <SHA>
+git push --force origin/gh-pages
+```
+
 **Note**: If you have forked m/charts, it may be helpful to run through these steps on your fork first to double check that the process works as expected, for peace of mind and to lower the risk of something going wrong in our charts repo.
 
 Once the patched chart version is published, you can open up a PR in `kubeaddons-kommander` to bump the addon revision and pull in the patch. There are docs on how to patch the addon in the `kubeaddons-kommander` repo's [`README`](https://github.com/mesosphere/kubeaddons-kommander#dealing-with-previously-released-stable-versions).


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Following kommander 1.3.0 GA, we should bump the chart's minor version for v1.16.0. patches for v1.3 should patch this chart's 0.15.x versions. Also, wrote up some chart patching instructions in the readme, please review

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-70979

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
