### PR TITLE
fix: dka empty clusters renders invalid yaml

### DIFF
--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.2.4"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.2.11
+version: 1.2.12
 home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mesosphere/dex-k8s-authenticator

--- a/staging/dex-k8s-authenticator/templates/configmap.yaml
+++ b/staging/dex-k8s-authenticator/templates/configmap.yaml
@@ -32,8 +32,10 @@ data:
     {{- if .generateHmacSecret }}
     hmac_secret: "${DKA_HMAC_SECRET}"
     {{- end }}
+    {{- if .clusters }}
     clusters:
 {{ toYaml .clusters | indent 4 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.caCerts.enabled }}
     caCerts: "true"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
When providing empty clusters list to `dex-k8s-authenticator` the ConfigMap ends with invalid YAML that cannot be parsed.

Example:
```
data:
  config.yaml: |-
    listen: http://0.0.0.0:5555
    web_path_prefix: /
    debug: false
    pluginVersion:
    useClusterHostnameForClusterName: false
    clusters:
    {}
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
