### PR TITLE
build: Add mergebot config, move off Dispatch to TC

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -176,7 +176,6 @@ do_bump_addon = bump_addon("bump-addon", kba_git)
 kommander_chart_path = "stable/kommander/Chart.yaml"
 
 # Robot Actions
-action(tasks=["publish"], on=push(branches=["master", "release/*"]))
 action(tasks=[do_bump_kommander], on=push(branches=["master"], paths=[kommander_chart_path]))
 action(tasks=[do_bump_addon], on=push(branches=["master"], paths=["!" + kommander_chart_path, "stable/*/Chart.yaml", "staging/*/Chart.yaml"]))
 

--- a/Dispatchfile
+++ b/Dispatchfile
@@ -176,14 +176,11 @@ do_bump_addon = bump_addon("bump-addon", kba_git)
 kommander_chart_path = "stable/kommander/Chart.yaml"
 
 # Robot Actions
-action(tasks=["test-helm"], on=pull_request())
 action(tasks=["publish"], on=push(branches=["master", "release/*"]))
 action(tasks=[do_bump_kommander], on=push(branches=["master"], paths=[kommander_chart_path]))
 action(tasks=[do_bump_addon], on=push(branches=["master"], paths=["!" + kommander_chart_path, "stable/*/Chart.yaml", "staging/*/Chart.yaml"]))
 
 # Chatops Actions
-action(tasks=["test-helm"], on=pull_request(chatops=["test"]))
-action(tasks=["test-helm"], on=pull_request(chatops=["test-helm"]))
 action(tasks=[do_bump_kubecost], on=pull_request(chatops=["bump-kubecost"]))
 
 # Cron Actions

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -5,7 +5,7 @@
   },
   "test": true,
   "test-binding": {
-    "mcharts/lint-charts": {
+    "charts/lint-test": {
       "type": "teamcity",
       "required": "true",
       "priority": 2,
@@ -14,18 +14,7 @@
           "documentation"
         ]
       },
-      "id": "mcharts_LintCharts"
-    },
-    "mcharts/test-charts": {
-      "type": "teamcity",
-      "required": "true",
-      "priority": 2,
-      "ignore": {
-        "labels": [
-          "documentation"
-        ]
-      },
-      "id": "mcharts_TestCharts"
+      "id": "ClosedSource_Konvoy_ChartPr"
     }
   },
   "autotest-on-backports-and-trains": true,

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -1,0 +1,34 @@
+{
+  "override-status": {
+    "enabled": true,
+    "jira_label": "mergebot-override"
+  },
+  "test": true,
+  "test-binding": {
+    "mcharts/lint-charts": {
+      "type": "teamcity",
+      "required": "true",
+      "priority": 2,
+      "ignore": {
+        "labels": [
+          "documentation"
+        ]
+      },
+      "id": "mcharts_LintCharts"
+    },
+    "mcharts/test-charts": {
+      "type": "teamcity",
+      "required": "true",
+      "priority": 2,
+      "ignore": {
+        "labels": [
+          "documentation"
+        ]
+      },
+      "id": "mcharts_TestCharts"
+    }
+  },
+  "autotest-on-backports-and-trains": true,
+  "autotrigger-tests-on-ready-for-review": true,
+  "ready-for-review-label": "ok-to-test"
+}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
We need to move off Dispatch for this repo. I'm reusing the existing charts PR TC job (lint and test charts) that is triggered for PRs. I think we need to merge this PR to `master` to be able to test the mergebot config

https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Konvoy_ChartPr?branch=&mode=builds

Also removed the publish job off Dispatch, and re-activated ths TC publish job: https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Konvoy_Chart?branch=&buildTypeTab=overview&mode=builds#all-projects

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-86436

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
