### PR TITLE
fix: convert the `object-bucket-claim` Job into a Helm hook

### DIFF
--- a/stable/object-bucket-claim/Chart.yaml
+++ b/stable/object-bucket-claim/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for ObjectBucketClaim to be consumed by other applicat
 home: https://github.com/mesosphere/charts
 keywords:
   - kommander
-version: 0.1.8
-appVersion: "0.1.7"
+version: 0.1.9
+appVersion: "0.1.9"
 maintainers:
   - name: cwyl02
   - name: takirala

--- a/stable/object-bucket-claim/README.md
+++ b/stable/object-bucket-claim/README.md
@@ -26,7 +26,6 @@ dkp:
     # generateBucketName: ceph-bkt
     storageClassName: s3-provider-sc
     priorityClassName: dkp-critical-priority
-    ttlSecondsAfterFinished: 100
 
     labels: {}
     additionalConfig:
@@ -50,7 +49,6 @@ their default values. (`$app` is `velero`|`loki`|`your-app` in the example above
 | `dkp.$app.additionalConfig.maxObjects` | Limit of number of S3 objects this bucket can hold                       | ""      |
 | `dkp.$app.additionalConfig.maxSize`    | Limit of the storage this S3 bucket can use from the S3 storage provider | ""      |
 | `dkp.$app.priorityClassName`           | Priority class to set on pods                                            | ""      |
-| `dkp.$app.ttlSecondsAfterFinished`     | Number of seconds to clean up the Job after it has finished              | ""      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/object-bucket-claim/templates/object-bucket-claim.yaml
+++ b/stable/object-bucket-claim/templates/object-bucket-claim.yaml
@@ -29,11 +29,19 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: check-{{ $config.bucketName }}
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: check-{{ $config.bucketName }}
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -49,6 +57,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: check-{{ $config.bucketName }}
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-weight: "-4"
+    helm.sh/hook-delete-policy: before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -62,11 +74,11 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: check-{{ $config.bucketName }}
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   backoffLimit: 12
-  {{- if $config.ttlSecondsAfterFinished }}
-  ttlSecondsAfterFinished: {{ $config.ttlSecondsAfterFinished }}
-  {{- end }}
   template:
     metadata:
       name: check-{{ $config.bucketName }}

--- a/stable/object-bucket-claim/templates/object-bucket-claim.yaml
+++ b/stable/object-bucket-claim/templates/object-bucket-claim.yaml
@@ -28,7 +28,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: check-{{ $config.bucketName }}
+  name: object-bucket-claims-check-{{ $config.bucketName }}
   annotations:
     helm.sh/hook: post-install, post-upgrade
     helm.sh/hook-weight: "-5"
@@ -37,7 +37,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: check-{{ $config.bucketName }}
+  name: object-bucket-claims-check-{{ $config.bucketName }}
   annotations:
     helm.sh/hook: post-install, post-upgrade
     helm.sh/hook-weight: "-5"
@@ -56,7 +56,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: check-{{ $config.bucketName }}
+  name: object-bucket-claims-check-{{ $config.bucketName }}
   annotations:
     helm.sh/hook: post-install, post-upgrade
     helm.sh/hook-weight: "-4"
@@ -64,16 +64,16 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: check-{{ $config.bucketName }}
+  name: object-bucket-claims-check-{{ $config.bucketName }}
 subjects:
   - kind: ServiceAccount
-    name: check-{{ $config.bucketName }}
+    name: object-bucket-claims-check-{{ $config.bucketName }}
     namespace: {{ $.Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: check-{{ $config.bucketName }}
+  name: object-bucket-claims-check-{{ $config.bucketName }}
   annotations:
     helm.sh/hook: post-install, post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
@@ -81,9 +81,9 @@ spec:
   backoffLimit: 12
   template:
     metadata:
-      name: check-{{ $config.bucketName }}
+      name: object-bucket-claims-check-{{ $config.bucketName }}
     spec:
-      serviceAccountName: check-{{ $config.bucketName }}
+      serviceAccountName: object-bucket-claims-check-{{ $config.bucketName }}
       restartPolicy: OnFailure
       {{- if $config.priorityClassName }}
       priorityClassName: "{{ $config.priorityClassName }}"

--- a/stable/object-bucket-claim/values.yaml
+++ b/stable/object-bucket-claim/values.yaml
@@ -11,7 +11,6 @@ dkp:
   #   labels: {}
   #   priorityClassName: dkp-critical-priority
   #   # it is required to set ttl for jobs to avoid immutable errors during upgrades if certain spec fields change
-  #   ttlSecondsAfterFinished: 100
   #   additionalConfig:
   #     # maxObjects: "1000"
   #     # in string format like "2G", minimum is "4K"


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
Autoremoval of completed jobs as triggered by the `ttlSecondsAfterFinished` interferes with proper functioning of the Helm controller in two ways:
- when the Job somehow gets removed before the controller manages to check for its completion, the controller fails reconciliation of the corresponding HelmRelease
- a rollback to remediate a failed upgrade will fail if the versions have different immutable fields (`podTemplateSpec`, etc), as the rollback attempt normally happens before the Job is deleted

This PR makes Helm execute this Job as a Helm hook, similarly to how all other Jobs in `mesosphere/charts` are managed. In addition, to avoid a potential collision with the old non-hook version of the chart, the Job is renamed.

**Which issue(s) this PR fixes**:
- Fixes https://d2iq.atlassian.net/browse/D2IQ-99927 (might be a partial fix, because of the Velero breakage https://d2iq.atlassian.net/browse/D2IQ-99936)

**Special notes for your reviewer**:
Perfomed an additional manual test on Kommander from the current `main`:
- made the Velero HelmRelease fail reconciliation (by setting an invalid image repository)
- reinstalled rook-ceph-cluster
- waited until **remediations** of `obect-bucket-claims` started to fail
- cleared Velero's values, so that it can be reconciled normally
- waited until `obect-bucket-claims` got successfully reconciled

**Does this PR introduce a user-facing change?**:
```release-note
The object-bucket-claim chart no longer uses the `ttlSecondsAfterFinished` value. 
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
