### PR TITLE
feat: store hmac as k8s secret for dex-k8s-auth

### DIFF
--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-appVersion: "v1.2.2"
+appVersion: "v1.2.4"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.2.9
+version: 1.2.11
 home: https://github.com/mesosphere/charts
 sources:
-- https://github.com/mintel/dex-k8s-authenticator
+- https://github.com/mesosphere/dex-k8s-authenticator
 maintainers:
 - name: mhrabovcin
-  email: mhrabovcin.c@mesosphere.com
+  email: mhrabovcin.c@d2iq.com

--- a/staging/dex-k8s-authenticator/templates/configmap.yaml
+++ b/staging/dex-k8s-authenticator/templates/configmap.yaml
@@ -25,9 +25,12 @@ data:
     {{- if .idpCaPem }}
     idp_ca_pem: {{ toYaml .idpCaPem | indent 4 }}
     {{- end }}
-    {{- if and .tlsCert .tlsKey }} 
+    {{- if and .tlsCert .tlsKey }}
     tls_cert: "{{ .tlsCert }}"
     tls_key: "{{ .tlsKey }}"
+    {{- end }}
+    {{- if .generateHmacSecret }}
+    hmac_secret: "${DKA_HMAC_SECRET}"
     {{- end }}
     clusters:
 {{ toYaml .clusters | indent 4 }}

--- a/staging/dex-k8s-authenticator/templates/deployment.yaml
+++ b/staging/dex-k8s-authenticator/templates/deployment.yaml
@@ -97,6 +97,13 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
+          {{- if .Values.dexK8sAuthenticator.generateHmacSecret }}
+          - name: DKA_HMAC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "dex-k8s-authenticator.fullname" . }}-hmac-secret
+                key: hmac-secret
+          {{- end }}
           {{- range $key, $value := .Values.env }}
           - name: {{ $key | quote }}
             value: {{ tpl $value $ | quote }}
@@ -130,7 +137,7 @@ spec:
 {{- end }}
 {{- if .Values.caCerts.enabled }}
 {{- if .Values.caCerts.secrets }}
-{{- range .Values.caCerts.secrets }} 
+{{- range .Values.caCerts.secrets }}
       - name: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}
         secret:
           secretName: {{ template "dex-k8s-authenticator.fullname" $ }}-{{ .name }}

--- a/staging/dex-k8s-authenticator/templates/secret_hmac.yaml
+++ b/staging/dex-k8s-authenticator/templates/secret_hmac.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.dexK8sAuthenticator.generateHmacSecret -}}
+{{- $secret_name := printf "%s-hmac-secret" (include "dex-k8s-authenticator.fullname" .) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secret_name }}
+  annotations:
+    "helm.sh/resource-policy": "keep"
+type: Opaque
+data:
+  # retrieve the secret data using lookup function and when not exists, return an empty dictionary / map as result
+  {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secret_name).data | default dict }}
+  # set $hmacSecret to existing secret data or generate a random one when not exists
+  {{- $hmacSecret := (get $secret "hmac-secret") | default (randAlphaNum 32 | b64enc) }}
+  # generate 32 chars long random string, base64 encode it and then double-quote the result string.
+  hmac-secret: {{ $hmacSecret | b64enc | quote }}
+{{- end -}}

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: mesosphere/dex-k8s-authenticator
-  tag: v1.1.1-62a0a92-mesosphere
+  tag: v1.2.4
   pullPolicy: Always
 
 dexK8sAuthenticator:
@@ -25,6 +25,10 @@ dexK8sAuthenticator:
     initialDelaySeconds: 10   # Under high load use 'initialDelaySeconds: 15'
     timeoutSeconds: 10   # Under high load use 'timeoutSeconds: 30'
   web_path_prefix: /
+  # When enabled the helm chart will generate HMAC secret value, stores it as
+  # a k8s secret and mounts into the `dex-k8s-authenticator` as an ENV variable
+  # and adds as configuration option.
+  generateHmacSecret: false
   # logoUrl: http://<path-to-your-logo.png>
   # tlsCert: /path/to/dex-client.crt
   # tlsKey: /path/to/dex-client.key


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Allows to use helm to generate HMAC secret during the installation and store it as a secret. The generated value is mounted to `dex-k8s-authenticator` as an ENV variable and its not stored in the ConfigMap.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:
I've manually test that the value is correctly injected into the container by running a custom build of `dex-k8s-auth` that will print the HMAC secret:

```
KUBECONFIG=kubeconfig-mh-management kubectl -n kommander logs dex-k8s-authenticator-77dd9fffc-rd6xb
2022/06/27 15:50:16 Using config file: /app/configuration/config.yaml
2022/06/27 15:50:16 HMAC_SECRET: QjZqMFZMMER5dmtuRVVpMDlwaFVodDFIczd6SmM1SEQ=
2022/06/27 15:50:16 useClusterHostname: true
2022/06/27 15:50:16 Creating new provider https://172.20.255.200/dex
```

```
 KUBECONFIG=kubeconfig-mh-management kubectl -n kommander get secret dex-k8s-authenticator-hmac-secret -o json | jq -r '.data["hmac-secret"] | @base64d'
QjZqMFZMMER5dmtuRVVpMDlwaFVodDFIczd6SmM1SEQ=
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
