### PR TITLE
[stable/dex] fix: Prevent name collision for config and cert secrets

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.9.12
+version: 2.9.13
 appVersion: 2.22.0
 description: Dex
 keywords:

--- a/stable/dex/templates/certificate.yaml
+++ b/stable/dex/templates/certificate.yaml
@@ -15,7 +15,7 @@ metadata:
     # https://github.com/helm/helm/issues/5482
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  secretName: dex
+  secretName: {{ template "dex.fullname" . }}-tls
   issuerRef:
   {{- if .Values.certIssuerRef }}
     {{- toYaml .Values.certIssuerRef | nindent 4 }}

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -211,7 +211,7 @@ install_certmanager() {
     docker_exec kubectl create secret tls kubernetes-root-ca \
         --namespace=cert-manager --cert=/tmp/ca.crt --key=/tmp/ca.key
 
-    docker_exec helm install cert-manager --debug \
+    docker_exec helm install cert-manager --debug --timeout=8m0s \
         --values stable/cert-manager-setup/ci/test-values.yaml \
         --namespace cert-manager stable/cert-manager-setup
 


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The hardcoded secret name "dex" will collide with the name of the config secret if the chart release is named "dex". This will lead to a failed chart install or upgrade if cert-manager creates the secret before Helm can.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/COPS-7193

**Special notes for your reviewer**:

I looked at updating the deployment to reflect the new cert secret name, but it already expects it by default: https://github.com/mesosphere/charts/blob/7e5e0248cef5bc23e5716a4f8d3a13c9145609b9/stable/dex/templates/deployment.yaml#L1-L3

So it looks like we'll also need to remove this line from the default dex chart config to receive this fix: https://github.com/mesosphere/kommander-applications/blob/dd82bdd3ce7d2c87c1ad45598dfb9ea8b1662aba/services/dex/2.9.12/defaults/cm.yaml#L35

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[stable/dex] Fixes a race condition between Helm and cert-manager that may cause a chart install to fail.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
