### PR TITLE
kubecost: Fix prom job hooks

### DIFF
--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.85.0
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.17.0
+version: 0.17.1
 maintainers:
   - name: gracedo

--- a/stable/kubecost/templates/hooks-clusterid.yaml
+++ b/stable/kubecost/templates/hooks-clusterid.yaml
@@ -1,4 +1,3 @@
-{{- if index .Values "cost-analyzer" "global" "prometheus" "enabled" }}
 {{- if .Values.hooks.clusterID.enabled }}
 ---
 apiVersion: v1
@@ -56,6 +55,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kubecost.fullname" . }}-hook
     namespace: {{ $.Release.Namespace }}
+{{- if index .Values "cost-analyzer" "global" "prometheus" "enabled" }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -91,6 +91,7 @@ spec:
               echo "Done replacing \$CLUSTER_ID with $CLUSTERID"
               EOF
       restartPolicy: OnFailure
+{{- end }}
 {{- if index .Values "cost-analyzer" "prometheus" "server" "clusterIDConfigmap" }}
 ---
 apiVersion: batch/v1
@@ -142,6 +143,5 @@ spec:
             - -c
             - kubectl delete configmap {{ index .Values "cost-analyzer" "prometheus" "server" "clusterIDConfigmap" }} -n {{ .Release.Namespace }} --ignore-not-found
       restartPolicy: OnFailure
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
If prometheus is disabled, we still want to run the cluster-info configmap creation job, just not the prometheus edit config job. Moved some conditionals so that if prometheus is disabled, we still run the cm create job.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
