### PR TITLE
feat: use gatekeeper constraints to enforce spec.serviceAccountName

### DIFF
--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.4.0-rc.1"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.6.8
+version: 0.6.9
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:

--- a/staging/gatekeeper/templates/gatekeeper-dkp-constraints.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-dkp-constraints.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disableDkpConstraints }}
 ---
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
@@ -48,3 +49,4 @@ spec:
     namespaceSelector:
       matchLabels:
         kommander.d2iq.io/managed-by-kind: "Project"
+{{- end }}

--- a/staging/gatekeeper/templates/gatekeeper-dkp-constraints.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-dkp-constraints.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: requiredserviceaccountname
+  annotations:
+    description: >-
+      Requires the given resource to have the
+      .spec.serviceAccountName field set.
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequiredServiceAccountName
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package requiredserviceaccountname
+
+        violation[{"msg": msg}] {
+          value := object.get(input.review.object.spec, "serviceAccountName", "")
+          value == ""
+          msg := "must have a serviceAccountName set"
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RequiredServiceAccountName
+metadata:
+  name: helmrelease-must-have-sa
+spec:
+  match:
+    kinds:
+      - apiGroups: ["helm.toolkit.fluxcd.io"]
+        kinds: ["HelmRelease"]
+    namespaceSelector:
+      matchLabels:
+        kommander.d2iq.io/managed-by-kind: "Project"
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RequiredServiceAccountName
+metadata:
+  name: kustomization-must-have-sa
+spec:
+  match:
+    kinds:
+      - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+        kinds: ["Kustomization"]
+    namespaceSelector:
+      matchLabels:
+        kommander.d2iq.io/managed-by-kind: "Project"

--- a/staging/gatekeeper/templates/gatekeeper-flux-constraints.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-flux-constraints.yaml
@@ -1,10 +1,11 @@
-{{- if not .Values.disableDkpConstraints }}
+{{- if .Values.enableFluxConstraints }}
 ---
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: requiredserviceaccountname
   annotations:
+    "helm.sh/hook-weight": "10"
     description: >-
       Requires the given resource to have the
       .spec.serviceAccountName field set.
@@ -28,6 +29,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: RequiredServiceAccountName
 metadata:
   name: helmrelease-must-have-sa
+  annotations:
+    "helm.sh/hook-weight": "20"
 spec:
   match:
     kinds:
@@ -41,6 +44,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: RequiredServiceAccountName
 metadata:
   name: kustomization-must-have-sa
+  annotations:
+    "helm.sh/hook-weight": "20"
 spec:
   match:
     kinds:

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -23,7 +23,7 @@ auditInterval: 60
 constraintViolationsLimit: 20
 auditFromCache: false
 disableValidatingWebhook: false
-disableDkpConstraints: false
+enableFluxConstraints: true
 auditChunkSize: 0
 logLevel: INFO
 emitAdmissionEvents: false

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -23,6 +23,7 @@ auditInterval: 60
 constraintViolationsLimit: 20
 auditFromCache: false
 disableValidatingWebhook: false
+disableDkpConstraints: false
 auditChunkSize: 0
 logLevel: INFO
 emitAdmissionEvents: false


### PR DESCRIPTION

Flux kustomizations and HelmRelease created by kommander are populated with `spec.serviceAccountName` to make sure they do not deploy manifests outside the scope of their namespace.

A user might unintentionally (or with mal intent) deploy resources on a namespace they do not have access to by just creating a helmRelease or a flux kustomization. We must ensure we guard against this. Flux recommends having a admissioncontroller (like gatekeeper) to enforce this.

This PR adds constraint templates to ensure ALL kustomizations / HelmReleases in a namespace have a service account in them.

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
