### PR TITLE
feat: add utilisation metrics configs to prometheus-adapter rules

### DIFF
--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -13,6 +13,24 @@ data:
 {{- if or .Values.rules.default .Values.rules.custom }}
     rules:
 {{- if .Values.rules.default }}
+    - seriesQuery: 'node_memory_Active_bytes'
+      resources:
+        overrides:
+          node:
+            resource: node
+      name:
+        matches: "^(.*)_Active_bytes"
+        as: "${1}_percentage"
+      metricsQuery: 'avg_over_time(node_memory_Active_bytes[30d])/node_memory_MemTotal_bytes'
+    - seriesQuery: 'node_cpu_seconds_total'
+      resources:
+        overrides:
+          node:
+            resource: node
+      name:
+        matches: "^(.*)_seconds_total"
+        as: "${1}_percentage"
+      metricsQuery: '(1 - rate(node_cpu_seconds_total{mode="idle"}[30d]))'
     - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
       seriesFilters: []
       resources:


### PR DESCRIPTION
part of: [D2IQ-96682](https://d2iq.atlassian.net/browse/D2IQ-96682)
Added metrics config to expose average cpu and memory utilisation of nodes.

[D2IQ-96682]: https://d2iq.atlassian.net/browse/D2IQ-96682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ