### PR TITLE
[staging/istio] feat: Add servicemonitor labels chart value

### DIFF
--- a/staging/istio/Chart.yaml
+++ b/staging/istio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio
-version: 1.11.5
+version: 1.11.6
 appVersion: 1.11.5
 description: Helm chart for Istio
 keywords:

--- a/staging/istio/charts/prometheus-operator/Chart.yaml
+++ b/staging/istio/charts/prometheus-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: prometheus-operator
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.3.1
 tillerVersion: ">=2.7.2"

--- a/staging/istio/charts/prometheus-operator/templates/servicemonitors.yaml
+++ b/staging/istio/charts/prometheus-operator/templates/servicemonitors.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-proxies
-    release: prometheus-kubeaddons
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchExpressions:
@@ -37,7 +39,9 @@ metadata:
   name: istio-component
   labels:
     monitoring: istio-components
-    release: prometheus-kubeaddons
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   jobLabel: istio
   selector:

--- a/staging/istio/charts/prometheus-operator/values.yaml
+++ b/staging/istio/charts/prometheus-operator/values.yaml
@@ -1,3 +1,6 @@
 enabled: true
 # Controls the default scrape interval used in the ServiceMonitors
 scrapeInterval: 15s
+
+serviceMonitor:
+  labels: {}

--- a/staging/istio/requirements.lock
+++ b/staging/istio/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.1.0
 - name: prometheus-operator
   repository: ""
-  version: 1.1.0
+  version: 1.1.1
 - name: security
   repository: ""
   version: 0.0.2
-digest: sha256:fa502845a76baa028420e64229e264d0a11510e6de1e19a6d10b00b9e0f5ee43
-generated: "2020-09-30T10:54:54.688347-07:00"
+digest: sha256:bc7eff3ded598cb454e8ed713f4a38768da15357591568d9901b66d867450799
+generated: "2022-03-14T19:32:58.149047-07:00"

--- a/staging/istio/requirements.yaml
+++ b/staging/istio/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
   version: 1.1.0
   condition: grafana.enabled
 - name: prometheus-operator
-  version: 1.1.0
+  version: 1.1.1
   condition: prometheus.enabled
 - name: security
   version: 0.0.2


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This allows setting custom servicemonitor labels in chart values. This allows us to update servicemonitor labels in response to changes in Prometheus configuration without modifying this chart.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
