### PR TITLE
kube-prometheus-stack: Allow grafana svc name override in cronjob

### DIFF
--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.1.2
+version: 18.1.3
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/cronjob-home-dashboard.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/grafana/cronjob-home-dashboard.yaml
@@ -52,7 +52,7 @@ data:
     set -o nounset
     set -o errexit
     set -o pipefail
-    GRAFANA_API_URL="http://{{ .Release.Name }}-grafana.{{ .Release.Namespace }}:{{ .Values.grafana.service.port }}"
+    GRAFANA_API_URL="http://{{ template "kube-prometheus-stack.homeDashboard.grafanaServiceName" . }}.{{ .Release.Namespace }}:{{ .Values.grafana.service.port }}"
     CURL="curl --verbose --max-time 60 --retry 10 --retry-connrefused --fail"
     DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" $GRAFANA_API_URL/api/search/?query={{ .Values.mesosphereResources.homeDashboard.name | urlquery }} | jq '.[0].id' || true )
     if [ "$DASHBOARD_ID" == "" ]; then

--- a/staging/kube-prometheus-stack/patch/patch_11_mesosphere_helpers.sh
+++ b/staging/kube-prometheus-stack/patch/patch_11_mesosphere_helpers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This patch adds mesosphere specific patterns to ignore into .helmignore
+# This patch adds mesosphere specific templates into _helpers.tpl
 
 source $(dirname "$0")/helpers.sh
 
@@ -8,7 +8,7 @@ set -xeuo pipefail
 
 SRCFILE="${BASEDIR}"/templates/_helpers.tpl
 
-sed -i '/# Mesosphere-specific files to ignore/,$d' ${SRCFILE}
+sed -i '/# Mesosphere-specific templates/,$d' ${SRCFILE}
 
 cat << EOF >> ${SRCFILE}
 # Mesosphere-specific templates

--- a/staging/kube-prometheus-stack/patch/patch_11_mesosphere_helpers.sh
+++ b/staging/kube-prometheus-stack/patch/patch_11_mesosphere_helpers.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# This patch adds mesosphere specific patterns to ignore into .helmignore
+
+source $(dirname "$0")/helpers.sh
+
+set -xeuo pipefail
+
+SRCFILE="${BASEDIR}"/templates/_helpers.tpl
+
+sed -i '/# Mesosphere-specific files to ignore/,$d' ${SRCFILE}
+
+cat << EOF >> ${SRCFILE}
+# Mesosphere-specific templates
+
+{{/* Override grafana service name if applicable, only in cronjob */}}
+{{- define "kube-prometheus-stack.homeDashboard.grafanaServiceName" -}}
+   {{- default (printf "%s-grafana" .Release.Name ) .Values.mesosphereResources.homeDashboard.serviceNameOverride -}}
+{{- end -}}
+EOF
+
+git_add_and_commit "${BASEDIR}"/templates/_helpers.tpl

--- a/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
+++ b/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
@@ -20,6 +20,7 @@ mesosphereResources:
     velero: false
   homeDashboard:
     name: "Kubernetes / Compute Resources / Cluster"
+    serviceNameOverride: ""
     cronJob:
       enabled: true
       name: set-grafana-home-dashboard

--- a/staging/kube-prometheus-stack/templates/_helpers.tpl
+++ b/staging/kube-prometheus-stack/templates/_helpers.tpl
@@ -131,3 +131,9 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
     {{- print "policy/v1beta1" -}}
   {{- end -}}
 {{- end -}}
+# Mesosphere-specific templates
+
+{{/* Override grafana service name if applicable, only in cronjob */}}
+{{- define "kube-prometheus-stack.homeDashboard.grafanaServiceName" -}}
+   {{- default (printf "%s-grafana" .Release.Name ) .Values.mesosphereResources.homeDashboard.serviceNameOverride -}}
+{{- end -}}

--- a/staging/kube-prometheus-stack/templates/grafana/cronjob-home-dashboard.yaml
+++ b/staging/kube-prometheus-stack/templates/grafana/cronjob-home-dashboard.yaml
@@ -52,7 +52,7 @@ data:
     set -o nounset
     set -o errexit
     set -o pipefail
-    GRAFANA_API_URL="http://{{ .Release.Name }}-grafana.{{ .Release.Namespace }}:{{ .Values.grafana.service.port }}"
+    GRAFANA_API_URL="http://{{ template "kube-prometheus-stack.homeDashboard.grafanaServiceName" . }}.{{ .Release.Namespace }}:{{ .Values.grafana.service.port }}"
     CURL="curl --verbose --max-time 60 --retry 10 --retry-connrefused --fail"
     DASHBOARD_ID=$($CURL -H "X-Forwarded-User: $X_FORWARDED_USER" $GRAFANA_API_URL/api/search/?query={{ .Values.mesosphereResources.homeDashboard.name | urlquery }} | jq '.[0].id' || true )
     if [ "$DASHBOARD_ID" == "" ]; then

--- a/staging/kube-prometheus-stack/values.yaml
+++ b/staging/kube-prometheus-stack/values.yaml
@@ -2643,6 +2643,7 @@ mesosphereResources:
     velero: false
   homeDashboard:
     name: "Kubernetes / Compute Resources / Cluster"
+    serviceNameOverride: ""
     cronJob:
       enabled: true
       name: set-grafana-home-dashboard


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
It looks like 2.x centralized-grafana was trying to hit `centralized-grafana-grafana` service instead of the actual service `centralized-grafana` in the cronjob. We were templating the service name to `{{ .Release.Name }}-grafana` which generally works, but I found that the grafana subchart defines its `fullname` like so:

https://github.com/grafana/helm-charts/blob/grafana-6.16.4/charts/grafana/templates/_helpers.tpl#L19-L20
```
{{- define "grafana.fullname" -}}
{{- if .Values.fullnameOverride -}}
{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
{{- else -}}
{{- $name := default .Chart.Name .Values.nameOverride -}}
************{{- if contains $name .Release.Name -}}************
{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
{{- else -}}
{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
{{- end -}}
{{- end -}}
{{- end -}}
```

Essentially here `centralized-grafana` is the `.Release.Name` but since it contains `grafana` (chart name) it uses just `.Release.Name` without appending the `-grafana`.

To get around this, this pr Introduces a value to be able to specify overrides for that service name.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-84020

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
