### PR TITLE
Fix missing commas in dcgm-exporter configuration

### DIFF
--- a/staging/nvidia/Chart.yaml
+++ b/staging/nvidia/Chart.yaml
@@ -4,7 +4,7 @@ description: Nvidia GPU device plugin for running Nvidia GPU
 keywords:
   - gpu
   - nvidia
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.2.0"
 home: http://github.com/mesosphere/charts/staging
 sources:

--- a/staging/nvidia/charts/nvidia-dcgm-exporter/templates/default-counters.yaml
+++ b/staging/nvidia/charts/nvidia-dcgm-exporter/templates/default-counters.yaml
@@ -5,9 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   default-counters.csv: |
-    # These settings are taken from the dcgm-exporter repository:
-    # https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/etc/dcgm-exporter/default-counters.csv
-    #
+    # These settings are taken from the dcgm-exporter repository,,
+    # https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/etc/dcgm-exporter/default-counters.csv,,
     # Format,,
     # If line starts with a '#' it is considered a comment,,
     # DCGM FIELD, Prometheus metric type, help message
@@ -33,7 +32,7 @@ data:
     DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
     DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
     DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
-    DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
+    DCGM_FI_DEV_DEC_UTIL,     gauge, Decoder utilization (in %).
 
     # Errors and violations,,
     DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
It puts some commas and removes a blank comment line. `dcgm-exporter` requires all the lines should have two commas, even in the comments.

**Which issue(s) this PR fixes**:
[D2IQ-78131](https://jira.d2iq.com/browse/D2IQ-78131)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
