### PR TITLE
[kube-prometheus-stack] Set pathType on Ingress only when supported

### DIFF
--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.4.4
+version: 15.4.5
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/mesosphere/patch/12_set_pathtype_only_when_supported.patch
+++ b/staging/kube-prometheus-stack/patch/mesosphere/patch/12_set_pathtype_only_when_supported.patch
@@ -1,0 +1,157 @@
+commit a9118052897c7e361a19ef697963f3f1452c8b00
+Author: Branden Rolston <branden@d2iq.com>
+Date:   Tue May 11 18:54:25 2021 -0700
+
+    Set pathType on ingress only when supported
+    
+    Setting pathType on an Ingress path is unsupported prior to k8s 1.16,
+    supported in networking.k8s.io/v1beta1 with k8s 1.18, and required in
+    networking.k8s.io/v1. Setting pathType only when it is supported allows
+    using the same set of chart values across this range of k8s versions.
+
+diff --git a/staging/kube-prometheus-stack/templates/_helpers.tpl b/staging/kube-prometheus-stack/templates/_helpers.tpl
+index 8336cb89..9ee060bd 100644
+--- a/staging/kube-prometheus-stack/templates/_helpers.tpl
++++ b/staging/kube-prometheus-stack/templates/_helpers.tpl
+@@ -116,3 +116,9 @@ Allow the release namespace to be overridden for multi-namespace deployments in
+ {{- define "kube-prometheus-stack.ingress.isStable" -}}
+   {{- eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+ {{- end -}}
++
++{{/* Check Ingress supports pathType */}}
++{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
++{{- define "kube-prometheus-stack.ingress.supportsPathType" -}}
++  {{- or (eq (include "kube-prometheus-stack.ingress.isStable" .) "true") (and (eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "kube-prometheus-stack.ingress.kubeVersion" .))) -}}
++{{- end -}}
+diff --git a/staging/kube-prometheus-stack/templates/alertmanager/ingress.yaml b/staging/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+index 8ade2709..f337502e 100644
+--- a/staging/kube-prometheus-stack/templates/alertmanager/ingress.yaml
++++ b/staging/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+@@ -5,6 +5,7 @@
+ {{- $routePrefix := list .Values.alertmanager.alertmanagerSpec.routePrefix }}
+ {{- $paths := .Values.alertmanager.ingress.paths | default $routePrefix -}}
+ {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
++{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+ apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
+ kind: Ingress
+ metadata:
+@@ -34,7 +35,7 @@ spec:
+         paths:
+   {{- range $p := $paths }}
+           - path: {{ tpl $p $ }}
+-            {{- if $pathType }}
++            {{- if and $pathType $ingressSupportsPathType }}
+             pathType: {{ $pathType }}
+             {{- end }}
+             backend:
+@@ -54,7 +55,7 @@ spec:
+         paths:
+   {{- range $p := $paths }}
+           - path: {{ tpl $p $ }}
+-            {{- if $pathType }}
++            {{- if and $pathType $ingressSupportsPathType }}
+             pathType: {{ $pathType }}
+             {{- end }}
+             backend:
+diff --git a/staging/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml b/staging/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+index c55ec2ad..e50bd56b 100644
+--- a/staging/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
++++ b/staging/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+@@ -4,6 +4,7 @@
+ {{- $servicePort := .Values.alertmanager.service.port -}}
+ {{- $ingressValues := .Values.alertmanager.ingressPerReplica -}}
+ {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
++{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+ apiVersion: v1
+ kind: List
+ metadata:
+@@ -38,7 +39,7 @@ items:
+             paths:
+       {{- range $p := $ingressValues.paths }}
+               - path: {{ tpl $p $ }}
+-                {{- if $pathType }}
++                {{- if and $pathType $ingressSupportsPathType }}
+                 pathType: {{ $pathType }}
+                 {{- end }}
+                 backend:
+diff --git a/staging/kube-prometheus-stack/templates/prometheus/ingress.yaml b/staging/kube-prometheus-stack/templates/prometheus/ingress.yaml
+index 67f6ecea..3992789b 100644
+--- a/staging/kube-prometheus-stack/templates/prometheus/ingress.yaml
++++ b/staging/kube-prometheus-stack/templates/prometheus/ingress.yaml
+@@ -5,6 +5,7 @@
+   {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix -}}
+   {{- $paths := .Values.prometheus.ingress.paths | default $routePrefix -}}
+   {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
++  {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+ apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
+ kind: Ingress
+ metadata:
+@@ -34,7 +35,7 @@ spec:
+         paths:
+   {{- range $p := $paths }}
+           - path: {{ tpl $p $ }}
+-            {{- if $pathType }}
++            {{- if and $pathType $ingressSupportsPathType }}
+             pathType: {{ $pathType }}
+             {{- end }}
+             backend:
+@@ -54,7 +55,7 @@ spec:
+         paths:
+   {{- range $p := $paths }}
+           - path: {{ tpl $p $ }}
+-            {{- if $pathType }}
++            {{- if and $pathType $ingressSupportsPathType }}
+             pathType: {{ $pathType }}
+             {{- end }}
+             backend:
+diff --git a/staging/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml b/staging/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+index 5a4d6e19..ace40586 100644
+--- a/staging/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
++++ b/staging/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+@@ -5,6 +5,7 @@
+ {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix }}
+ {{- $paths := .Values.prometheus.thanosIngress.paths | default $routePrefix -}}
+ {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
++{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+ apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
+ kind: Ingress
+ metadata:
+@@ -33,7 +34,7 @@ spec:
+         paths:
+   {{- range $p := $paths }}
+           - path: {{ tpl $p $ }}
+-            {{- if $pathType }}
++            {{- if and $pathType $ingressSupportsPathType }}
+             pathType: {{ $pathType }}
+             {{- end }}
+             backend:
+@@ -53,7 +54,7 @@ spec:
+         paths:
+   {{- range $p := $paths }}
+           - path: {{ tpl $p $ }}
+-            {{- if $pathType }}
++            {{- if and $pathType $ingressSupportsPathType }}
+             pathType: {{ $pathType }}
+             {{- end }}
+             backend:
+diff --git a/staging/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml b/staging/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+index a89c1a98..0624f5be 100644
+--- a/staging/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
++++ b/staging/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+@@ -4,6 +4,7 @@
+ {{- $servicePort := .Values.prometheus.servicePerReplica.port -}}
+ {{- $ingressValues := .Values.prometheus.ingressPerReplica -}}
+ {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
++{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+ apiVersion: v1
+ kind: List
+ metadata:
+@@ -38,7 +39,7 @@ items:
+             paths:
+       {{- range $p := $ingressValues.paths }}
+               - path: {{ tpl $p $ }}
+-                {{- if $pathType }}
++                {{- if and $pathType $ingressSupportsPathType }}
+                 pathType: {{ $pathType }}
+                 {{- end }}
+                 backend:

--- a/staging/kube-prometheus-stack/patch/patch_12_set_pathtype_only_when_supported.sh
+++ b/staging/kube-prometheus-stack/patch/patch_12_set_pathtype_only_when_supported.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source $(dirname "$0")/helpers.sh
+
+set -xeuo pipefail
+
+patch -d "${BASEDIR}" -p3 --no-backup-if-mismatch < patch/mesosphere/patch/12_set_pathtype_only_when_supported.patch
+
+git_add_and_commit "${BASEDIR}"/templates

--- a/staging/kube-prometheus-stack/templates/_helpers.tpl
+++ b/staging/kube-prometheus-stack/templates/_helpers.tpl
@@ -116,3 +116,9 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- define "kube-prometheus-stack.ingress.isStable" -}}
   {{- eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
 {{- end -}}
+
+{{/* Check Ingress supports pathType */}}
+{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
+{{- define "kube-prometheus-stack.ingress.supportsPathType" -}}
+  {{- or (eq (include "kube-prometheus-stack.ingress.isStable" .) "true") (and (eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "kube-prometheus-stack.ingress.kubeVersion" .))) -}}
+{{- end -}}

--- a/staging/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/staging/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -5,6 +5,7 @@
 {{- $routePrefix := list .Values.alertmanager.alertmanagerSpec.routePrefix }}
 {{- $paths := .Values.alertmanager.ingress.paths | default $routePrefix -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -34,7 +35,7 @@ spec:
         paths:
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
-            {{- if $pathType }}
+            {{- if and $pathType $ingressSupportsPathType }}
             pathType: {{ $pathType }}
             {{- end }}
             backend:
@@ -54,7 +55,7 @@ spec:
         paths:
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
-            {{- if $pathType }}
+            {{- if and $pathType $ingressSupportsPathType }}
             pathType: {{ $pathType }}
             {{- end }}
             backend:

--- a/staging/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/staging/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -4,6 +4,7 @@
 {{- $servicePort := .Values.alertmanager.service.port -}}
 {{- $ingressValues := .Values.alertmanager.ingressPerReplica -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
 apiVersion: v1
 kind: List
 metadata:
@@ -38,7 +39,7 @@ items:
             paths:
       {{- range $p := $ingressValues.paths }}
               - path: {{ tpl $p $ }}
-                {{- if $pathType }}
+                {{- if and $pathType $ingressSupportsPathType }}
                 pathType: {{ $pathType }}
                 {{- end }}
                 backend:

--- a/staging/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/staging/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -5,6 +5,7 @@
   {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix -}}
   {{- $paths := .Values.prometheus.ingress.paths | default $routePrefix -}}
   {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
+  {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -34,7 +35,7 @@ spec:
         paths:
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
-            {{- if $pathType }}
+            {{- if and $pathType $ingressSupportsPathType }}
             pathType: {{ $pathType }}
             {{- end }}
             backend:
@@ -54,7 +55,7 @@ spec:
         paths:
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
-            {{- if $pathType }}
+            {{- if and $pathType $ingressSupportsPathType }}
             pathType: {{ $pathType }}
             {{- end }}
             backend:

--- a/staging/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+++ b/staging/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
@@ -5,6 +5,7 @@
 {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix }}
 {{- $paths := .Values.prometheus.thanosIngress.paths | default $routePrefix -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -33,7 +34,7 @@ spec:
         paths:
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
-            {{- if $pathType }}
+            {{- if and $pathType $ingressSupportsPathType }}
             pathType: {{ $pathType }}
             {{- end }}
             backend:
@@ -53,7 +54,7 @@ spec:
         paths:
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
-            {{- if $pathType }}
+            {{- if and $pathType $ingressSupportsPathType }}
             pathType: {{ $pathType }}
             {{- end }}
             backend:

--- a/staging/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/staging/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -4,6 +4,7 @@
 {{- $servicePort := .Values.prometheus.servicePerReplica.port -}}
 {{- $ingressValues := .Values.prometheus.ingressPerReplica -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
 apiVersion: v1
 kind: List
 metadata:
@@ -38,7 +39,7 @@ items:
             paths:
       {{- range $p := $ingressValues.paths }}
               - path: {{ tpl $p $ }}
-                {{- if $pathType }}
+                {{- if and $pathType $ingressSupportsPathType }}
                 pathType: {{ $pathType }}
                 {{- end }}
                 backend:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Setting pathType on an Ingress path is unsupported prior to k8s 1.16, supported in networking.k8s.io/v1beta1 with k8s 1.18, and required in networking.k8s.io/v1. Setting pathType only when it is supported allows using the same set of chart values across this range of k8s versions.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-75500

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kube-prometheus-stack] Omits Ingress pathType when unsupported, preventing validation errors.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
