### PR TITLE
feat: Bump dex to 2.11.0

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dex
-version: 2.10.0
-appVersion: 2.31.0
+version: 2.11.0
+appVersion: 2.35.1-d2iq.1
 description: Dex
 keywords:
 - dex

--- a/stable/dex/templates/secret.yaml
+++ b/stable/dex/templates/secret.yaml
@@ -27,6 +27,7 @@ stringData:
       tlsKey: {{ .grpc.tlsKey }}
       tlsClientCA: {{ .grpc.tlsClientCA }}
     {{- end }}
+    lazyInitConnectors: {{ .lazyInitConnectors }}
     {{- if .connectors }}
     connectors:
 {{ toYaml .connectors | indent 4 }}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -3,8 +3,8 @@
 # Declare name/value pairs to be passed into your templates.
 # name: value
 
-image: ghcr.io/dexidp/dex
-imageTag: "v2.31.0"
+image: docker.io/mesosphere/dex
+imageTag: "v2.35.1-d2iq.1"
 imagePullPolicy: "IfNotPresent"
 
 inMiniKube: false
@@ -187,6 +187,8 @@ config:
     tlsCert: /etc/dex/tls/grpc/server/tls.crt
     tlsKey: /etc/dex/tls/grpc/server/tls.key
     tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
+
+  lazyInitConnectors: false
   connectors: []
 #  - type: github
 #    id: github


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature
 
**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
I set the `lazyInitConnectors` field in the default desired dex configuration in https://github.com/mesosphere/kommander-applications/pull/934. However, since the helm chart values.yaml did not support the field, the field was not rendered in the actual dex configuration.

This PR updates the helm chart.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://d2iq.atlassian.net/browse/D2IQ-95346

**Special notes for your reviewer**:
 
* Add support for the `lazyInitConnectors` dex configuration field to the values.yaml.
* Change the default image to the d2iq fork, because upstream dex does not yet support the `lazyInitConnectors` field.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds support for the `lazyInitConnectors` field to the dex chart, and changes the default image to the d2iq fork. 
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
