### PR TITLE
[multiple charts] Use kubectl images from chart values

### DIFF
--- a/staging/gatekeeper/Chart.yaml
+++ b/staging/gatekeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.4.0-rc.1"
 description: Gatekeeper - Policy Controller for Kubernetes
 name: gatekeeper
-version: 0.6.9
+version: 0.6.10
 home: https://github.com/open-policy-agent/gatekeeper
 icon: https://www.openpolicyagent.org/img/opa-logo.svg
 maintainers:

--- a/staging/gatekeeper/patch/patch_2_upgrade_crds_job.sh
+++ b/staging/gatekeeper/patch/patch_2_upgrade_crds_job.sh
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: gatekeeper-crds
       containers:
         - name: gatekeeper-crds
-          image: "bitnami/kubectl:1.19.7"
+          image: {{ .Values.kubectlImage }}
           volumeMounts:
             - name: gatekeeper-crds
               mountPath: /etc/gatekeeper-crds

--- a/staging/gatekeeper/templates/crds.yaml
+++ b/staging/gatekeeper/templates/crds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: gatekeeper-crds
       containers:
         - name: gatekeeper-crds
-          image: "bitnami/kubectl:1.19.7"
+          image: {{ .Values.kubectlImage }}
           volumeMounts:
             - name: gatekeeper-crds
               mountPath: /etc/gatekeeper-crds

--- a/staging/gatekeeper/values.yaml
+++ b/staging/gatekeeper/values.yaml
@@ -104,7 +104,7 @@ webhook:
   certManager:
     enabled: false
 
-kubectlImage: bitnami/kubectl:1.15
+kubectlImage: bitnami/kubectl:1.23.5
 
 # enable mutations
 mutations:

--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 3.1.5
+version: 3.2.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/staging/velero/templates/install-crds.yaml
+++ b/staging/velero/templates/install-crds.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: velero-crds
       containers:
         - name: velero-crds
-          image: "bitnami/kubectl:1.19.7"
+          image: {{ .Values.kubectlImage }}
           volumeMounts:
             - name: velero-crds
               mountPath: /etc/velero-crds

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -301,4 +301,4 @@ minioBackend: false
 ## End of additional Velero resource settings.
 ##
 
-kubectlImage: "bitnami/kubectl:1.19.7"
+kubectlImage: "bitnami/kubectl:1.23.5"

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -300,3 +300,5 @@ minioBackend: false
 ##
 ## End of additional Velero resource settings.
 ##
+
+kubectlImage: "bitnami/kubectl:1.19.7"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug and Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This updates charts so that their kubectl images can be set in chart values.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-84836

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[staging/gatekeeper] Fixes CRD jobs to use the kubectl image from chart values.
[staging/velero] Adds a `kubectlImage` chart value.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
