### PR TITLE
feat: add kommander-cert-federation chart

### DIFF
--- a/stable/kommander-cert-federation/Chart.yaml
+++ b/stable/kommander-cert-federation/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: "0.0.2"
+description: A Helm chart to create and federate TLS certificates used by kommander internals
+home: https://github.com/mesosphere/charts
+name: kommander-cert-federation
+type: application
+version: v0.0.2
+maintainers:
+  - name: mikolajb
+  - name: takirala

--- a/stable/kommander-cert-federation/Chart.yaml
+++ b/stable/kommander-cert-federation/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to create and federate TLS certificates used by komman
 home: https://github.com/mesosphere/charts
 name: kommander-cert-federation
 type: application
-version: v0.0.2
+version: 0.0.2
 maintainers:
   - name: mikolajb
   - name: takirala

--- a/stable/kommander-cert-federation/templates/cert-federation.yaml
+++ b/stable/kommander-cert-federation/templates/cert-federation.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ required "A valid .Values.secretName is required" .Values.secretName }}-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: {{ required "A valid .Values.commonName is required" .Values.commonName }}
+  {{- with .Values.dnsNames }}
+  dnsNames:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  duration: 87600h
+  subject:
+    organizations:
+      - D2iQ
+  secretName: {{ .Values.secretName }}
+  issuerRef:
+    name: {{ .Values.clusterIssuerName }}
+    kind: ClusterIssuer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-kommander-secret-edit
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-kommander-secret-edit
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["types.kubefed.io"]
+    resources: ["federatedsecrets"]
+    verbs: ["get", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-kommander-secret-edit
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-kommander-secret-edit
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-kommander-secret-edit
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  ## .Release.Namespace added to prevent race condition related apply same release to different namespaces at the same time
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-kommander-secret-edit
+  namespace: {{ .Values.kubefedNamespace }}
+rules:
+  - apiGroups: ["core.kubefed.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  ## .Release.Namespace added to prevent race condition related apply same release to different namespaces at the same time
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-kommander-secret-edit
+  namespace: {{ .Values.kubefedNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-kommander-secret-edit
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-kommander-secret-edit
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-cert-federation
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    secret.reloader.stakater.com/reload: {{ .Values.secretName }}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      tls-ca-field-to-a-secret: copy-and-federate-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        tls-ca-field-to-a-secret: copy-and-federate-{{ .Release.Name }}
+    spec:
+      initContainers:
+      # These initContainers should run at most once (should succeed only once).
+      - name: patch-secret
+        image: bitnami/kubectl:1.23.4
+        command:
+          - sh
+          - "-c"
+          - |
+            /bin/bash <<'EOF'
+            set -uxeo pipefail
+
+            # Ensure FederatedSecret does not exist before patching secret. Otherwise, FederatedSecret will overwrite the patch.
+            echo "ensuring federatedsecret {{ .Values.secretName }} does not exist"
+            kubectl delete federatedsecret {{ .Values.secretName }} --ignore-not-found=true
+
+            # Even though removing FederatedSecret will remove Secret, cert-manager will create it again.
+            # If the recreation does not occur in time, container exits and tries in next attempt.
+            echo "patching {{ .Values.secretName }} secret"
+            CA_CRT=$(kubectl get secrets {{ .Values.secretName }} -o=jsonpath='{.data.ca\.crt}')
+            kubectl patch secret {{ .Values.secretName }} --type='json' -p="[{\"op\": \"add\", \"path\": \"/data/tls.ca\", \"value\": \"${CA_CRT}\"}]"
+
+            echo "{{ .Values.secretName }} secret patched"
+            EOF
+      - name: federate-secret
+        image: quay.io/kubernetes-multicluster/kubefed:v0.9.1
+        command:
+          - sh
+          - "-c"
+          - |
+            /bin/sh <<'EOF'
+            set -uxeo pipefail
+
+            echo "federating secret {{ .Values.secretName }}"
+            /hyperfed/kubefedctl federate --kubefed-namespace {{ .Values.kubefedNamespace }} --namespace {{ .Release.Namespace }} secret {{ .Values.secretName }}
+            EOF
+      containers:
+      # This is a dummy container to ensure deployment is Running. It will be restarted by reloader if/when certs are renewed.
+      - name: wait-for-renewal
+        image: bitnami/kubectl:1.23.4
+        command:
+          - sh
+          - "-c"
+          - |
+            /bin/bash <<'EOF'
+            # Sleep until either reloader restarts the deployment or the default duration of a certificate expires.
+            # This Deployment used to be a Job but this Job was needed to be run whenever the certificate updates (like an on-demand CronJob) and thus it was promoted to be a Deployment.
+            sleep 90d
+            EOF
+      serviceAccountName: {{ .Release.Name }}-kommander-secret-edit
+      terminationGracePeriodSeconds: 10

--- a/stable/kommander-cert-federation/values.yaml
+++ b/stable/kommander-cert-federation/values.yaml
@@ -1,0 +1,12 @@
+# Secret name of a generated Certificate
+secretName:
+# Common name of a generated Certificate
+commonName:
+# The name of a cluster issuer used to generate clusters. The default value
+# `kommander-ca` is created as part of kommander bootstrap process.
+clusterIssuerName: kommander-ca
+# kubefed namespace is used to access kubefed resources
+kubefedNamespace: kube-federation-system
+
+# dnsNames are used as certificate SANs
+dnsNames: []


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

Because of how we ship the current `cert-federation` chart with a static version 0.0.1 - https://github.com/mesosphere/kommander/blob/main/chart/cert-federation/Chart.yaml#L7 recent changes (https://github.com/mesosphere/kommander/commits/main/chart/cert-federation/templates/cert-federation.yaml) have updated the chart here - https://github.com/mesosphere/kommander/blob/gh-pages/charts/cert-federation-v0.0.1.tgz (overwritten) even though we shipped the same chart in older versions of kommander. This is not desired as it effectively makes it an unknown of what "version" of the chart a customer is running as its updated (overwritten) with every change to that chart. 

This PR fixes above issue by adding this chart into `m/charts` repo and thus enforcing a proper versioning scheme (e.g.: bumping version everytime there is a change).

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

https://jira.d2iq.com/browse/D2IQ-89706

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
