### PR TITLE
fix(knative): Set WEBHOOK_PORT on net-istio-webhook deployment

### DIFF
--- a/staging/knative/Chart.yaml
+++ b/staging/knative/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: knative
-version: 1.10.3
+version: 1.10.4
 description: "Kubernetes-based platform to build, deploy, and manage modern serverless workloads"
 home: https://knative.dev/
 maintainers:
@@ -16,5 +16,5 @@ dependencies:
     version: 1.10.0
     condition: eventing-sources.enabled
   - name: serving
-    version: 1.10.2
+    version: 1.10.3
     condition: serving.enabled

--- a/staging/knative/charts/serving/Chart.yaml
+++ b/staging/knative/charts/serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: serving
-version: 1.10.2
+version: 1.10.3
 kubeVersion: ">=1.24.0"
 description: "Knative Serving"
 sources:

--- a/staging/knative/charts/serving/templates/net-istio.yaml
+++ b/staging/knative/charts/serving/templates/net-istio.yaml
@@ -418,6 +418,8 @@ spec:
               value: knative.dev/net-istio
             - name: WEBHOOK_NAME
               value: net-istio-webhook
+            - name: WEBHOOK_PORT
+              value: "8443"
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This PR fixes the error in the net-istio-webhook pod:
```
panic: failed to convert the environment variable "WEBHOOK_PORT" : strconv.Atoi: parsing "tcp://10.97.172.47:9090": invalid syntax

goroutine 1 [running]:
knative.dev/pkg/webhook.PortFromEnv(0xc000084730?)
	knative.dev/pkg@v0.0.0-20230418073056-dfad48eaa5d0/webhook/env.go:44 +0x125
main.main()
	knative.dev/net-istio/cmd/webhook/main.go:84 +0x7c
```

I have no idea why the `WEBHOOK_PORT` is set to that value, It's not defined on the deployment at all so it should use the default of `8443`. It was made configurable in https://github.com/knative-sandbox/net-istio/commit/8a63e68aa04c6fa25e227d6f48ba73c397f28ca4 but that sets it to the default port if the env var isn't found. 

This must have been missed on the last bump of knative.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://d2iq.atlassian.net/browse/D2IQ-97714

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
