### PR TITLE
chore: fix gatekeeper so only proxy settings are for mutations

### DIFF
--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.3.0"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.6.3
+version: 0.6.4
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:

--- a/staging/gatekeeper/patch/templates/gatekeeper-proxy-mutations.yaml
+++ b/staging/gatekeeper/patch/templates/gatekeeper-proxy-mutations.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.proxySettings.noProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
+{{- if and (and .Values.mutations.podProxySettings.noProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
 ---
 apiVersion: mutations.gatekeeper.sh/v1alpha1
 kind: Assign
@@ -24,9 +24,9 @@ spec:
     assign:
       value:
         name: NO_PROXY
-        value: {{ .Values.proxySettings.noProxy }}
+        value: {{ .Values.mutations.podProxySettings.noProxy }}
 {{- end }}
-{{- if and (and .Values.proxySettings.httpProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
+{{- if and (and .Values.mutations.podProxySettings.httpProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
 ---
 apiVersion: mutations.gatekeeper.sh/v1alpha1
 kind: Assign
@@ -52,9 +52,9 @@ spec:
     assign:
       value:
         name: HTTP_PROXY
-        value: {{ .Values.proxySettings.httpProxy }}
+        value: {{ .Values.mutations.podProxySettings.httpProxy }}
 {{- end }}
-{{- if and (and .Values.proxySettings.httpsProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
+{{- if and (and .Values.mutations.podProxySettings.httpsProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
 ---
 apiVersion: mutations.gatekeeper.sh/v1alpha1
 kind: Assign
@@ -80,5 +80,5 @@ spec:
     assign:
       value:
         name: HTTPS_PROXY
-        value: {{ .Values.proxySettings.httpsProxy }}
+        value: {{ .Values.mutations.podProxySettings.httpsProxy }}
 {{- end }}

--- a/staging/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -57,18 +57,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        {{- if .Values.proxySettings.noProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxySettings.noProxy }}
-        {{- end }}
-        {{- if .Values.proxySettings.httpProxy }}
-        - name: HTTP_PROXY
-          value: {{ .Values.proxySettings.httpProxy }}
-        {{- end }}
-        {{- if .Values.proxySettings.httpsProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxySettings.httpsProxy }}
-        {{- end }}
         image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         livenessProbe:

--- a/staging/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -71,18 +71,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        {{- if .Values.proxySettings.noProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.proxySettings.noProxy }}
-        {{- end }}
-        {{- if .Values.proxySettings.httpProxy }}
-        - name: HTTP_PROXY
-          value: {{ .Values.proxySettings.httpProxy }}
-        {{- end }}
-        {{- if .Values.proxySettings.httpsProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.proxySettings.httpsProxy }}
-        {{- end }}
         image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         livenessProbe:

--- a/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.proxySettings.noProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
+{{- if and (and .Values.mutations.podProxySettings.noProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
 ---
 apiVersion: mutations.gatekeeper.sh/v1alpha1
 kind: Assign
@@ -24,9 +24,9 @@ spec:
     assign:
       value:
         name: NO_PROXY
-        value: {{ .Values.proxySettings.noProxy }}
+        value: {{ .Values.mutations.podProxySettings.noProxy }}
 {{- end }}
-{{- if and (and .Values.proxySettings.httpProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
+{{- if and (and .Values.mutations.podProxySettings.httpProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
 ---
 apiVersion: mutations.gatekeeper.sh/v1alpha1
 kind: Assign
@@ -52,9 +52,9 @@ spec:
     assign:
       value:
         name: HTTP_PROXY
-        value: {{ .Values.proxySettings.httpProxy }}
+        value: {{ .Values.mutations.podProxySettings.httpProxy }}
 {{- end }}
-{{- if and (and .Values.proxySettings.httpsProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
+{{- if and (and .Values.mutations.podProxySettings.httpsProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
 ---
 apiVersion: mutations.gatekeeper.sh/v1alpha1
 kind: Assign
@@ -80,5 +80,5 @@ spec:
     assign:
       value:
         name: HTTPS_PROXY
-        value: {{ .Values.proxySettings.httpsProxy }}
+        value: {{ .Values.mutations.podProxySettings.httpsProxy }}
 {{- end }}

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -94,18 +94,17 @@ webhook:
 
 kubectlImage: bitnami/kubectl:1.15
 
-# ProxySettings
-proxySettings:
-  noProxy:
-  httpProxy:
-  httpsProxy:
-
 # enable mutations
 mutations:
   enable: false
 
   # proxy settings
   enablePodProxy: false
+
+  podProxySettings:
+    noProxy:
+    httpProxy:
+    httpsProxy:
 
   # apply mutations on objects whose labels match namespace labels
   namespaceSelectorForProxy: {}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
We are moving to set mutations only having the ability to set proxy settings, remove these from gatekeeper itself.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
