### PR TITLE
D2IQ-74604 feat(traefik): allow overriding int cert vars

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.88.0
+version: 1.89.0
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/init-cert-job.yaml
+++ b/staging/traefik/templates/init-cert-job.yaml
@@ -24,6 +24,22 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["traefik"]
         env:
+        {{- if .Values.initCert }}
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: {{ .Values.initCert.ingressNamespace | default "kubeaddons" | quote }} 
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: {{ .Values.initCert.ingressServiceName | default "traefik-kubeaddons" | quote }} 
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: {{.Values.initCert.ingressCertificateName | default "traefik-kubeaddons" | quote }}
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: {{ .Values.initCert.ingressCertificateIssuer | default "kubernetes-ca" | quote }}
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: {{ .Values.initCert.ingressCertificateSecretName | default "traefik-kubeaddons-certificate" | quote }}
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: {{ .Values.initCert.konvoyAddonsConfigMap | default "konvoyconfig-kubeaddons" | quote }}
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: {{ .Values.initCert.clusterHostnameKey | default "clusterHostname" | quote }}
+        {{- else }}
         - name: "TRAEFIK_INGRESS_NAMESPACE"
           value: "kubeaddons"
         - name: "TRAEFIK_INGRESS_SERVICE_NAME"
@@ -38,4 +54,5 @@ spec:
           value: "konvoyconfig-kubeaddons"
         - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
           value: "clusterHostname"
+        {{- end }}
 {{- end }}

--- a/staging/traefik/templates/tests/test-certificate.yaml
+++ b/staging/traefik/templates/tests/test-certificate.yaml
@@ -136,4 +136,77 @@ spec:
           value: "konvoyconfig-kubeaddons"
         - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
           value: "clusterHostname"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "traefik.fullname" . }}-reload
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "traefik.fullname" . }}-reload
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: ["apps", "extensions"]
+    resources: ["deployments"]
+    resourceNames: ["{{ template "traefik.fullname" . }}"]
+    verbs: ["get", "patch", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "traefik.fullname" . }}-reload
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "traefik.fullname" . }}-reload
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "traefik.fullname" . }}-reload
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "traefik.fullname" . }}-reload-pod
+  labels:
+    app: {{ template "traefik.fullname" . }}
+    chart: {{ template "traefik.chart" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "5"
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      serviceAccountName: {{ template "traefik.fullname" . }}-reload
+      restartPolicy: Never
+      containers:
+      - name: {{ template "traefik.fullname" . }}-konvoyconfig-kubeaddons-deploy-job-pod
+        image: bitnami/kubectl:1.18.8-debian-10-r15
+        command:
+        - kubectl
+        - -n
+        - {{ template "traefik.fullname" . }}
+        - rollout
+        - restart
+        - deployment
+        - {{ template "traefik.fullname" . }}
+      restartPolicy: Never
+---
 {{- end }}

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -538,6 +538,14 @@ tracing:
 # to point to a secret name that traefik is waiting on to
 # be mounted before being able to successfully start up.
 initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.3.0
+# initCert:
+#   ingressNamespace: "kubeaddons"
+#   ingressServiceName: "traefik-kubeaddons"
+#   ingressCertificateName: "traefik-kubeaddons"
+#   ingressCertificateIssuer: "kubernetes-ca"
+#   ingressCertificateSecretName: "traefik-kubeaddons-certificate"
+#   konvoyAddonsConfigMap: "konvoyconfig-kubeaddons"
+#   clusterHostnameKey: "clusterHostname"
 
 dashboardRBAC:
   enabled: true


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:

For kommander 2 we need to be able to change the default env vars for
the traefik init cert Job, this adds the ability to set values for the
Job's env vars via the chart.

**Which issue(s) this PR fixes**:
In support of [D2IQ-74604](https://jira.d2iq.com/browse/D2IQ-74604)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
