### PR TITLE
fix: shorten TFA hooks names

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "3.0.2"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.3.2
+version: 0.3.3
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/hooks.yaml
+++ b/staging/traefik-forward-auth/templates/hooks.yaml
@@ -77,7 +77,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{.Release.Name}}-session-key-pre-install"
+  name: "{{.Release.Name}}-sesh-key-pre-install"
   labels:
     app.kubernetes.io/managed-by: {{.Release.Service | quote }}
     app.kubernetes.io/instance: {{.Release.Name | quote }}
@@ -145,7 +145,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{.Release.Name}}-session-key-post-delete"
+  name: "{{.Release.Name}}-sesh-key-post-delete"
   labels:
     app.kubernetes.io/managed-by: {{.Release.Service | quote }}
     app.kubernetes.io/instance: {{.Release.Name | quote }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Bumping to TFA >3.0.0 caused below error in YAKCL https://github.com/mesosphere/yakcl/pull/438
```
auth/templates/hooks.yaml failed: Job.batch \"traefik-forward-auth-kommander-kubeaddons-session-key-pre-install\" is invalid: spec.template.labels: Invalid value: \"traefik-forward-auth-kommander-kubeaddons-session-key-pre-install\": must be no more than 63 characters"}
```

I did not find any examples of using `generateName` in our charts and an upstream issue https://github.com/helm/helm/issues/3348 so decided to go with the safer route and just shorten the name to something that will be <=63 characters

```
traefik-forward-auth-kommander-kubeaddons-sess-key-pre-install
traefik-forward-auth-kommander-kubeaddons-sess-key-post-delete
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:
Testing this fix in https://github.com/mesosphere/yakcl/pull/438


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
