### PR TITLE
[gatekeeper] chore: change scope of proxy items as wildcard does not work consistently

### DIFF
--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.3.0"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.6.1
+version: 0.6.2
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:

--- a/staging/gatekeeper/patch/templates/gatekeeper-proxy-mutations.yaml
+++ b/staging/gatekeeper/patch/templates/gatekeeper-proxy-mutations.yaml
@@ -11,7 +11,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: '*'
+    scope: "Namespaced"
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}
@@ -37,7 +37,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: '*'
+    scope: "Namespaced"
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}
@@ -63,7 +63,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: '*'
+    scope: "Namespaced"
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}

--- a/staging/gatekeeper/patch/templates/gatekeeper-proxy-mutations.yaml
+++ b/staging/gatekeeper/patch/templates/gatekeeper-proxy-mutations.yaml
@@ -10,6 +10,12 @@ spec:
       kinds: ["Pod"]
       versions: ["*"]
 
+  match:
+    scope: '*'
+    {{- if .Values.mutations.excludeNamespacesFromProxy }}
+    excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
+    {{- end }}
+
   location: "spec.containers[name:*].env[name:NO_PROXY]"
 
   parameters:
@@ -30,6 +36,12 @@ spec:
       kinds: ["Pod"]
       versions: ["*"]
 
+  match:
+    scope: '*'
+    {{- if .Values.mutations.excludeNamespacesFromProxy }}
+    excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
+    {{- end }}
+
   location: "spec.containers[name:*].env[name:HTTP_PROXY]"
 
   parameters:
@@ -49,6 +61,12 @@ spec:
     - groups: [""]
       kinds: ["Pod"]
       versions: ["*"]
+
+  match:
+    scope: '*'
+    {{- if .Values.mutations.excludeNamespacesFromProxy }}
+    excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
+    {{- end }}
 
   location: "spec.containers[name:*].env[name:HTTPS_PROXY]"
 

--- a/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
@@ -11,7 +11,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: "*"
+    scope: '*'
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}
@@ -37,7 +37,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: "*"
+    scope: '*'
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}
@@ -63,7 +63,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: "*"
+    scope: '*'
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}

--- a/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
@@ -11,7 +11,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: '*'
+    scope: "Namespaced"
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}
@@ -37,7 +37,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: '*'
+    scope: "Namespaced"
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}
@@ -63,7 +63,7 @@ spec:
       versions: ["*"]
 
   match:
-    scope: '*'
+    scope: "Namespaced"
     {{- if .Values.mutations.excludeNamespacesFromProxy }}
     excludedNamespaces: {{ .Values.mutations.excludeNamespacesFromProxy }}
     {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Wildcard scope does not seem to work consistently, and doesnt seem to be handled in code.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:
This was tested with velero and other static pods, the scope and exclusion now work consistently.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
