### PR TITLE
chore: add V2 GC configuration for Knative Serving

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: knative
-version: 0.3.6
+version: 0.3.7
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
 name: serving
-version: 0.3.6
+version: 0.3.7
 kubeVersion: ">=1.17.0"
 description: "Knative Serving"
 sources:
 - https://github.com/knative/serving
 maintainers:
-- name: chhsia0
-- name: gilbert88
+- name: akirillov
 appVersion: "v0.18.3"

--- a/staging/knative/charts/serving/templates/serving.yaml
+++ b/staging/knative/charts/serving/templates/serving.yaml
@@ -596,6 +596,9 @@ metadata:
   annotations:
     knative.dev/example-checksum: "6a69cdef"
 data:
+  {{- if .Values.gc.responsiveRevisionGC }}
+  responsive-revision-gc: "{{ .Values.gc.responsiveRevisionGC }}"
+  {{- end }}
   _example: |
     ################################
     #                              #
@@ -711,10 +714,17 @@ metadata:
   annotations:
     knative.dev/example-checksum: "4b89cfa0"
 data:
+  {{- if .Values.gc.responsiveRevisionGC }}
+  retain-since-create-time: "{{ .Values.gc.retainSinceCreateTime }}"
+  retain-since-last-active-time: "{{ .Values.gc.retainSinceLastActiveTime }}"
+  min-non-active-revisions: "{{ .Values.gc.minNonActiveRevisions }}"
+  max-non-active-revisions: "{{ .Values.gc.maxNonActiveRevisions }}"
+  {{- else }}
   stale-revision-create-delay: "{{ .Values.gc.staleRevisionCreateDelay }}"
   stale-revision-timeout: "{{ .Values.gc.staleRevisionTimeout }}"
   stale-revision-minimum-generations: "{{ .Values.gc.staleRevisionMinimumGenerations }}"
   stale-revision-lastpinned-debounce: "{{ .Values.gc.staleRevisionLastpinnedDebounce }}"
+  {{- end }}
   _example: |
     ################################
     #                              #

--- a/staging/knative/charts/serving/values.yaml
+++ b/staging/knative/charts/serving/values.yaml
@@ -19,3 +19,14 @@ gc:
   staleRevisionTimeout: "15h"
   staleRevisionMinimumGenerations: "20"
   staleRevisionLastpinnedDebounce: "5h"
+  # V2 GC settings
+  # To enable V2 GC set responsiveRevisioGC to "allowed"
+  responsiveRevisionGC: ""
+  # Duration since creation before considering a revision for GC or "disabled".
+  retainSinceCreateTime: "48h"
+  # Duration since active before considering a revision for GC or "disabled".
+  retainSinceLastActiveTime: "15h"
+  # Minimum number of non-active revisions to retain.
+  minNonActiveRevisions: "20"
+  # Maximum number of non-active revisions to retain or "disabled" to disable any maximum limit.
+  maxNonActiveRevisions: "1000"

--- a/staging/knative/requirements.yaml
+++ b/staging/knative/requirements.yaml
@@ -6,5 +6,5 @@ dependencies:
     version: 0.2.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 0.3.6
+    version: 0.3.7
     condition: serving.enabled

--- a/staging/knative/values.yaml
+++ b/staging/knative/values.yaml
@@ -21,3 +21,14 @@ serving:
     staleRevisionTimeout: "15h"
     staleRevisionMinimumGenerations: "20"
     staleRevisionLastpinnedDebounce: "5h"
+    # V2 GC settings
+    # To enable V2 GC set responsiveRevisioGC to "allowed"
+    responsiveRevisionGC: ""
+    # Duration since creation before considering a revision for GC or "disabled".
+    retainSinceCreateTime: "48h"
+    # Duration since active before considering a revision for GC or "disabled".
+    retainSinceLastActiveTime: "15h"
+    # Minimum number of non-active revisions to retain.
+    minNonActiveRevisions: "20"
+    # Maximum number of non-active revisions to retain or "disabled" to disable any maximum limit.
+    maxNonActiveRevisions: "1000"


### PR DESCRIPTION
**What type of PR is this?**
chore

**What this PR does/ why we need it**:
This is a follow-up PR for exposing GC configuration for Knative Serving https://github.com/mesosphere/charts/pull/1207. This PR exposes V2 GC settings which are more functional compared to the old GC and V2 GC becomes the default in the future versions of Knative Serving. Parameter names stay the same.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
