### PR TITLE
fix: increase the failureThreshold of the DKA liveness probe

### DIFF
--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.2.4"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.2.14
+version: 1.2.15
 home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mesosphere/dex-k8s-authenticator

--- a/staging/dex-k8s-authenticator/values.yaml
+++ b/staging/dex-k8s-authenticator/values.yaml
@@ -15,7 +15,7 @@ dexK8sAuthenticator:
   port: 5555
   debug: false
   livenessProbe:
-    failureThreshold: 3   # Under high load use 'failureThreshold: 6'
+    failureThreshold: 6   # Updated to 6 to prevent failures with >50 clusters (https://d2iq.atlassian.net/browse/D2IQ-94340)
     periodSeconds: 10   # Under high load use 'periodSeconds: 30'
     initialDelaySeconds: 10   # Under high load use 'initialDelaySeconds: 15'
     timeoutSeconds: 10   # Under high load use 'timeoutSeconds: 30'


### PR DESCRIPTION
This PR increases to 6 the failureThreshold for the DKA liveness probe to prevent failures when the number of clusters to parse is >=50. The long time required to read the configuration file made the application to not respond correctly to liveness probe, resulting in CrashLoopBackoff.
https://d2iq.atlassian.net/browse/D2IQ-94340

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
