### PR TITLE
ci: escape double quotes in commit message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ CT_TARGET_BRANCH ?= master
 CT_SINCE         ?= HEAD~1
 COMMIT_USERNAME  ?= $(shell git config user.name)
 COMMIT_EMAIL 	 ?= $(shell git config user.email)
-COMMIT_MESSAGE   ?= $(shell git log -1 --no-show-signature --pretty=format:'%B') # Use the commit message from the last commit
+COMMIT_MESSAGE   ?= $(shell git log -1 --no-show-signature --pretty=format:'%B' |sed "s/\"/'/g") # Use the commit message from the last commit
 HELM_LINT        ?= true
 HELM_DEP_UPDATE  ?= true
 


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
CI

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The `publish` make target grabs the latest commit message to use for publishing charts to gh pages.

If the last commit contains double quotes, the publish will fail (See this commit 9adbd8945f08f826f46bf0ab372dda975a82226e)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
