### PR TITLE
[kubecost] fix: Set default pvc size to 32Gi

### DIFF
--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.79.1
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.10.0
+version: 0.10.1
 maintainers:
   - name: gracedo

--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.79.1
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.10.1
+version: 0.11.0
 maintainers:
   - name: gracedo

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -50,9 +50,9 @@ cost-analyzer:
 
   # Define persistence volume for cost-analyzer, more information at https://github.com/kubecost/docs/blob/master/storage.md
   persistentVolume:
-    # default size is increased to 32Gi in 1.72.0, but breaks upgrades if automatic disk resize not supported
+    # Upgrades from original default 0.2Gi may break if automatic disk resize is not supported
     # https://github.com/kubecost/cost-analyzer-helm-chart/issues/507
-    size: 0.2Gi
+    size: 32Gi
     # Note that setting this to false means configurations will be wiped out on pod restart.
     enabled: true
     # storageClass: "-"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
CBP ran into issues with the kubecost cost-analyzer PVC size getting set to an extremely large number, which was reported in kubecost here: https://github.com/kubecost/cost-analyzer-helm-chart/issues/507. To resolve this, the team increased the default pv size from 0.2Gi (causes issues with some storage providers, in CBP case they use portworx, I think) to 32Gi. We originally avoided making this change due to concerns around upgrades whether the disk would handle automatic resizing with no loss of data, but Kubecost has a helpful doc on how to deal with such issues that we can reference in our upgrade docs as well https://github.com/kubecost/docs/blob/master/storage.md. The bulk of the data stored in this PVC is caching data for faster startup time, so I envision this not having too much risk if data loss occurs. The other data stored is configuration value changes if users were using the kubecost UI to update settings. I am not sure if this is a common use case for customers to be changing settings via the UI; we supply base configuration via helm values. In any case, we will supply the necessary docs so that an upgrade can go smoothly.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-75770
[COPS ticket TBA]

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix(kubecost): Increase default cost-analyzer persistent volume size to 32Gi. Upgrades may require manual intervention if your provisioner does not support volume expansion.
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
