### PR TITLE
[release/prometheus-operator-9.3.x] Add missing pre-delete hook to SA

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.6
+version: 9.3.7
 appVersion: 0.38.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/staging/prometheus-operator/patch/mesosphere/templates/hooks/prometheus-cluster-id-hooks.yaml
+++ b/staging/prometheus-operator/patch/mesosphere/templates/hooks/prometheus-cluster-id-hooks.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-delete
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 ---

--- a/staging/prometheus-operator/templates/mesosphere-hooks/prometheus-cluster-id-hooks.yaml
+++ b/staging/prometheus-operator/templates/mesosphere-hooks/prometheus-cluster-id-hooks.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-delete
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 ---


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug (backport)

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Backports #993 to pull into Konvoy 1.6 (and 1.5?) patch release. My concern is that we have already applied a patch to 9.3.x here: https://github.com/mesosphere/charts/pull/970 which was done for konvoy 1.7 to mitigate some CVEs; this patch was pulled into yakcl federated prometheus to avoid upgrading the federatedaddon. So these extra CVE mitigations would be pulled into a konvoy 1.6/1.5 patch.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
