### PR TITLE
kube-prometheus-stack: Rename "Addons" to "Platform Services" in grafana dashboards

### DIFF
--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.4.5
+version: 15.4.6
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/elasticsearchdashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/elasticsearchdashboard.yaml
@@ -7405,7 +7405,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / ElasticSearch",
+      "title": "Platform Services / ElasticSearch",
       "uid": "kX_OVivWz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/fluentbitdashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/fluentbitdashboard.yaml
@@ -514,7 +514,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Fluent Bit",
+      "title": "Platform Services / Fluent Bit",
       "uid": "-55j0u7Zz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/grafanadashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/grafanadashboard.yaml
@@ -1089,7 +1089,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Grafana",
+      "title": "Platform Services / Grafana",
       "uid": "dzzFSTSZk",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/kibanadashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/kibanadashboard.yaml
@@ -856,7 +856,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Kibana",
+      "title": "Platform Services / Kibana",
       "uid": "ZRx-PoKZz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/localvolumeprovisioner.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/localvolumeprovisioner.yaml
@@ -726,7 +726,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Local Volume Provisioner",
+      "title": "Platform Services / Local Volume Provisioner",
       "uid": "YvfWbASZz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/opsportaldashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/opsportaldashboard.yaml
@@ -944,7 +944,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Ops Portal",
+      "title": "Platform Services / Ops Portal",
       "uid": "Jw7Mw-HWz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/traefikdashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/traefikdashboard.yaml
@@ -733,7 +733,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Traefik",
+      "title": "Platform Services / Traefik",
       "uid": "qPdAviJmz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/velerodashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/dashboards/velerodashboard.yaml
@@ -1146,7 +1146,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Velero",
+      "title": "Platform Services / Velero",
       "uid": "jBn6wfDZz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/elasticsearchdashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/elasticsearchdashboard.yaml
@@ -7405,7 +7405,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / ElasticSearch",
+      "title": "Platform Services / ElasticSearch",
       "uid": "kX_OVivWz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/fluentbitdashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/fluentbitdashboard.yaml
@@ -514,7 +514,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Fluent Bit",
+      "title": "Platform Services / Fluent Bit",
       "uid": "-55j0u7Zz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/grafanadashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/grafanadashboard.yaml
@@ -1089,7 +1089,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Grafana",
+      "title": "Platform Services / Grafana",
       "uid": "dzzFSTSZk",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/kibanadashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/kibanadashboard.yaml
@@ -856,7 +856,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Kibana",
+      "title": "Platform Services / Kibana",
       "uid": "ZRx-PoKZz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/localvolumeprovisioner.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/localvolumeprovisioner.yaml
@@ -726,7 +726,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Local Volume Provisioner",
+      "title": "Platform Services / Local Volume Provisioner",
       "uid": "YvfWbASZz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/opsportaldashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/opsportaldashboard.yaml
@@ -944,7 +944,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Ops Portal",
+      "title": "Platform Services / Ops Portal",
       "uid": "Jw7Mw-HWz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/traefikdashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/traefikdashboard.yaml
@@ -733,7 +733,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Traefik",
+      "title": "Platform Services / Traefik",
       "uid": "qPdAviJmz",
       "version": 1
     }

--- a/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/velerodashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/dashboards/mesosphere-dashboards/velerodashboard.yaml
@@ -1146,7 +1146,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Addons / Velero",
+      "title": "Platform Services / Velero",
       "uid": "jBn6wfDZz",
       "version": 1
     }


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
 We renamed addons to platform services in konvoy 1.8

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-76286

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
