### PR TITLE
WIP - traefik cert-manager: Flexible default cert

### DIFF
--- a/staging/traefik/templates/certificate.yaml
+++ b/staging/traefik/templates/certificate.yaml
@@ -33,22 +33,24 @@ spec:
     name: kubernetes-ca
     kind: ClusterIssuer
   {{- end }}
-  # DCOS-60297 Update certificate to comply with Apple security requirements
-  # https://support.apple.com/en-us/HT210176
-  duration: 19200h   # 800 days
+  dnsNames:
+    - {{ .Values.ssl.defaultCN }}
+    {{- range .Values.ssl.defaultSANList }}
+    - {{ . }}
+    {{- end }}
+  duration: {{ .Values.ssl.defaultDuration }}
+  {{- if .Values.ssl.defaultUsages }}
   usages:
-  - digital signature
-  - key encipherment
-  - server auth
+    {{- toYaml .Values.ssl.defaultUsages | nindent 2 }}
+  {{- end }}
 {{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
   subject:
-    organizations:
-    - D2iQ
+  {{- toYaml .Values.ssl.defaultSubject | nindent 2 }}
 {{- else }}
   organization:
-  - D2iQ
+  {{- toYaml .Values.ssl.defaultSubject.organizations | nindent 2 }}
 {{- end }}
   # The commonName will get replaced by kubeaddons-config
   # init-container for traefik
-  commonName: traefik.localhost.localdomain
+  commonName: {{ .Values.ssl.defaultCN }}
 {{- end }}

--- a/staging/traefik/values.yaml
+++ b/staging/traefik/values.yaml
@@ -129,13 +129,23 @@ ssl:
   insecureSkipVerify: false
   generateTLS: false
   useCertManager: false
-  # defaultCN: "example.com"
+  defaultCN: "traefik.localhost.localdomain"
     # or *.example.com
   defaultSANList: []
     # - example.com
     # - test1.example.com
   defaultIPList: []
     # - 1.2.3.4
+  defaultUsages:
+    - digital signature
+    - key encipherment
+    - server auth
+  defaultSubject:
+    organizations:
+      - D2iQ
+  # DCOS-60297 Update certificate to comply with Apple security requirements
+  # https://support.apple.com/en-us/HT210176
+  defaultDuration: 19200h  # 800 days
   # cipherSuites: []
   # https://docs.traefik.io/configuration/entrypoints/#specify-minimum-tls-version
   # tlsMinVersion: VersionTLS12


### PR DESCRIPTION
**What type of PR is this?**
Bug/Feature

**What this PR does/ why we need it**:
The default cert provided by traefik chart needs to be more flexible. Make certificate attributes being configurable and support SAN

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-74969

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
