### PR TITLE
fix: add required flag to be able to view grafana dashboard

### DIFF
--- a/staging/kube-prometheus-stack/Chart.yaml
+++ b/staging/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 44.2.1
+version: 44.2.3
 appVersion: v0.62.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/staging/kube-prometheus-stack/patch/mesosphere/templates/ingress-rbac/grafana.yaml
+++ b/staging/kube-prometheus-stack/patch/mesosphere/templates/ingress-rbac/grafana.yaml
@@ -6,6 +6,7 @@ metadata:
   name: dkp-{{ template "kube-prometheus-stack.fullname" . }}-grafana-admin
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-grafana
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 {{- if .Values.grafana.ingress.labels }}
 {{ toYaml .Values.grafana.ingress.labels | indent 4 }}
 {{- end }}
@@ -28,6 +29,7 @@ metadata:
   name: dkp-{{ template "kube-prometheus-stack.fullname" . }}-grafana-view
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-grafana
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 {{- if .Values.grafana.ingress.labels }}
 {{ toYaml .Values.grafana.ingress.labels | indent 4 }}
 {{- end }}
@@ -54,6 +56,7 @@ metadata:
   name: dkp-{{ template "kube-prometheus-stack.fullname" . }}-grafana-edit
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-grafana
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 {{- if .Values.grafana.ingress.labels }}
 {{ toYaml .Values.grafana.ingress.labels | indent 4 }}
 {{- end }}

--- a/staging/kube-prometheus-stack/templates/ingress-rbac/grafana.yaml
+++ b/staging/kube-prometheus-stack/templates/ingress-rbac/grafana.yaml
@@ -6,6 +6,7 @@ metadata:
   name: dkp-{{ template "kube-prometheus-stack.fullname" . }}-grafana-admin
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-grafana
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 {{- if .Values.grafana.ingress.labels }}
 {{ toYaml .Values.grafana.ingress.labels | indent 4 }}
 {{- end }}
@@ -28,6 +29,7 @@ metadata:
   name: dkp-{{ template "kube-prometheus-stack.fullname" . }}-grafana-view
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-grafana
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 {{- if .Values.grafana.ingress.labels }}
 {{ toYaml .Values.grafana.ingress.labels | indent 4 }}
 {{- end }}
@@ -54,6 +56,7 @@ metadata:
   name: dkp-{{ template "kube-prometheus-stack.fullname" . }}-grafana-edit
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-grafana
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 {{- if .Values.grafana.ingress.labels }}
 {{ toYaml .Values.grafana.ingress.labels | indent 4 }}
 {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
backports https://github.com/mesosphere/charts/pull/1448 into previous KPS release (for dkp 2.5)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://d2iq.atlassian.net/browse/D2IQ-98716



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
