### PR TITLE
feat: bump v2beta2 HPA to v2 in knative

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -9,11 +9,11 @@ icon: https://raw.githubusercontent.com/knative/docs/master/docs/images/logo/rgb
 appVersion: "v0.22.3"
 dependencies:
   - name: eventing
-    version: 0.2.0
+    version: 0.2.1
     condition: eventing.enabled
   - name: eventing-sources
     version: 0.2.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 0.4.2
+    version: 0.4.3
     condition: serving.enabled

--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: knative
-version: 0.5.2
+version: 0.6.0
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:

--- a/staging/knative/charts/eventing/Chart.yaml
+++ b/staging/knative/charts/eventing/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: eventing
-version: 0.2.0
+version: 0.2.1
 description: "Knative Eventing"
 sources:
 - https://github.com/knative/eventing

--- a/staging/knative/charts/eventing/templates/eventing.yaml
+++ b/staging/knative/charts/eventing/templates/eventing.yaml
@@ -3903,7 +3903,7 @@ spec:
           containerPort: 8008
 
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: broker-ingress-hpa
@@ -3923,7 +3923,7 @@ spec:
         type: Utilization
         averageUtilization: 70
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: broker-filter-hpa

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: serving
-version: 0.4.2
+version: 0.4.3
 kubeVersion: ">=1.23.0"
 description: "Knative Serving"
 sources:

--- a/staging/knative/charts/serving/templates/serving-core.yaml
+++ b/staging/knative/charts/serving/templates/serving-core.yaml
@@ -2443,7 +2443,7 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: webhook


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bumps knative charts to not use deprecated v2beta2 as its no longer supported in k8s 1.26+

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
Partially address https://d2iq.atlassian.net/browse/D2IQ-96638 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
