### PR TITLE
fix(traefik): use issuer value if available

### DIFF
--- a/staging/traefik/Chart.yaml
+++ b/staging/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.89.0
+version: 1.89.1
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/staging/traefik/templates/certificate.yaml
+++ b/staging/traefik/templates/certificate.yaml
@@ -27,7 +27,11 @@ spec:
   secretName: {{ template "traefik.fullname" . }}-certificate
   {{- end }}
   issuerRef:
+  {{- if .Values.initCert }}
+    name: {{ .Values.initCert.ingressCertificateIssuer | default "kubernetes-ca" | quote }}
+  {{- else }}
     name: kubernetes-ca
+  {{- end }}
     kind: ClusterIssuer
   # DCOS-60297 Update certificate to comply with Apple security requirements
   # https://support.apple.com/en-us/HT210176


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
update the certificate template to check for the issuer value and
fallback to "kubernetes-ca" only if it is not set.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:
This is a follow-up to #1067 as I missed that issuer was also hard-coded in the certificate template.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- allow traefik ca issuer to be set from a value, but default to kubernetes-ca if not set
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
