### PR TITLE
[kommander] feat: create local secrets with server proxy certificates

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: gracedo
   - name: dkoshkin
 name: kommander
-version: 0.19.2
+version: 0.19.3

--- a/stable/kommander/charts/kommander-karma/Chart.yaml
+++ b/stable/kommander/charts/kommander-karma/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Kommander Karma
 name: kommander-karma
 home: https://github.com/mesosphere/charts
-version: 0.3.14
+version: 0.3.15
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander/charts/kommander-karma/templates/federated-addon.yaml
+++ b/stable/kommander/charts/kommander-karma/templates/federated-addon.yaml
@@ -11,8 +11,6 @@ spec:
   placement:
     clusterSelector:
       matchLabels: {}
-      matchExpressions:
-        - {key: kommander.mesosphere.io/connection-type, operator: NotIn, values: [unidirectional]}
   template:
     metadata:
       namespace: kubeaddons

--- a/stable/kommander/charts/kommander-thanos/Chart.yaml
+++ b/stable/kommander/charts/kommander-thanos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.10.1
 description: Kommander Thanos
 name: kommander-thanos
 home: https://github.com/mesosphere/charts
-version: 0.1.17
+version: 0.1.18
 maintainers:
   - name: branden
   - name: gracedo

--- a/stable/kommander/charts/kommander-thanos/templates/secret.yaml
+++ b/stable/kommander/charts/kommander-thanos/templates/secret.yaml
@@ -12,7 +12,11 @@ metadata:
 data:
   tls.crt: {{ b64enc $thanosClient.Cert }}
   tls.key: {{ b64enc $thanosClient.Key }}
-  ca.crt: {{ b64enc $thanosCa.Cert }} 
+  ca.crt: {{ b64enc $thanosCa.Cert }}
+
+# The thanosServer certificate is stored as a federated and local secret. This
+# allows to use same certificate on directly connected clusters and clusters
+# connected via kubetunnel.
 ---
 apiVersion: types.kubefed.io/v1beta1
 kind: FederatedSecret
@@ -30,4 +34,16 @@ spec:
     data:
       tls.crt: {{ b64enc $thanosServer.Cert }}
       tls.key: {{ b64enc $thanosServer.Key }}
-      ca.crt: {{ b64enc $thanosCa.Cert }} 
+      ca.crt: {{ b64enc $thanosCa.Cert }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: kommander-thanos-server-tls
+  labels:
+{{ include "kommander-thanos.labels" . | indent 4 }}
+data:
+  tls.crt: {{ b64enc $thanosServer.Cert }}
+  tls.key: {{ b64enc $thanosServer.Key }}
+  ca.crt: {{ b64enc $thanosCa.Cert }}

--- a/stable/kommander/requirements.lock
+++ b/stable/kommander/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.14
 - name: kommander-thanos
   repository: ""
-  version: 0.1.17
+  version: 0.1.18
 - name: kubeaddons-catalog
   repository: https://mesosphere.github.io/charts/staging
   version: 0.1.16
@@ -23,5 +23,5 @@ dependencies:
 - name: grafana
   repository: https://mesosphere.github.io/charts/stable
   version: 4.6.3
-digest: sha256:8c4e8745d136e948709d453a853c8ba74d824ccc9f28d76884fca1abbc86e822
-generated: "2021-03-23T15:30:00.122157+01:00"
+digest: sha256:2d366e5ada3985d2baaaf0c7c30a2c982841e5f4fd4bb3c29b9d28798657bf9f
+generated: "2021-03-24T14:30:06.218692849+01:00"

--- a/stable/kommander/requirements.lock
+++ b/stable/kommander/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kommander-karma
   repository: ""
-  version: 0.3.14
+  version: 0.3.15
 - name: kommander-thanos
   repository: ""
   version: 0.1.18
@@ -23,5 +23,5 @@ dependencies:
 - name: grafana
   repository: https://mesosphere.github.io/charts/stable
   version: 4.6.3
-digest: sha256:2d366e5ada3985d2baaaf0c7c30a2c982841e5f4fd4bb3c29b9d28798657bf9f
-generated: "2021-03-24T14:30:06.218692849+01:00"
+digest: sha256:e482202c994d764f1f1a8b0db184711a2c63d6e0ee090e84ae7b37b4917a457d
+generated: "2021-03-25T07:21:40.941497029+01:00"

--- a/stable/kommander/requirements.yaml
+++ b/stable/kommander/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: kommander-karma
-    version: "0.3.14"
+    version: "0.3.15"
   - name: kommander-thanos
     version: "0.1.18"
   - name: kubeaddons-catalog

--- a/stable/kommander/requirements.yaml
+++ b/stable/kommander/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - name: kommander-karma
     version: "0.3.14"
   - name: kommander-thanos
-    version: "0.1.17"
+    version: "0.1.18"
   - name: kubeaddons-catalog
     version: "0.1.16"
     repository: "https://mesosphere.github.io/charts/staging"

--- a/stable/kommander/templates/kubecost/secret.yaml
+++ b/stable/kommander/templates/kubecost/secret.yaml
@@ -13,6 +13,10 @@ data:
   tls.crt: {{ b64enc $thanosClient.Cert }}
   tls.key: {{ b64enc $thanosClient.Key }}
   ca.crt: {{ b64enc $thanosCa.Cert }}
+
+# The thanosServer certificate is stored as a federated and local secret. This
+# allows to use same certificate on directly connected clusters and clusters
+# connected via kubetunnel.
 ---
 apiVersion: types.kubefed.io/v1beta1
 kind: FederatedSecret
@@ -31,3 +35,15 @@ spec:
       tls.crt: {{ b64enc $thanosServer.Cert }}
       tls.key: {{ b64enc $thanosServer.Key }}
       ca.crt: {{ b64enc $thanosCa.Cert }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: kommander-kubecost-thanos-server-tls
+  labels:
+{{ include "kommander.labels" . | indent 4 }}
+data:
+  tls.crt: {{ b64enc $thanosServer.Cert }}
+  tls.key: {{ b64enc $thanosServer.Key }}
+  ca.crt: {{ b64enc $thanosCa.Cert }}


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
In addition to existing `FederatedSecrets` with TLS certificate and key for `mtls-proxy` create also a local copy of server certificate data that can be used for local management cluster `mtls-proxy` instances.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-74659

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
