### PR TITLE
[release/kube-prometheus-stack-15.4.x] Fix alertmanager crd filename

### DIFF
--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.4.7
+version: 15.4.8
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part1.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/hooks/v9-to-v11-upgrade-part1.yaml
@@ -11,8 +11,8 @@ metadata:
 data:
   crd-alertmanagerconfigs.yaml: |-
 {{ .Files.Get "crds/crd-alertmanagerconfigs.yaml" | printf "%s" | indent 4 }}
-  crd-alertmanager.yaml: |-
-{{ .Files.Get "crds/crd-alertmanager.yaml" | printf "%s" | indent 4 }}
+  crd-alertmanagers.yaml: |-
+{{ .Files.Get "crds/crd-alertmanagers.yaml" | printf "%s" | indent 4 }}
   crd-podmonitors.yaml: |-
 {{ .Files.Get "crds/crd-podmonitors.yaml" | printf "%s" | indent 4 }}
   crd-probes.yaml: |-

--- a/staging/kube-prometheus-stack/templates/mesosphere-hooks/v9-to-v11-upgrade-part1.yaml
+++ b/staging/kube-prometheus-stack/templates/mesosphere-hooks/v9-to-v11-upgrade-part1.yaml
@@ -11,8 +11,8 @@ metadata:
 data:
   crd-alertmanagerconfigs.yaml: |-
 {{ .Files.Get "crds/crd-alertmanagerconfigs.yaml" | printf "%s" | indent 4 }}
-  crd-alertmanager.yaml: |-
-{{ .Files.Get "crds/crd-alertmanager.yaml" | printf "%s" | indent 4 }}
+  crd-alertmanagers.yaml: |-
+{{ .Files.Get "crds/crd-alertmanagers.yaml" | printf "%s" | indent 4 }}
   crd-podmonitors.yaml: |-
 {{ .Files.Get "crds/crd-podmonitors.yaml" | printf "%s" | indent 4 }}
   crd-probes.yaml: |-


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
`crd-alertmanager.yaml` was renamed to `crd-alertmanagers.yaml` in chart version v11.0.0, but we didn't catch this change in any of our upgrade scripts so any users on v11+ will run into outdated alertmanager CRDs upon upgrading. I traced this back to any version including and over konvoy 1.6.2.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/COPS-6842
https://jira.d2iq.com/browse/D2IQ-79666

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[prometheus] Prometheus addon upgrades now upgrade the alertmanager CRD (COPS-6842)
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
