### PR TITLE
[mtls-proxy] fix: env values indentation

### DIFF
--- a/stable/mtls-proxy/Chart.yaml
+++ b/stable/mtls-proxy/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "1.0"
 description: mTLS proxy
 name: mtls-proxy
 home: https://github.com/mesosphere/charts
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: branden

--- a/stable/mtls-proxy/templates/deployment.yaml
+++ b/stable/mtls-proxy/templates/deployment.yaml
@@ -43,9 +43,9 @@ spec:
             - name: tls
               containerPort: 443
               protocol: TCP
-          {{- with .Values.env }}
+          {{- if .Values.env }}
           env:
-            {{- toYaml . | indent 12 }}
+{{ toYaml .Values.env | indent 10 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/stable/mtls-proxy/values.yaml
+++ b/stable/mtls-proxy/values.yaml
@@ -23,7 +23,7 @@ ingress:
   hosts: []
 
 # Environment variables to be passed to ghostunnel deployment container.
-env: {}
+env: []
 #  - name: SOME_VAR
 #    value: some-var-value
 #  - name: SOME_OTHER_VAR


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
Fixes indentation error that casues YAML parsing error when providing custom ENV variables:

```
YAML parse error on mtls-proxy/templates/deployment.yaml: error converting YAML to JSON: yaml: line 44: block sequence entries are not allowed in this context
```

**Which issue(s) this PR fixes**:
no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
