### PR TITLE
chore: Update Dispatchfile to publish on release/* branches

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -274,7 +274,7 @@ kommander_chart_path = "stable/kommander/Chart.yaml"
 
 # Robot Actions
 action(tasks=["test-helm2", "test-helm3"], on=pull_request())
-action(tasks=["publish"], on=push(branches=["master"]))
+action(tasks=["publish"], on=push(branches=["master", "release/*"]))
 action(tasks=[do_bump_kommander], on=push(branches=["master"], paths=[kommander_chart_path]))
 action(tasks=[do_bump_addon], on=push(branches=["master"], paths=["!" + kommander_chart_path, "stable/*/Chart.yaml", "staging/*/Chart.yaml"]))
 

--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: gracedo
   - name: dkoshkin
 name: kommander
-version: 0.29.3
+version: 0.29.4

--- a/stable/kommander/README.md
+++ b/stable/kommander/README.md
@@ -31,12 +31,12 @@ helm install --namespace "kommander" --name "kommander-kubeaddons" --set kommand
 ## Backporting / Patch Releases
 The minor version should be bumped following every Kommander release.
 
-- Kommander v1.4.x -> chart version v0.16.x
+- Kommander v1.4.x -> chart version v0.28.x
 - Kommander v1.3.x patches should go into chart version v0.15.x
 
 This allows us to backport and create patch releases. When backporting, you should work off of the appropriate release branch for the chart. The release branch follows a `release/kommander-v0.15.x` convention for v0.15.x chart versions. If the release branch does not exist, you must create it. Browse the chart's git history until you find the commit before the chart was bumped to the next minor version. Branch off that commit to create the release branch, which will sit at the latest patch version of the chart before it was bumped to the next minor version (and release of Kommander).
 
-Push this release branch to the m/charts repo. Then, branch off the release branch to backport your changes. Open up a PR against the release branch. When the PR is merged, you are ready to publish the new patch chart version. There is a `make publish` target that runs the necessary `helm` commands to package and index the new chart. Making sure you are on the release branch, run `make publish`. This will push a commit to the `gh-pages` branch with the new chart tar file and the updated index.yaml. Double check this has been done properly by checking out the `gh-pages` branch, and that no other charts have been modified or deleted. It is expected to see timestamp changes across the yaml file as it is re-indexed.
+Push this release branch to the m/charts repo. Then, branch off the release branch to backport your changes. Open up a PR against the release branch. When the PR is merged, a Dispatch job is automatically triggered which runs the Publish job. This is the `make publish` target that runs the necessary `helm` commands to package and index the new chart, and pushes a commit to the `gh-pages` branch with the new chart tar file and the updated index.yaml. Double check this has been done properly by checking out the `gh-pages` branch, and that no other charts have been modified or deleted. It is expected to see timestamp changes across the yaml file as it is re-indexed.
 
 If for any reason the publish results in a bad commit, you can revert the commit by getting the SHA of the previous commit on `gh-pages` prior to the latest push and running:
 ```bash

--- a/stable/kommander/README.md
+++ b/stable/kommander/README.md
@@ -31,7 +31,7 @@ helm install --namespace "kommander" --name "kommander-kubeaddons" --set kommand
 ## Backporting / Patch Releases
 The minor version should be bumped following every Kommander release.
 
-- Kommander v1.4.x -> chart version v0.28.x
+- Kommander v1.4.x -> chart version v0.29.x
 - Kommander v1.3.x patches should go into chart version v0.15.x
 
 This allows us to backport and create patch releases. When backporting, you should work off of the appropriate release branch for the chart. The release branch follows a `release/kommander-v0.15.x` convention for v0.15.x chart versions. If the release branch does not exist, you must create it. Browse the chart's git history until you find the commit before the chart was bumped to the next minor version. Branch off that commit to create the release branch, which will sit at the latest patch version of the chart before it was bumped to the next minor version (and release of Kommander).


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Now, we run the publish job automatically on pushes to `release/*` branches so that we no longer need to manually run `make publish` on those branches on updates. This has been tested on this PR https://github.com/mesosphere/charts/pull/1104 going into `release/kommander-0.15.x` which ran the Dispatch publish job, resulting in the chart publish to `gh-pages` 🥳 https://github.com/mesosphere/charts/commit/f199f12d4b6c8bf1d34758c70828028c1ef902cc. FYI, for any other existing release branches, we still need to cherry-pick this Dispatchfile change to get this triggered on that branch. So far, this has been added to `release/kommander-0.15.x` and `release/prometheus-operator-9.3.x`

h/t @faiq for the help :D 

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
