### PR TITLE
ci: Update out of date actions

### DIFF
--- a/.github/workflows/ct.yaml
+++ b/.github/workflows/ct.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install asdf plugins
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v2
 
       - name: Install Python
         uses: actions/setup-python@v4
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install asdf plugins
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v2
 
       - name: Test charts
         run: make ct.test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install asdf plugins
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v2
 
       - name: gather versions
         uses: endorama/asdf-parse-tool-versions@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: asdf-vm/actions/install@v2
 
       - name: gather versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: jimmidyson/asdf-parse-tool-versions@v2
         id: versions
 
       # We're switching directories for building the charts, so we need to set the helm and chart testing plugins


### PR DESCRIPTION
- ci: Upgrade asdf install action to v2
- ci: Use forked asdf parse versions

Otherwise this will break GHA once set-output is removed at end of May.