### PR TITLE
fix(publish): Actually pass in env vars to command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ publish: ## Publishes changed helm charts to gh-pages
 publish: export LC_COLLATE := C
 publish: export TZ := UTC
 publish: tools.install.helm tools.install.helm-ct ; $(info $(M) publishing charts)
-	$(HACK_DIR)/charts/publish.sh $(PUBLISH_ENV)
+	$(PUBLISH_ENV) $(HACK_DIR)/charts/publish.sh
 
 .PHONY: ct.lint
 ct.lint: ## Run chart-testing (ct) linter against charts.


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
discovered a bug in the publish target when the job failed on latest change to publish the KPS chart, which added the subchart tarballs to .gitignore and requires `helm dep update` to run when packaging to include it. the envvars (which sets `HELM_DEP_UPDATE` to true) were not actually getting passed into the command.

```
Error: found in Chart.yaml, but missing in charts/ directory: kube-state-metrics, prometheus-node-exporter, grafana, prometheus-windows-exporter
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
