### PR TITLE
feat: Bump istio to 1.14.1

### DIFF
--- a/staging/istio/Chart.yaml
+++ b/staging/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: istio
-version: 1.13.5
-appVersion: 1.13.4
+version: 1.14.1
+appVersion: 1.14.1
 description: Helm chart for Istio
 keywords:
   - istio

--- a/staging/istio/crds/crd-operator.yaml
+++ b/staging/istio/crds/crd-operator.yaml
@@ -1,3 +1,4 @@
+# SYNC WITH manifests/charts/base/files
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/staging/istio/templates/deployment.yaml
+++ b/staging/istio/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.deploymentHistory }}
   selector:
     matchLabels:
       name: istio-operator
@@ -67,3 +68,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+---

--- a/staging/istio/templates/service.yaml
+++ b/staging/istio/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
     protocol: TCP
   selector:
     name: istio-operator
+---

--- a/staging/istio/values.yaml
+++ b/staging/istio/values.yaml
@@ -12,14 +12,14 @@ security:
 prometheus:
   enabled: true
 
-### Default values for istio-operator, bundled with istio-1.13.4
+### Default values for istio-operator, bundled with istio-1.14.1
 
 # Note: These are nested so that additional values can be assigned to the default IstioOperator spec (see operator.yaml)
 # ref: https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec
 istioOperator:
   profile: default
   hub: docker.io/istio
-  tag: 1.13.4
+  tag: 1.14.1
   components:
     cni:
       enabled: true
@@ -42,6 +42,9 @@ enableCRDTemplates: false
 
 # revision for the operator resources
 revision: ""
+
+# The number of old ReplicaSets to retain in operator deployment
+deploymentHistory: 10
 
 # Operator resource defaults
 operator:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
feat

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
When bumping kiali to the latest, I got a warning that it required istio 1.14+, so bumping istio to latest here https://github.com/istio/istio/tree/1.14.1/manifests/charts/istio-operator

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
