### PR TITLE
fix: remove duplicate tolerations keys for metallb chart

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.12.2
+version: 0.12.3
 name: metallb
 deprecated: true
 appVersion: 0.8.1

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -28,9 +28,6 @@ spec:
         prometheus.io/port: "7472"
 {{- end }}
     spec:
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
@@ -74,10 +71,12 @@ spec:
         {{- with .Values.speaker.nodeSelector }}
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.speaker.tolerations }}
       tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      {{- with .Values.speaker.tolerations }}
 {{ toYaml . | indent 8 }}
-    {{- end }}
+      {{- end }}
     {{- with .Values.speaker.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
Duplicate keys cause Flux to fail, see https://github.com/fluxcd/helm-controller/issues/283 Additionally, the `node-role.kubernetes.io/master` will no longer be removed/lost in case when new tolerations are defined.

**Which issue(s) this PR fixes**:
* https://jira.d2iq.com/browse/D2IQ-81473

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Defining custom tolerations for metallb speaker no longer results in removing/forgetting of `node-role.kubernetes.io/master` toleration.
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
