### PR TITLE
[release/prometheus-operator-9.3.x][BACKPORT] use existing storagespec

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -202,7 +202,7 @@ kommander_chart_path = "stable/kommander/Chart.yaml"
 
 # Robot Actions
 action(tasks=["test-helm2", "test-helm3"], on=pull_request())
-action(tasks=["publish"], on=push(branches=["master"]))
+action(tasks=["publish"], on=push(branches=["master", "release/*"]))
 action(tasks=[do_bump_kommander], on=push(branches=["master"], paths=[kommander_chart_path]))
 action(tasks=[do_bump_addon], on=push(branches=["master"], paths=["!" + kommander_chart_path, "stable/*/Chart.yaml", "staging/*/Chart.yaml"]))
 

--- a/staging/prometheus-operator/Chart.yaml
+++ b/staging/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.8
+version: 9.3.9
 appVersion: 0.38.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/staging/prometheus-operator/patch/mesosphere/patch/11_use_existing_storage_definitions.patch
+++ b/staging/prometheus-operator/patch/mesosphere/patch/11_use_existing_storage_definitions.patch
@@ -1,0 +1,94 @@
+commit 7c01b4a4e11cd75a4bb2f8c7d655ff3b789d0dfb
+Author: Joe Julian <me@joejulian.name>
+Date:   Mon Mar 15 17:44:27 2021 -0700
+
+    use exiting storage config if it already exists
+
+    If either prometheus or alertmanager resources exist and have a storage
+    attribute defined in their spec, reuse that instead of what's defined
+    in the values.
+
+    This prevents the accidental redefinition of the volumeClaimTemplate and
+    the abaondomnet of old data.
+
+diff --git a/staging/prometheus-operator/templates/NOTES.txt b/staging/prometheus-operator/templates/NOTES.txt
+index 4ef1bc3c8..f08a8afaa 100644
+--- a/staging/prometheus-operator/templates/NOTES.txt
++++ b/staging/prometheus-operator/templates/NOTES.txt
+@@ -1,5 +1,23 @@
++{{- $namespace := include "prometheus-operator.namespace" . }}
++{{- $name := print (include "prometheus-operator.fullname" .) "-prometheus" }}
++{{- $prometheus := (lookup "monitoring.coreos.com/v1" "Prometheus" $namespace $name) }}
++{{- $spec := ($prometheus).spec }}
++{{- $storage := ($spec).storage }}
++{{- if $storage }}
++NOTICE: A Prometheus resource was already defined. Retaining the existing storage definition.
++If this is not the desired behavior, delete the {{ $name }} prometheus resource from the {{ $namespace }} namespace and upgrade this helm release.
++{{- end }}
++{{- $name = print (include "prometheus-operator.fullname" .) "-alertmanager" }}
++{{- $alertmanager := (lookup "monitoring.coreos.com/v1" "Alertmanager" $namespace $name) }}
++{{- $spec = ($alertmanager).spec }}
++{{- $storage = ($spec).storage }}
++{{- if $storage }}
++NOTICE: An Alertmanager resource was already defined. Retaining the existing storage definition.
++If this is not the desired behavior, delete the {{ $name }} alertmanager resource from the {{ $namespace }} namespace and upgrade this helm release.
++{{- end }}
++
+ The Prometheus Operator has been installed. Check its status by running:
+   kubectl --namespace {{ template "prometheus-operator.namespace" . }} get pods -l "release={{ $.Release.Name }}"
+
+ Visit https://github.com/coreos/prometheus-operator for instructions on how
+-to create & configure Alertmanager and Prometheus instances using the Operator.
+\ No newline at end of file
++to create & configure Alertmanager and Prometheus instances using the Operator.
+
+diff --git a/staging/prometheus-operator/templates/alertmanager/alertmanager.yaml b/staging/prometheus-operator/templates/alertmanager/alertmanager.yaml
+index 7bc2465ce..2b3f1e8de 100644
+--- a/staging/prometheus-operator/templates/alertmanager/alertmanager.yaml
++++ b/staging/prometheus-operator/templates/alertmanager/alertmanager.yaml
+@@ -56,8 +56,18 @@ spec:
+ {{ toYaml .Values.alertmanager.alertmanagerSpec.securityContext | indent 4 }}
+ {{- end }}
+ {{- if .Values.alertmanager.alertmanagerSpec.storage }}
+-  storage:
+-{{ toYaml .Values.alertmanager.alertmanagerSpec.storage | indent 4 }}
++{{- $namespace := include "prometheus-operator.namespace" . }}
++{{- $name := print (include "prometheus-operator.fullname" .) "-alertmanager" }}
++{{- $alertmanager := (lookup "monitoring.coreos.com/v1" "Prometheus" $namespace $name) }}
++{{- $spec := ($alertmanager).spec }}
++{{- $storage := ($spec).storage }}
++{{- if $storage }}
++  # This Alertmanager resource was already defined. Keeping the existing storage definition.
++  # If this is not the desired behavior, delete this resource before upgrading the helm release.
++  storage: {{ toYaml $storage | nindent 4 }}
++{{- else }}
++  storage: {{ toYaml .Values.alertmanager.alertmanagerSpec.storage | nindent 4 }}
++{{- end }}
+ {{- end }}
+ {{- if .Values.alertmanager.alertmanagerSpec.podMetadata }}
+   podMetadata:
+diff --git a/staging/prometheus-operator/templates/prometheus/prometheus.yaml b/staging/prometheus-operator/templates/prometheus/prometheus.yaml
+index 210fd50fe..ab4025daa 100644
+--- a/staging/prometheus-operator/templates/prometheus/prometheus.yaml
++++ b/staging/prometheus-operator/templates/prometheus/prometheus.yaml
+@@ -159,9 +159,17 @@ spec:
+ {{ else }}
+   ruleSelector: {}
+ {{- end }}
+-{{- if .Values.prometheus.prometheusSpec.storageSpec }}
+-  storage:
+-{{ toYaml .Values.prometheus.prometheusSpec.storageSpec | indent 4 }}
++{{- $namespace := include "prometheus-operator.namespace" . }}
++{{- $name := print (include "prometheus-operator.fullname" .) "-prometheus" }}
++{{- $prometheus := (lookup "monitoring.coreos.com/v1" "Prometheus" $namespace $name) }}
++{{- $spec := ($prometheus).spec }}
++{{- $storage := ($spec).storage }}
++{{- if $storage }}
++  # This Prometheus resource was already defined. Keeping the existing storage definition.
++  # If this is not the desired behavior, delete this resource before upgrading the helm release.
++  storage: {{ toYaml $storage | nindent 4 }}
++{{- else }}
++  storage: {{ toYaml .Values.prometheus.prometheusSpec.storageSpec | nindent 4 }}
+ {{- end }}
+ {{- if .Values.prometheus.prometheusSpec.podMetadata }}
+   podMetadata:

--- a/staging/prometheus-operator/patch/patch_11_mesosphere_patch_storage.sh
+++ b/staging/prometheus-operator/patch/patch_11_mesosphere_patch_storage.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source $(dirname "$0")/helpers.sh
+
+set -x
+
+patch -d "${BASEDIR}" -p3 < patch/mesosphere/patch/11_use_existing_storage_definitions.patch
+
+git_add_and_commit "${BASEDIR}"/templates

--- a/staging/prometheus-operator/templates/NOTES.txt
+++ b/staging/prometheus-operator/templates/NOTES.txt
@@ -1,3 +1,21 @@
+{{- $namespace := include "prometheus-operator.namespace" . }}
+{{- $name := print (include "prometheus-operator.fullname" .) "-prometheus" }}
+{{- $prometheus := (lookup "monitoring.coreos.com/v1" "Prometheus" $namespace $name) }}
+{{- $spec := ($prometheus).spec }}
+{{- $storage := ($spec).storage }}
+{{- if $storage }}
+NOTICE: A Prometheus resource was already defined. Retaining the existing storage definition.
+If this is not the desired behavior, delete the {{ $name }} prometheus resource from the {{ $namespace }} namespace and upgrade this helm release.
+{{- end }}
+{{- $name = print (include "prometheus-operator.fullname" .) "-alertmanager" }}
+{{- $alertmanager := (lookup "monitoring.coreos.com/v1" "Alertmanager" $namespace $name) }}
+{{- $spec = ($alertmanager).spec }}
+{{- $storage = ($spec).storage }}
+{{- if $storage }}
+NOTICE: An Alertmanager resource was already defined. Retaining the existing storage definition.
+If this is not the desired behavior, delete the {{ $name }} alertmanager resource from the {{ $namespace }} namespace and upgrade this helm release.
+{{- end }}
+
 The Prometheus Operator has been installed. Check its status by running:
   kubectl --namespace {{ template "prometheus-operator.namespace" . }} get pods -l "release={{ $.Release.Name }}"
 

--- a/staging/prometheus-operator/templates/alertmanager/alertmanager.yaml
+++ b/staging/prometheus-operator/templates/alertmanager/alertmanager.yaml
@@ -56,8 +56,18 @@ spec:
 {{ toYaml .Values.alertmanager.alertmanagerSpec.securityContext | indent 4 }}
 {{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.storage }}
-  storage:
-{{ toYaml .Values.alertmanager.alertmanagerSpec.storage | indent 4 }}
+{{- $namespace := include "prometheus-operator.namespace" . }}
+{{- $name := print (include "prometheus-operator.fullname" .) "-alertmanager" }}
+{{- $alertmanager := (lookup "monitoring.coreos.com/v1" "Prometheus" $namespace $name) }}
+{{- $spec := ($alertmanager).spec }}
+{{- $storage := ($spec).storage }}
+{{- if $storage }}
+  # This Alertmanager resource was already defined. Keeping the existing storage definition.
+  # If this is not the desired behavior, delete this resource before upgrading the helm release.
+  storage: {{ toYaml $storage | nindent 4 }}
+{{- else }}
+  storage: {{ toYaml .Values.alertmanager.alertmanagerSpec.storage | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.podMetadata }}
   podMetadata:

--- a/staging/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/staging/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -159,9 +159,17 @@ spec:
 {{ else }}
   ruleSelector: {}
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.storageSpec }}
-  storage:
-{{ toYaml .Values.prometheus.prometheusSpec.storageSpec | indent 4 }}
+{{- $namespace := include "prometheus-operator.namespace" . }}
+{{- $name := print (include "prometheus-operator.fullname" .) "-prometheus" }}
+{{- $prometheus := (lookup "monitoring.coreos.com/v1" "Prometheus" $namespace $name) }}
+{{- $spec := ($prometheus).spec }}
+{{- $storage := ($spec).storage }}
+{{- if $storage }}
+  # This Prometheus resource was already defined. Keeping the existing storage definition.
+  # If this is not the desired behavior, delete this resource before upgrading the helm release.
+  storage: {{ toYaml $storage | nindent 4 }}
+{{- else }}
+  storage: {{ toYaml .Values.prometheus.prometheusSpec.storageSpec | nindent 4 }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.podMetadata }}
   podMetadata:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
backports https://github.com/mesosphere/charts/pull/1038

If either prometheus or alertmanager resources exist and have a storage
attribute defined in their spec, reuse that instead of what's defined
in the values.

This prevents the accidental redefinition of the volumeClaimTemplate and
the abandonment of old data.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/COPS-6870

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an upgrade issue that occurred when upgrading from a prior chart version to a version >=9.3.0 and <=9.3.7 which had a bug where the desired PVC name prefix was being discarded. This bug caused upgrades to that version to create and use new storage claims instead of the existing ones. This feature will now always use the storage setting defined in the cluster, if there is one, reusing the existing claims.
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
