### PR TITLE
[kube-prometheus-stack] Disable grafana home dashboard cronjob

### DIFF
--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 33.0.0
+version: 33.0.1
 appVersion: 0.54.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
+++ b/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
@@ -19,16 +19,9 @@ mesosphereResources:
     elasticsearch: false
     velero: false
   homeDashboard:
-    name: "Kubernetes / Compute Resources / Cluster"
-    serviceNameOverride: ""
     cronJob:
-      enabled: true
-      name: set-grafana-home-dashboard
-      image: apteno/alpine-jq:2021-01-19
+      enabled: false
   hooks:
-    grafana:
-      image: apteno/alpine-jq:2021-01-19
-      secretKeyRef: dkp-credentials
     prometheus:
       jobName: prom-get-cluster-id
       kubectlImage: bitnami/kubectl:1.19.7

--- a/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
+++ b/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
@@ -24,7 +24,7 @@ mesosphereResources:
   hooks:
     prometheus:
       jobName: prom-get-cluster-id
-      kubectlImage: bitnami/kubectl:1.19.7
+      kubectlImage: bitnami/kubectl:1.21.3
       configmapName: cluster-info-configmap
   ingressRBAC:
     enabled: true


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
feat/chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Discovered that we can use config to set home dashboard now, so we no longer need to use cronjobs to set the home dashboard, yay! Also bumped kubectl to 1.21.3 which looks to be the image mostly used in other kommander apps

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-77877

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kube-prometheus-stack: Disable grafana home dashboard cronjob
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
