### PR TITLE
feat: add thanos-traefik chart

### DIFF
--- a/staging/thanos-traefik/.helmignore
+++ b/staging/thanos-traefik/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/staging/thanos-traefik/Chart.yaml
+++ b/staging/thanos-traefik/Chart.yaml
@@ -1,24 +1,9 @@
 apiVersion: v2
 name: thanos-traefik
 description: A Helm chart for Kubernetes that exposes thanos GRPC service over traefik with mTLS termination
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.0.1
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: "0.0.1"
+maintainers:
+- name: mhrabovcin
+  email: mhrabovcin.c@d2iq.com

--- a/staging/thanos-traefik/Chart.yaml
+++ b/staging/thanos-traefik/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: thanos-traefik
+description: A Helm chart for Kubernetes that exposes thanos GRPC service over traefik with mTLS termination
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/staging/thanos-traefik/templates/_helpers.tpl
+++ b/staging/thanos-traefik/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "thanos-traefik.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "thanos-traefik.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "thanos-traefik.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "thanos-traefik.labels" -}}
+helm.sh/chart: {{ include "thanos-traefik.chart" . }}
+{{ include "thanos-traefik.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "thanos-traefik.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "thanos-traefik.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "thanos-traefik.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "thanos-traefik.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/staging/thanos-traefik/templates/ingressroutetcp.yaml
+++ b/staging/thanos-traefik/templates/ingressroutetcp.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.disable }}
+{{ if .Values.enabled }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP

--- a/staging/thanos-traefik/templates/ingressroutetcp.yaml
+++ b/staging/thanos-traefik/templates/ingressroutetcp.yaml
@@ -1,0 +1,38 @@
+{{ if not .Values.disable }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ include "thanos-traefik.fullname" . }}-ingress
+  labels:
+{{ include "thanos-traefik.labels" . | indent 4 }}
+spec:
+  entryPoints:
+    {{ toYaml .Values.route.endpoints | nindent 4}}
+  routes:
+    - match: HostSNI(`{{ .Values.route.sni }}`)
+      services:
+      {{ toYaml .Values.route.services | nindent 6 }}
+  tls:
+    secretName: {{ .Values.route.tls.secretName }}
+    options:
+      name: {{ include "thanos-traefik.fullname" . }}-tls-options
+      namespace: {{ .Release.Namespace }}
+    passthrough: false
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TLSOption
+metadata:
+  name: {{ include "thanos-traefik.fullname" . }}-tls-options
+  labels:
+{{ include "thanos-traefik.labels" . | indent 4 }}
+spec:
+  sniStrict: true
+  clientAuth:
+    # the CA certificate is extracted from secret data key `tls.ca` of the given
+    # secrets.
+    secretNames:
+      - {{ .Values.tlsoptions.secretName }}
+    clientAuthType: RequireAndVerifyClientCert
+{{ end }}

--- a/staging/thanos-traefik/templates/ingressroutetcp.yaml
+++ b/staging/thanos-traefik/templates/ingressroutetcp.yaml
@@ -8,13 +8,13 @@ metadata:
 {{ include "thanos-traefik.labels" . | indent 4 }}
 spec:
   entryPoints:
-    {{ toYaml .Values.route.endpoints | nindent 4}}
+    {{- toYaml .Values.route.endpoints | nindent 4}}
   routes:
     - match: HostSNI(`{{ .Values.route.sni }}`)
       services:
-      {{ toYaml .Values.route.services | nindent 6 }}
+      {{- toYaml .Values.route.services | nindent 6 }}
   tls:
-    secretName: {{ .Values.route.tls.secretName }}
+    secretName: {{ .Values.route.tls.secretName | required "A valid route.tls.secretName is required" }}
     options:
       name: {{ include "thanos-traefik.fullname" . }}-tls-options
       namespace: {{ .Release.Namespace }}
@@ -33,6 +33,6 @@ spec:
     # the CA certificate is extracted from secret data key `tls.ca` of the given
     # secrets.
     secretNames:
-      - {{ .Values.tlsoptions.secretName }}
+      - {{ .Values.tlsoptions.secretName | required "A valid tlsoptions.secretName is required" }}
     clientAuthType: RequireAndVerifyClientCert
 {{ end }}

--- a/staging/thanos-traefik/values.yaml
+++ b/staging/thanos-traefik/values.yaml
@@ -29,11 +29,11 @@ route:
   tls:
     # Define the secret name that contains the server certificate that should
     # be used for TLS termination by traefik
-    secretName: kommander-prometheus-thanos-certificates
+    secretName: kommander-thanos-server-tls
 
 # Configuration for TLS Options that will instruct traefik to perform the
 # TLS termination and client cert verification.
 tlsoptions:
   # The secret must have `tls.ca` key with a root CA certificate that will
   # be used for TLS verification.
-  secretName: kommander-prometheus-thanos-certificates
+  secretName: kommander-thanos-server-tls

--- a/staging/thanos-traefik/values.yaml
+++ b/staging/thanos-traefik/values.yaml
@@ -1,0 +1,39 @@
+# Default values for traefik-prometheus-thanos.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Setting this option to true will allow installing this chart and not creating
+# any configuration objects.
+disable: false
+
+# Configuration options for the ingress route tcp. The route will be configured
+# to do the TLS termination and verification of client cert (mtls).
+route:
+  # These are the traefik endpoints for which the TCP route will get created
+  endpoints:
+    - web
+    - websecure
+
+  # Hostname that will be used to match the route. GRPC client must send this
+  # in TCP request when providing a client certificate.
+  sni: server.thanos.localhost.localdomain
+
+  # List of the thanos sidecar grpc service that will get the the connections.
+  services:
+    - name: kube-prometheus-stack-prometheus
+      port: 10901
+
+  tls:
+    # Define the secret name that contains the server certificate that should
+    # be used for TLS termination by traefik
+    secretName: kommander-prometheus-thanos-certificates
+
+# Configuration for TLS Options that will instruct traefik to perform the
+# TLS termination and client cert verification.
+tlsoptions:
+  # The secret must have `tls.ca` key with a root CA certificate that will
+  # be used for TLS verification.
+  secretName: kommander-prometheus-thanos-certificates

--- a/staging/thanos-traefik/values.yaml
+++ b/staging/thanos-traefik/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 # Setting this option to true will allow installing this chart and not creating
 # any configuration objects.
-disable: false
+enabled: true
 
 # Configuration options for the ingress route tcp. The route will be configured
 # to do the TLS termination and verification of client cert (mtls).

--- a/staging/thanos-traefik/values.yaml
+++ b/staging/thanos-traefik/values.yaml
@@ -1,4 +1,4 @@
-# Default values for traefik-prometheus-thanos.
+# Default values for traefik-thanos.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/test/helm3/ct-e2e.yaml
+++ b/test/helm3/ct-e2e.yaml
@@ -28,7 +28,7 @@ excluded-charts:
   - kube-prometheus-stack # D2IQ-62817
   - traefik-forward-auth  # D2IQ-62819
   - local-path-provisioner
-  - thanos-traefik
+  - thanos-traefik        # This requires installing dependencies like traefik2
   - vsphere-csi-driver
   - kubefed
 chart-repos:

--- a/test/helm3/ct-e2e.yaml
+++ b/test/helm3/ct-e2e.yaml
@@ -28,6 +28,7 @@ excluded-charts:
   - kube-prometheus-stack # D2IQ-62817
   - traefik-forward-auth  # D2IQ-62819
   - local-path-provisioner
+  - thanos-traefik
   - vsphere-csi-driver
   - kubefed
 chart-repos:


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
This is a new chart that will be used by Kommander 2 to expose Thanos GRPC endpoint for metrics scraping from attached (managed) clusters. The traefik will be configured to perform TLS termination and verification.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-76605

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
