### PR TITLE
fix: bump knative serving version to v1.10.2

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: knative
-version: 1.10.2
+version: 1.10.3
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:
@@ -16,5 +16,5 @@ dependencies:
     version: 1.10.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 1.10.1
+    version: 1.10.2
     condition: serving.enabled


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

This PR bumps the knative serving version chart in the parent knative chart.

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
