### PR TITLE
fix: Use fixed CN for dex controller cert

### DIFF
--- a/stable/dex-controller/templates/certificates.yaml
+++ b/stable/dex-controller/templates/certificates.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  commonName: {{ template "dex-controller.fullname" . }}-webhook-service.kubeaddons.svc
+  commonName: dex-controller-webhook-service
   dnsNames:
   - {{ template "dex-controller.fullname" . }}-webhook-service.kubeaddons.svc.cluster.local
   - {{ template "dex-controller.fullname" . }}-webhook-service.kubeaddons.svc.cluster

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.9.7
+version: 2.9.8
 appVersion: 2.22.0
 description: Dex
 keywords:


### PR DESCRIPTION
CN is not used in any modern software for cert validation and
`dnsNames` is properly specified for validation. Using a fixed
CN here ensures cert-manager does not reject the Certificate.
