### PR TITLE
chore: bump nginx for opsportal-landing

### DIFF
--- a/stable/opsportal/Chart.yaml
+++ b/stable/opsportal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.0
 home: https://github.com/mesosphere/charts
 description: OpsPortal Chart
 name: opsportal
-version: 0.8.0
+version: 0.8.1
 maintainers:
   - name: hectorj2f
   - name: alejandroEsc

--- a/stable/opsportal/templates/landing.yaml
+++ b/stable/opsportal/templates/landing.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
         - name: opsportal-landing
-          image: nginx:1.17-alpine
+          image: nginx:1.18-alpine
           imagePullPolicy: IfNotPresent
           resources:
             {{ with .Values.landing.resources }}


### PR DESCRIPTION


**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
nginx:1.18-alpine uses Alpine 3.11.11 which has a fix for CVE-2020-1971.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-75532

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump nginx version used for opsportal-landing, from 1.17-alpine to 1.18-alpine, for security reasons.
```

**Checklist**

* [X] *If a chart is changed, the chart version is correctly incremented.*
* [X] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
