### PR TITLE
[kommander] feat: use custom built karma version with proxy support

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: gracedo
   - name: dkoshkin
 name: kommander
-version: 0.19.0
+version: 0.19.1

--- a/stable/kommander/charts/kommander-karma/Chart.yaml
+++ b/stable/kommander/charts/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.12
+version: 0.3.13
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander/charts/kommander-karma/values.yaml
+++ b/stable/kommander/charts/kommander-karma/values.yaml
@@ -12,6 +12,14 @@ federate:
     name: kommander-system
 
 karma:
+  image:
+    # This image should be re-built and updated until the upstream karma version
+    # adds proxy support. The default value comes from `karma` chart version
+    # `1.4.1` that is included in `kommander-karma` subchart.
+    # See: https://jira.d2iq.com/browse/D2IQ-74658
+    repository: mesosphere/karma
+    tag: v0.55-d2iq-proxy
+
   service:
     labels:
       servicemonitor.kubeaddons.mesosphere.io/path: "kommander__monitoring__karma__metrics"

--- a/stable/kommander/requirements.lock
+++ b/stable/kommander/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kommander-karma
   repository: ""
-  version: 0.3.12
+  version: 0.3.13
 - name: kommander-thanos
   repository: ""
   version: 0.1.16
@@ -10,10 +10,10 @@ dependencies:
   version: 0.1.16
 - name: kommander-federation
   repository: https://mesosphere.github.io/yakcl/charts
-  version: 0.10.0
+  version: v0.10.0
 - name: kommander-licensing
   repository: https://mesosphere.github.io/yakcl/charts
-  version: 0.10.0
+  version: v0.10.0
 - name: kommander-ui
   repository: https://mesosphere.github.io/kommander-ui/charts
   version: 6.91.1
@@ -23,5 +23,5 @@ dependencies:
 - name: grafana
   repository: https://mesosphere.github.io/charts/stable
   version: 4.6.3
-digest: sha256:dab7ba9e8fff7a052490bf0d750d77dad72769d1c3e42341d97d6a329e6478ed
-generated: "2021-03-11T17:33:28.987743268Z"
+digest: sha256:25b2254dcaeb23e9746ad7fecf7b4c88f8e91cb534e6817c14380cd9df21e5b3
+generated: "2021-03-18T16:24:39.014575426+01:00"

--- a/stable/kommander/requirements.yaml
+++ b/stable/kommander/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: kommander-karma
-    version: "0.3.12"
+    version: "0.3.13"
   - name: kommander-thanos
     version: "0.1.16"
   - name: kubeaddons-catalog


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
Adds support for tunneled clusters to karma. The karma must be deployed with a custom version from https://github.com/mesosphere/karma/tree/v0.55-d2iq-proxy

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-74658

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support tunneled clusters in karma configuration
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
