### PR TITLE
fix: use correct config for ct lint

### DIFF
--- a/.github/workflows/ct.yaml
+++ b/.github/workflows/ct.yaml
@@ -20,6 +20,15 @@ jobs:
       - name: Install asdf plugins
         uses: asdf-vm/actions/install@v1
 
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip' # caching pip dependencies
+
+      - name: Install chart-testing (ct) lint dependencies
+        run: pip install yamllint yamale
+
       - name: Lint charts
         run: make ct.lint
 


### PR DESCRIPTION
**What type of PR is this?**

CI

**What this PR does/ why we need it**:

Fixes ct lint command.

**Which issue(s) this PR fixes**:

--

**Special notes for your reviewer**:

This is a quick fix that focuses on fixing CI first.  It assumes `yamllint` and `yamale` packages should be installed locally for now. 

**Does this PR introduce a user-facing change?**:

--

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
