### PR TITLE
chore: Bump kubecost to 0.25.1

### DIFF
--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,9 +3,10 @@ appVersion: 1.93.2
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.25.0
+version: 0.25.1
 maintainers:
   - name: gracedo
+  - name: bcmendoza
 dependencies:
   - name: cost-analyzer
     version: 1.93.2

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -99,7 +99,7 @@ cost-analyzer:
       # NOTE: This does not affect the external_labels set in prometheus config.
       clusterIDConfigmap: kubecost-cluster-info-configmap
       image:
-        tag: v2.19.2
+        tag: v2.36.0
       extraFlags:
       - web.enable-admin-api
       - web.enable-lifecycle
@@ -133,7 +133,7 @@ cost-analyzer:
           enabled: true
       sidecarContainers:
       - name: thanos-sidecar
-        image: thanosio/thanos:v0.15.0
+        image: thanosio/thanos:v0.26.0
         args:
         - sidecar
         - --log.level=debug
@@ -165,7 +165,7 @@ cost-analyzer:
     alertmanager:
       enabled: true
       image:
-        tag: v0.21.0
+        tag: v0.24.0
       resources:
         limits:
           cpu: 50m


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
Bumps kubecost since we need to update container image tags for prometheus/prometheus, thanosio/thanos, and prometheus/alertmanager, all of which have tags affected by CVE-2022-28391.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-89799

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
