### PR TITLE
chore: Minor bump of kubectl 1.2x

### DIFF
--- a/stable/kommander-cert-federation/Chart.yaml
+++ b/stable/kommander-cert-federation/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 description: A Helm chart to create and federate TLS certificates used by kommander internals
 home: https://github.com/mesosphere/charts
 name: kommander-cert-federation
 type: application
-version: 0.0.2
+version: 0.0.3
 maintainers:
   - name: mikolajb
   - name: takirala

--- a/stable/kommander-cert-federation/templates/cert-federation.yaml
+++ b/stable/kommander-cert-federation/templates/cert-federation.yaml
@@ -100,7 +100,7 @@ spec:
       initContainers:
       # These initContainers should run at most once (should succeed only once).
       - name: patch-secret
-        image: bitnami/kubectl:1.23.4
+        image: bitnami/kubectl:1.23.7
         command:
           - sh
           - "-c"
@@ -135,7 +135,7 @@ spec:
       containers:
       # This is a dummy container to ensure deployment is Running. It will be restarted by reloader if/when certs are renewed.
       - name: wait-for-renewal
-        image: bitnami/kubectl:1.23.4
+        image: bitnami/kubectl:1.23.7
         command:
           - sh
           - "-c"

--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.93.2
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.25.0
+version: 0.25.1
 maintainers:
   - name: gracedo
 dependencies:

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -8,7 +8,7 @@ hooks:
   # Creates configmap to pass kube-system ns uid as envvar to kubecost.
   clusterID:
     enabled: true
-    kubectlImage: "bitnami/kubectl:1.21.3"
+    kubectlImage: "bitnami/kubectl:1.23.7"
 
 cost-analyzer:
   enabled: true

--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 34.9.1
+version: 34.9.2
 appVersion: 0.55.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
+++ b/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
@@ -19,7 +19,7 @@ mesosphereResources:
     elasticsearch: false
     velero: false
   hooks:
-    kubectlImage: bitnami/kubectl:1.21.3
+    kubectlImage: bitnami/kubectl:1.23.7
     prometheus:
       jobName: prom-get-cluster-id
       configmapName: cluster-info-configmap

--- a/staging/kube-prometheus-stack/values.yaml
+++ b/staging/kube-prometheus-stack/values.yaml
@@ -2812,7 +2812,7 @@ mesosphereResources:
     elasticsearch: false
     velero: false
   hooks:
-    kubectlImage: bitnami/kubectl:1.21.3
+    kubectlImage: bitnami/kubectl:1.23.7
     prometheus:
       jobName: prom-get-cluster-id
       configmapName: cluster-info-configmap

--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 3.2.1
+version: 3.2.2
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/staging/velero/templates/cleanup-crd.yaml
+++ b/staging/velero/templates/cleanup-crd.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       containers:
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.14.1
+          image: docker.io/bitnami/kubectl:1.23.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -301,4 +301,4 @@ minioBackend: false
 ## End of additional Velero resource settings.
 ##
 
-kubectlImage: "bitnami/kubectl:1.23.5"
+kubectlImage: "bitnami/kubectl:1.23.7"

--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -7,6 +7,7 @@ excluded-charts:
   - common
   - dex-controller # Moved to a different helm repo
   - kubefed
+  - kommander-cert-federation # Unable to test unless cert-manager is also upgraded
 chart-repos:
   - mesosphere-staging=https://mesosphere.github.io/charts/staging
   - mesosphere-stable=https://mesosphere.github.io/charts/stable

--- a/test/helm3/ct-e2e.yaml
+++ b/test/helm3/ct-e2e.yaml
@@ -31,6 +31,7 @@ excluded-charts:
   - thanos-traefik        # This requires installing dependencies like traefik2
   - vsphere-csi-driver
   - kubefed
+  - kommander-cert-federation # Unable to test unless cert-manager is also upgraded
 chart-repos:
   - mesosphere-staging=https://mesosphere.github.io/charts/staging
   - mesosphere-stable=https://mesosphere.github.io/charts/stable

--- a/test/helm3/ct.yaml
+++ b/test/helm3/ct.yaml
@@ -7,6 +7,7 @@ excluded-charts:
   - common
   - dex-controller # Moved to a different helm repo
   - kubefed
+  - kommander-cert-federation # Unable to test unless cert-manager is also upgraded
 chart-repos:
   - mesosphere-staging=https://mesosphere.github.io/charts/staging
   - mesosphere-stable=https://mesosphere.github.io/charts/stable


### PR DESCRIPTION
**What type of PR is this?**
chore

**What this PR does/ why we need it**:
Minor bumps of kubectl 1.2x (most are 1.23, but at least one is 1.21). This is to catch CVE fixes in the build artifacts.

**Which issue(s) this PR fixes**:
Partially fixes...
[D2IQ-90196](https://jira.d2iq.com/browse/D2IQ-90196)
[D2IQ-89723](https://jira.d2iq.com/browse/D2IQ-89723)
[D2IQ-90200](https://jira.d2iq.com/browse/D2IQ-90200)
[D2IQ-89801](https://jira.d2iq.com/browse/D2IQ-89801)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
