### PR TITLE
feat: add new kommander life cycle controller chart

### DIFF
--- a/stable/kommander-lifecycle-controller/.helmignore
+++ b/stable/kommander-lifecycle-controller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/kommander-lifecycle-controller/Chart.yaml
+++ b/stable/kommander-lifecycle-controller/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+name: kommander-lifecycle-controller
+appVersion: "0.1.0"
+version: 0.1.0
+description: A controller that will be responsible for the lifecycle of the KommanderCore resource.
+maintainers:
+  - name: azhovan

--- a/stable/kommander-lifecycle-controller/templates/_helpers.tpl
+++ b/stable/kommander-lifecycle-controller/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kommander-lifecycle-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kommander-lifecycle-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kommander-lifecycle-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/stable/kommander-lifecycle-controller/templates/crd_kommandercores.yaml
+++ b/stable/kommander-lifecycle-controller/templates/crd_kommandercores.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kommandercores.dkp.d2iq.io
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+spec:
+  group: dkp.d2iq.io
+  names:
+    kind: KommanderCore
+    listKind: KommanderCoreList
+    plural: kommandercores
+    singular: kommandercore
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: KommanderCore is the Schema for the kommandercores API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KommanderCoreSpec defines the desired state of KommanderCore.
+              type: object
+            status:
+              description: KommanderCoreStatus defines the observed state of KommanderCore.
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/stable/kommander-lifecycle-controller/templates/deployment.yaml
+++ b/stable/kommander-lifecycle-controller/templates/deployment.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    controller: {{ template "kommander-lifecycle-controller.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "kommander-lifecycle-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      controller: {{ template "kommander-lifecycle-controller.fullname" . }}
+  template:
+    metadata:
+      labels:
+        controller: {{ template "kommander-lifecycle-controller.fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    spec:
+      serviceAccountName: {{ template "kommander-lifecycle-controller.fullname" . }}-sa
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http

--- a/stable/kommander-lifecycle-controller/templates/service.yaml
+++ b/stable/kommander-lifecycle-controller/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "kommander-lifecycle-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - port: 7444 # arbitrary port
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    controller: {{ template "kommander-lifecycle-controller.fullname" . }}

--- a/stable/kommander-lifecycle-controller/templates/serviceaccount.yaml
+++ b/stable/kommander-lifecycle-controller/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    control-plane: {{ template "kommander-lifecycle-controller.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "kommander-lifecycle-controller.fullname" . }}-sa
+  namespace: {{ .Release.Namespace }}

--- a/stable/kommander-lifecycle-controller/values.yaml
+++ b/stable/kommander-lifecycle-controller/values.yaml
@@ -1,0 +1,9 @@
+# Default values for kommander-lifecycle-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+image:
+  repository: nginx
+  tag: 0.1.0
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
As a part of cluster expansion project, a new controller is created that will be responsible for the lifecycle of the KommanderCore resource.
[more info](https://github.com/mesosphere/dkp-platform/pull/376)

**Which issue(s) this PR fixes**:
https://d2iq.atlassian.net/browse/D2IQ-95249

**Special notes for your reviewer**:
This chart includes a arbitrary `image`, `port` and `app vesion`, that should be replaced with real values in the next steps.
number of `replicas` also can be revisited if current value is not proper.  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
