### PR TITLE
fix: chart testing workflow running on master instead of PR branch

### DIFF
--- a/.github/workflows/ct.yaml
+++ b/.github/workflows/ct.yaml
@@ -1,7 +1,7 @@
 name: chart testing
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 concurrency:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Chart testing workflow was running on `master` instead of the PR branch it should run on.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://d2iq.atlassian.net/browse/D2IQ-94277

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
