### PR TITLE
[chore] expose GC configuration settings for Knative Serving

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative
-version: 0.3.5
+version: 0.3.6
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: serving
-version: 0.3.5
+version: 0.3.6
 kubeVersion: ">=1.17.0"
 description: "Knative Serving"
 sources:

--- a/staging/knative/charts/serving/templates/serving.yaml
+++ b/staging/knative/charts/serving/templates/serving.yaml
@@ -711,6 +711,10 @@ metadata:
   annotations:
     knative.dev/example-checksum: "4b89cfa0"
 data:
+  stale-revision-create-delay: "{{ .Values.gc.staleRevisionCreateDelay }}"
+  stale-revision-timeout: "{{ .Values.gc.staleRevisionTimeout }}"
+  stale-revision-minimum-generations: "{{ .Values.gc.staleRevisionMinimumGenerations }}"
+  stale-revision-lastpinned-debounce: "{{ .Values.gc.staleRevisionLastpinnedDebounce }}"
   _example: |
     ################################
     #                              #

--- a/staging/knative/charts/serving/values.yaml
+++ b/staging/knative/charts/serving/values.yaml
@@ -13,3 +13,9 @@ namespaceKnativeServing:
 
 configDeployment:
   registriesSkippingTagResolving: ""
+
+gc:
+  staleRevisionCreateDelay: "48h"
+  staleRevisionTimeout: "15h"
+  staleRevisionMinimumGenerations: "20"
+  staleRevisionLastpinnedDebounce: "5h"

--- a/staging/knative/requirements.yaml
+++ b/staging/knative/requirements.yaml
@@ -6,5 +6,5 @@ dependencies:
     version: 0.2.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 0.3.5
+    version: 0.3.6
     condition: serving.enabled

--- a/staging/knative/values.yaml
+++ b/staging/knative/values.yaml
@@ -16,3 +16,8 @@ serving:
     additionalLabels: {}
   configDeployment:
     registriesSkippingTagResolving: ""
+  gc:
+    staleRevisionCreateDelay: "48h"
+    staleRevisionTimeout: "15h"
+    staleRevisionMinimumGenerations: "20"
+    staleRevisionLastpinnedDebounce: "5h"


### PR DESCRIPTION
**What type of PR is this?**
chore

**What this PR does/ why we need it**:
This PR adds template parameters to expose the garbage collection configuration for Knative.
See [D2IQ-77479: Expose KNative Serving GC configuration in the addon](https://jira.d2iq.com/browse/D2IQ-77479) for additional background.

**Which issue(s) this PR fixes**:
[D2IQ-77479: Expose KNative Serving GC configuration in the addon](https://jira.d2iq.com/browse/D2IQ-77479).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
