### PR TITLE
[release/kubecost-0.1.x] fix: Use --ignore-not-found in kubectl delete

### DIFF
--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.65.0
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.1.15
+version: 0.1.16
 maintainers:
   - name: gracedo

--- a/stable/kubecost/templates/hooks-clusterid.yaml
+++ b/stable/kubecost/templates/hooks-clusterid.yaml
@@ -141,7 +141,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - kubectl delete configmap {{ index .Values "cost-analyzer" "prometheus" "server" "clusterIDConfigmap" }} -n {{ .Release.Namespace }}
+            - kubectl delete configmap {{ index .Values "cost-analyzer" "prometheus" "server" "clusterIDConfigmap" }} -n {{ .Release.Namespace }} --ignore-not-found
       restartPolicy: OnFailure
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Prevent chart from failing uninstall in case the cm has already been deleted (has occurred with kommander which pulls this chart in as subchart, and oftentimes undergoes multiple uninstall attempts). This is a backport of https://github.com/mesosphere/charts/pull/1000 for komm1.1/konv1.5

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/COPS-6821
https://jira.d2iq.com/browse/D2IQ-74255

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix(kubecost): Ensure kubectl deletes do not fail if resource already deleted
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
