### PR TITLE
[gatekeeper] fix: Allow configuring sideeffects

### DIFF
--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.4.0-rc.1"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.6.8
+version: 0.6.9
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:

--- a/staging/gatekeeper/patch/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/staging/gatekeeper/patch/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -122,7 +122,9 @@ webhooks:
           - UPDATE
         resources:
           - '*'
-    sideEffects: None
+    {{ if .Values.mutations.sideEffects }}
+    sideEffects: {{ .Values.mutations.sideEffects }}
+    {{ end }}
 {{- end }}
 {{ if .Values.webhook.certManager.enabled }}
 ---

--- a/staging/gatekeeper/patch/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/staging/gatekeeper/patch/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -122,6 +122,7 @@ webhooks:
           - UPDATE
         resources:
           - '*'
+    sideEffects: None
 {{- end }}
 {{ if .Values.webhook.certManager.enabled }}
 ---

--- a/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-proxy-mutations.yaml
@@ -1,5 +1,5 @@
 {{- if and (and .Values.mutations.podProxySettings.noProxy .Values.mutations.enablePodProxy) .Values.mutations.enable }}
-# versions: ["*"] doesn't work and is not expected to work, as stated in the docs, "Globs are not allowed."
+# versions: ["*"] doesn't work and is not expected to work, as stated in the docs, "Globs are not allowed.":
 # https://github.com/open-policy-agent/gatekeeper/blob/001f4c3f3155e19e26955356e7be24207c5d5ac4/apis/mutations/v1alpha1/assign_types.go#L40
 # also see usage of this []string here: https://github.com/open-policy-agent/gatekeeper/blob/6ceb3f486a0a4b4887526e982762e6857829843a/pkg/mutation/schema/schema.go#L39-L48
 ---

--- a/staging/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -122,7 +122,9 @@ webhooks:
           - UPDATE
         resources:
           - '*'
-    sideEffects: None
+    {{ if .Values.mutations.sideEffects }}
+    sideEffects: {{ .Values.mutations.sideEffects }}
+    {{ end }}
 {{- end }}
 {{ if .Values.webhook.certManager.enabled }}
 ---

--- a/staging/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/staging/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -122,6 +122,7 @@ webhooks:
           - UPDATE
         resources:
           - '*'
+    sideEffects: None
 {{- end }}
 {{ if .Values.webhook.certManager.enabled }}
 ---

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -123,3 +123,6 @@ mutations:
 
   # disable the following namespaces
   excludeNamespacesFromProxy: []
+
+  # configure mutatingwebhookconfiguration sideEffects if necessary
+   sideEffects: ""

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -125,4 +125,4 @@ mutations:
   excludeNamespacesFromProxy: []
 
   # configure mutatingwebhookconfiguration sideEffects if necessary
-   sideEffects: ""
+  sideEffects: ""


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Missing a `sideEffects: None` in the `mutatingwebhookconfiguration` which is required for flux (komm 2.x). Adding `mutations.sideEffects` field to allow configuring `sideEffects` without potentially breaking backwards-compat with 1.x if gatekeeper ever needs to be bumped there. Default would still be to omit the field - we will set it when bumping to this version in 2.x

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/COPS-7127

**Special notes for your reviewer**:

(on another note, the patch scripts are not really updated. doesn't look like they've been used for some time so some scripts are outdated. I've only run the one relevant patch I needed here which didn't break anything)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
