### PR TITLE
add concurrency limit to grafana home dashboard cronjob

### DIFF
--- a/stable/kommander/Chart.yaml
+++ b/stable/kommander/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   - name: gracedo
   - name: dkoshkin
 name: kommander
-version: 0.38.5
+version: 0.38.6

--- a/stable/kommander/templates/grafana/cronjob-home-dashboard.yaml
+++ b/stable/kommander/templates/grafana/cronjob-home-dashboard.yaml
@@ -12,6 +12,12 @@ metadata:
 {{ include "kommander.labels" . | indent 4 }}
 spec:
   schedule: "*/5 * * * *"
+  # Set this value to replace as the actual job run is not expected to be
+  # running more than a few seconds in the normal conditions. If there is an
+  # error in the pod then there is no need to keep the old pod running. With
+  # this value missing the cronjob could potentially schedule failing pods
+  # wihtout any limit.
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:

--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.1.1
+version: 18.1.2
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/cronjob-home-dashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/cronjob-home-dashboard.yaml
@@ -10,6 +10,12 @@ metadata:
   name: {{ .Release.Name }}-{{ .Values.mesosphereResources.homeDashboard.cronJob.name }}
 spec:
   schedule: "*/5 * * * *"
+  # Set this value to replace as the actual job run is not expected to be
+  # running more than a few seconds in the normal conditions. If there is an
+  # error in the pod then there is no need to keep the old pod running. With
+  # this value missing the cronjob could potentially schedule failing pods
+  # wihtout any limit.
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:

--- a/staging/kube-prometheus-stack/templates/grafana/cronjob-home-dashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/cronjob-home-dashboard.yaml
@@ -10,6 +10,12 @@ metadata:
   name: {{ .Release.Name }}-{{ .Values.mesosphereResources.homeDashboard.cronJob.name }}
 spec:
   schedule: "*/5 * * * *"
+  # Set this value to replace as the actual job run is not expected to be
+  # running more than a few seconds in the normal conditions. If there is an
+  # error in the pod then there is no need to keep the old pod running. With
+  # this value missing the cronjob could potentially schedule failing pods
+  # wihtout any limit.
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
Adds the concurrency policy `Replace` configuration to the set home dashboards `CronJob` to avoid potentially creating an unbound number of pods if a pod is failing to start.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/COPS-7105

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
