### PR TITLE
(release/prometheus-operator-9.3.x) use busybox sh instead of the no-longer-existing bash

### DIFF
--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.7
+version: 9.3.8
 appVersion: 0.38.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/staging/prometheus-operator/templates/grafana/cronjob-home-dashboard.yaml
+++ b/staging/prometheus-operator/templates/grafana/cronjob-home-dashboard.yaml
@@ -42,7 +42,7 @@ metadata:
   name: {{ .Release.Name }}-{{ .Values.mesosphereResources.homeDashboard.cronJob.name }}
 data:
   run.sh: |-
-    #!/bin/bash
+    #!/bin/sh
     set -o nounset
     set -o errexit
     set -o pipefail


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This backports #964 to prometheus-operator 9.3.x.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

The copy of the script at `staging/prometheus-operator/patch/mesosphere/templates/grafana/cronjob-home-dashboard.yaml` is already updated.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[prometheus-operator] Fixes the cronjob that sets the Grafana home dashboard.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
