### PR TITLE
chore: Bump kubectl to 1.24.1

### DIFF
--- a/stable/kommander-cert-federation/Chart.yaml
+++ b/stable/kommander-cert-federation/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to create and federate TLS certificates used by komman
 home: https://github.com/mesosphere/charts
 name: kommander-cert-federation
 type: application
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: mikolajb
   - name: takirala

--- a/stable/kommander-cert-federation/templates/cert-federation.yaml
+++ b/stable/kommander-cert-federation/templates/cert-federation.yaml
@@ -100,7 +100,7 @@ spec:
       initContainers:
       # These initContainers should run at most once (should succeed only once).
       - name: patch-secret
-        image: bitnami/kubectl:1.23.7
+        image: bitnami/kubectl:1.24.1
         command:
           - sh
           - "-c"
@@ -135,7 +135,7 @@ spec:
       containers:
       # This is a dummy container to ensure deployment is Running. It will be restarted by reloader if/when certs are renewed.
       - name: wait-for-renewal
-        image: bitnami/kubectl:1.23.7
+        image: bitnami/kubectl:1.24.1
         command:
           - sh
           - "-c"

--- a/stable/kubecost/Chart.yaml
+++ b/stable/kubecost/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.93.2
 description: Kubecost
 name: kubecost
 home: https://github.com/mesosphere/charts
-version: 0.25.1
+version: 0.25.2
 maintainers:
   - name: gracedo
 dependencies:

--- a/stable/kubecost/values.yaml
+++ b/stable/kubecost/values.yaml
@@ -8,7 +8,7 @@ hooks:
   # Creates configmap to pass kube-system ns uid as envvar to kubecost.
   clusterID:
     enabled: true
-    kubectlImage: "bitnami/kubectl:1.23.7"
+    kubectlImage: "bitnami/kubectl:1.24.1"
 
 cost-analyzer:
   enabled: true

--- a/staging/istio/Chart.yaml
+++ b/staging/istio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: istio
-version: 1.13.4
+version: 1.13.5
 appVersion: 1.13.4
 description: Helm chart for Istio
 keywords:

--- a/staging/istio/values.yaml
+++ b/staging/istio/values.yaml
@@ -2,7 +2,7 @@
 
 global:
   image: docker.io/bitnami/kubectl
-  tag: 1.22.6
+  tag: 1.24.1
 
 grafana:
   enabled: true

--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: knative
-version: 0.3.9
+version: 0.3.10
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:

--- a/staging/knative/charts/serving/values.yaml
+++ b/staging/knative/charts/serving/values.yaml
@@ -1,7 +1,7 @@
 global:
   serviceLabels: {}
   image: docker.io/bitnami/kubectl
-  tag: 1.22.8
+  tag: 1.24.1
 
 domain: example.com
 

--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 34.9.2
+version: 34.9.3
 appVersion: 0.55.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
+++ b/staging/kube-prometheus-stack/patch/patch_6_mesosphere_values.sh
@@ -19,7 +19,7 @@ mesosphereResources:
     elasticsearch: false
     velero: false
   hooks:
-    kubectlImage: bitnami/kubectl:1.23.7
+    kubectlImage: bitnami/kubectl:1.24.1
     prometheus:
       jobName: prom-get-cluster-id
       configmapName: cluster-info-configmap

--- a/staging/kube-prometheus-stack/values.yaml
+++ b/staging/kube-prometheus-stack/values.yaml
@@ -2812,7 +2812,7 @@ mesosphereResources:
     elasticsearch: false
     velero: false
   hooks:
-    kubectlImage: bitnami/kubectl:1.23.7
+    kubectlImage: bitnami/kubectl:1.24.1
     prometheus:
       jobName: prom-get-cluster-id
       configmapName: cluster-info-configmap

--- a/staging/velero/Chart.yaml
+++ b/staging/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.2
 description: A Helm chart for velero
 name: velero
-version: 3.2.2
+version: 3.2.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/staging/velero/templates/cleanup-crd.yaml
+++ b/staging/velero/templates/cleanup-crd.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
       containers:
         - name: kubectl
-          image: docker.io/bitnami/kubectl:1.23.7
+          image: bitnami/kubectl:1.24.1
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/staging/velero/values.yaml
+++ b/staging/velero/values.yaml
@@ -301,4 +301,4 @@ minioBackend: false
 ## End of additional Velero resource settings.
 ##
 
-kubectlImage: "bitnami/kubectl:1.23.7"
+kubectlImage: "bitnami/kubectl:1.24.1"


### PR DESCRIPTION
**What type of PR is this?**
chore

**What this PR does/ why we need it**:
Bumps kubectl to 1.24.1 across all charts used by kommander-applications.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-90193
https://jira.d2iq.com/browse/D2IQ-90194

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
