### PR TITLE
fix: multiple chart linting failing

### DIFF
--- a/hack/charts/publish.sh
+++ b/hack/charts/publish.sh
@@ -76,7 +76,7 @@ package() {
 lint() {
   logGroupStart "Linting charts"
 
-  helm lint "${CHARTS[*]}"
+  helm lint "${CHARTS[@]}"
 
   logGroupEnd
 }

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.13.3
+version: 2.13.4
 appVersion: 2.37.0
 description: Dex
 keywords:

--- a/staging/dex-k8s-authenticator/Chart.yaml
+++ b/staging/dex-k8s-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.2.4"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.2.17
+version: 1.2.18
 home: https://github.com/mesosphere/charts
 sources:
 - https://github.com/mesosphere/dex-k8s-authenticator


### PR DESCRIPTION
This PR fixes an issue when more than one chart is modified and passed to Helm for linting. Now, the space between those is no longer interpreted as a part of the path. 

The failure: https://github.com/mesosphere/charts/actions/runs/6637202644

Previous behavior:
```
▶ installing helm
helm 3.10.1 is already installed
▶ installing helm-ct
helm-ct 3.7.1 is already installed
▶ publishing charts
================================================================================
Finding changed charts
================================================================================
Adding stable/dex to charts list
Adding staging/dex-k8s-authenticator to charts list
================================================================================
Linting charts
================================================================================
==> Linting stable/dex staging/dex-k8s-authenticator
Error unable to check Chart.yaml file in chart: stat stable/dex staging/dex-k8s-authenticator/Chart.yaml: no such file or directory

Error: 1 chart(s) linted, 1 chart(s) failed
make: *** [Makefile:156: publish] Error 1
```

Now:

```
▶ installing helm
helm 3.10.1 is already installed
▶ installing helm-ct
helm-ct 3.7.1 is already installed
▶ publishing charts
================================================================================
Finding changed charts
================================================================================
Adding stable/dex to charts list
Adding staging/dex-k8s-authenticator to charts list
================================================================================
Linting charts
================================================================================
==> Linting stable/dex

==> Linting staging/dex-k8s-authenticator
[INFO] Chart.yaml: icon is recommended

2 chart(s) linted, 0 chart(s) failed
```


