### PR TITLE
build: Add @mesosphere/kommander group to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,27 +5,28 @@
 # Order is important: later rules override preceding rules
 
 # These owners will be the default owners for everything in the repo unless a later match takes precedence
-* @mesosphere/sig-ksphere-catalog
+* @mesosphere/sig-ksphere-catalog @mesosphere/kommander
 
-/Dispatchfile @mesosphere/devprod
-/stable/argo-cd @mesosphere/devx
-/stable/awsebscsiprovisioner @mesosphere/sig-ksphere-cluster
-/stable/awsebsprovisioner @mesosphere/sig-ksphere-cluster
-/stable/azuredisk-csi-driver @mesosphere/sig-ksphere-cluster
-/stable/azurediskprovisioner @mesosphere/sig-ksphere-cluster
-/stable/defaultstorageclass @mesosphere/sig-ksphere-cluster
-/stable/dex @mesosphere/sig-ksphere-security
-/stable/dex-controller @mesosphere/sig-ksphere-security
-/stable/dispatch @mesosphere/devx
-/stable/gcpdisk-csi-driver @mesosphere/sig-ksphere-cluster
-/stable/gcpdiskprovisioner @mesosphere/sig-ksphere-cluster
-/stable/kommander @mesosphere/d2iq-ui @mesosphere/sig-ksphere-multi-cluster @mesosphere/sig-ksphere-observability
-/stable/kubecost @mesosphere/sig-ksphere-observability
-/stable/localvolumeprovisioner @mesosphere/sig-ksphere-cluster
-/stable/mtls-proxy @mesosphere/sig-ksphere-observability
-/stable/opsportal @mesosphere/d2iq-ui @mesosphere/sig-ksphere-security
-/stable/tekton @mesosphere/devx
+# TODO: update owners once we decide what to do with SIGs
+# /Dispatchfile @mesosphere/devprod
+# /stable/argo-cd @mesosphere/devx
+# /stable/awsebscsiprovisioner @mesosphere/sig-ksphere-cluster
+# /stable/awsebsprovisioner @mesosphere/sig-ksphere-cluster
+# /stable/azuredisk-csi-driver @mesosphere/sig-ksphere-cluster
+# /stable/azurediskprovisioner @mesosphere/sig-ksphere-cluster
+# /stable/defaultstorageclass @mesosphere/sig-ksphere-cluster
+# /stable/dex @mesosphere/sig-ksphere-security
+# /stable/dex-controller @mesosphere/sig-ksphere-security
+# /stable/dispatch @mesosphere/devx
+# /stable/gcpdisk-csi-driver @mesosphere/sig-ksphere-cluster
+# /stable/gcpdiskprovisioner @mesosphere/sig-ksphere-cluster
+# /stable/kommander @mesosphere/d2iq-ui @mesosphere/sig-ksphere-multi-cluster @mesosphere/sig-ksphere-observability
+# /stable/kubecost @mesosphere/sig-ksphere-observability
+# /stable/localvolumeprovisioner @mesosphere/sig-ksphere-cluster
+# /stable/mtls-proxy @mesosphere/sig-ksphere-observability
+# /stable/opsportal @mesosphere/d2iq-ui @mesosphere/sig-ksphere-security
+# /stable/tekton @mesosphere/devx
 
-/staging/prometheus-operator @mesosphere/sig-ksphere-observability
+# /staging/prometheus-operator @mesosphere/sig-ksphere-observability
 
-/staging/istio/* @mesosphere/sig-ksphere-networking
+# /staging/istio/* @mesosphere/sig-ksphere-networking


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
We don't really use SIGs anymore - some have no users, some have one, they are all outdated. This is blocking PRs from getting merged, and oftentimes requires an admin to merge. For now, until we decide what we're doing with SIGs or decide how to tackle ownership of specific charts, let's add @mesosphere/kommander group as toplevel owner and remove SIGs from specific charts. The kommander team is owning the majority of applications, so I think this makes sense.

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
