### PR TITLE
feat: traefik-forward-auth: support publicly (OS) trusted CAs

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "3.1.0"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.3.7
+version: 0.3.8
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/templates/deployment.yaml
+++ b/staging/traefik-forward-auth/templates/deployment.yaml
@@ -78,12 +78,14 @@ spec:
             {{- end }}
             - name: CONFIG
               value: "/etc/traefik-forward-auth/config/config.ini"
+            {{- if not .Values.traefikForwardAuth.useSystemCA }}
             - name: SSL_CERT_FILE
               {{- if or .Values.traefikForwardAuth.caCertificate .Values.traefikForwardAuth.caSecretName }}
               value: "/etc/traefik-forward-auth/ca/ca.crt"
               {{- else}}
               value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
               {{- end }}
+            {{- end }}
             - name: LOG_LEVEL
               value: "trace"
             - name: SERVICE_ACCOUNT_TOKEN_PATH

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -41,6 +41,8 @@ traefikForwardAuth:
   #   ...
   #   -----END
   # or caSecretName: < name of the secret >
+  # To use system trusted CAs
+  # useSystemCA: true
   extraConfig: ""
   userCookieName: "_forward_auth_name"
   enableRBAC: false


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
Adds an option to use the OS trusted CAs for publicly trusted certificates (e.g. issued by Let's encrypt)

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-89301

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
