### PR TITLE
ci: add stacked PR support

### DIFF
--- a/.github/workflows/stacked-prs.yml
+++ b/.github/workflows/stacked-prs.yml
@@ -1,0 +1,32 @@
+name: Stacked PRs
+
+permissions:
+  actions: write
+  checks: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          # (Required) The token to use to make API calls to GitHub.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # (Optional) The label to use to mark dependent issues
+          label: stacked
+
+          # (Optional) Enable checking for dependencies in issues.
+          # Enable by setting the value to "on". Default "off"
+          check_issues: off
+
+          # (Optional) A comma-separated list of keywords. Default
+          # "depends on, blocked by"
+          keywords: depends on, blocked by


### PR DESCRIPTION
**What type of PR is this?**

Chore

**What this PR does/ why we need it**:

Adds Stacked PRs support to the repository. This workflow allows us to create a chain of PRs that are dependent on each other.  Instead of one big PR. 

**Which issue(s) this PR fixes**:

--

**Special notes for your reviewer**:

--

**Does this PR introduce a user-facing change?**:

--

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why they are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests passes locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
