### PR TITLE
feat: relax PDB for knative-serving activator and webhook

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: knative
-version: 0.5.1
+version: 0.5.2
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:
@@ -15,5 +15,5 @@ dependencies:
     version: 0.2.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 0.4.1
+    version: 0.4.2
     condition: serving.enabled

--- a/staging/knative/PATCHES.md
+++ b/staging/knative/PATCHES.md
@@ -1,0 +1,47 @@
+# Patches for knative charts
+
+Knative is not hosted via a helm repository upstream and the official recommended way to install is to either using another tool or using raw YAML manifests - https://knative.dev/docs/install/. Based on this, we don't use `helm dependency update` to update the subcharts here but instead use raw YAML manifests from upstream to update the chart here. Following lists the manual patches that needs to be applied whenever charts are bumped. 
+
+
+## Patch 1: Relax the PodDisruptionBudget policies
+
+Developed in order to fix https://d2iq.atlassian.net/browse/D2IQ-96590
+
+When fetching `serving-core.yaml` from [upstream](https://github.com/knative/serving/releases/download/knative-v1.9.2/serving-core.yaml) apply the following patch to it (if the latest version has moved the resources or has changed the fields on PDB please update this patch accordingly).
+
+1. Get the latest file
+```bash
+wget https://github.com/knative/serving/releases/download/knative-v1.9.2/serving-core.yaml
+```
+
+2. Create the patch kustomization
+
+```yaml
+cat <<EOF >>kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serving-core.yaml
+patches:
+  - target:
+      kind: PodDisruptionBudget
+      group: policy
+      version: v1
+    patch: |
+      - op: remove
+        path: /spec/minAvailable
+      - op: add
+        path: /spec/maxUnavailable
+        value: 1
+EOF
+```
+
+3. Apply the patch kustomization
+
+```bash
+kustomize build . > serving-core-patched.yaml
+```
+
+And then use the `serving-core-patched.yaml` to apply the changes to `charts/serving/templates/serving-core.yaml`
+
+<!-- More patches can be added here in future as needed. -->

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: serving
-version: 0.4.1
+version: 0.4.2
 kubeVersion: ">=1.23.0"
 description: "Knative Serving"
 sources:

--- a/staging/knative/charts/serving/templates/serving-core.yaml
+++ b/staging/knative/charts/serving/templates/serving-core.yaml
@@ -1770,7 +1770,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: "1.8.0"
 spec:
-  minAvailable: 80%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: activator
@@ -2479,7 +2479,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: "1.8.0"
 spec:
-  minAvailable: 80%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: webhook


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

Current PDB policies for knative serving activator and webhook make it impossible to run through upgrades when the corresponding HPA is not doing anything. In an ideal world, there will be ton of workloads which makes the HPA put up more pods and thus the current `minAvailable: 80%` might make sense. But most of the upgrades are run during downtime and in these scenarios HPA is not reliable to satisfy the `minAvailable: 80%` policy on PDB. 

This PR relaxes the PDB to instead use `maxUnavailable: 1` so that we can evict all pods when deployment has just 1 replica.


**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

https://d2iq.atlassian.net/browse/D2IQ-96590

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
