### PR TITLE
Fix velero chart for helm 3.6.0

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 3.1.1
+version: 3.1.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/staging/velero/templates/backupstoragelocation.yaml
+++ b/staging/velero/templates/backupstoragelocation.yaml
@@ -26,9 +26,8 @@ spec:
     {{- end }}
 {{- with .config }}
   config:
-{{ toYaml . | indent 4}}
-{{- if .s3ForcePathStyle }}
-    s3ForcePathStyle: {{ .s3ForcePathStyle | quote }}
+{{- range $key, $value := . }}
+{{- $key | nindent 4 }}: {{ $value | quote }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- fix(velero): Duplicate s3ForcePathStyle config key
- chore(velero): Bump chart version to 3.1.2

**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
When specifying `s3ForcePathStyle`, the helm template renders a duplicate key which breaks with helm 3.6.0:

```bash
$ helm template m-staging/velero --set configuration.backupStorageLocation.config.s3ForcePathStyle=true 2>/dev/null | grep -B 1 s3ForcePathStyle 2>/dev/null
  config:
    s3ForcePathStyle: true
    s3ForcePathStyle: "true"
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix duplicate keys in velero backupstoragelocation configuration.
```

**Checklist**

* [X] *If a chart is changed, the chart version is correctly incremented.*
* [X] The commit message explains the changes and why are needed.
* [X] The code builds and passes lint/style checks locally.
* [X] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
