### PR TITLE
[velero] fix: Bump minio subchart images to mitigate CVE-2021-2128i7

### DIFF
--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 3.1.4
+version: 3.1.5
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/staging/velero/charts/minio/Chart.yaml
+++ b/staging/velero/charts/minio/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/minio/minio
-version: 8.0.8
+version: 8.0.9

--- a/staging/velero/charts/minio/values.yaml
+++ b/staging/velero/charts/minio/values.yaml
@@ -14,7 +14,7 @@ clusterDomain: cluster.local
 ##
 image:
   repository: minio/minio
-  tag: RELEASE.2020-12-03T05-49-24Z
+  tag: RELEASE.2021-02-14T04-01-33Z
   pullPolicy: IfNotPresent
 
 ## Set default image, imageTag, and imagePullPolicy for the `mc` (the minio
@@ -22,7 +22,7 @@ image:
 ##
 mcImage:
   repository: minio/mc
-  tag: RELEASE.2020-11-25T23-04-07Z
+  tag: RELEASE.2021-02-14T04-28-06Z
   pullPolicy: IfNotPresent
 
 ## Set default image, imageTag, and imagePullPolicy for the `jq` (the JSON

--- a/staging/velero/requirements.lock
+++ b/staging/velero/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
   repository: ""
-  version: 8.0.8
-digest: sha256:722a61eeae8d9618dd1475570c17d32e9c81df00a8474ec74e341c4750740f34
-generated: "2021-01-19T21:58:32.25443-05:00"
+  version: 8.0.9
+digest: sha256:76e5c94eeefecf87bb02fdb7837b77e64be20e26850a12e2eca2bb4d39041823
+generated: "2022-01-10T17:02:59.251213-08:00"

--- a/staging/velero/requirements.yaml
+++ b/staging/velero/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: minio
-  version: 8.0.8
+  version: 8.0.9
   condition: minioBackend


### PR DESCRIPTION
Bump the minio images used in minio subchart (pulled into velero)
in order to mitigate CVE-2021-2128i7.

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Bump minio images to ones that include the fix for https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-21287. Since this minio subchart is forked off an older/deprecated chart, I bumped it to the latest image used in that chart https://github.com/minio/charts/commit/032712dbd3a5cd717dcb524e3fcdf5eb85db8ab4#diff-5791b6226743c56f44f8274cc67b8beb9751b6403e697243ad00fd37af5635e3. It doesn't jump too many versions but still includes the CVE fix. 

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/COPS-7134

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
