### PR TITLE
prometheus: Add missing pre-delete hook to SA

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -18,7 +18,7 @@ name: prometheus-operator
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.11.8
+version: 12.11.9
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/prometheus-operator/patch/mesosphere/templates/hooks/prometheus-cluster-id-hooks.yaml
+++ b/staging/prometheus-operator/patch/mesosphere/templates/hooks/prometheus-cluster-id-hooks.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-delete
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 ---

--- a/staging/prometheus-operator/templates/mesosphere-hooks/prometheus-cluster-id-hooks.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/prometheus-cluster-id-hooks.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-delete
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 ---


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug (COPS)

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
A prometheus pre-delete SA hook was missing, which was required for the pre-delete jobs, causing addon deletion/cleanup to fail. Will open another PR to backport this fix to 9.3.x

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-74181
https://jira.d2iq.com/browse/COPS-6807

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix(prometheus): Adds a missing service account which caused addon deletion/cleanup to fail
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
