### PR TITLE
fix: use GITHUB_TOKEN to publish charts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,4 +47,4 @@ jobs:
         env:
           COMMIT_EMAIL: "ci@mesosphere.com"
           COMMIT_USERNAME: "D2iQ CI"
-          GIT_REMOTE_URL: "https://x-access-token:${{ secrets.MERGEBOT_TOKEN }}@github.com/mesosphere/charts.git"
+          GIT_REMOTE_URL: "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/mesosphere/charts.git"


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
MERGEBOT_TOKEN is no longer valid (and should be redundant)

**Which issue(s) this PR fixes**:
The `publish` workflow

**Special notes for your reviewer**:
Not tested; it might be necessary to add more write permissions to GITHUB_TOKEN (I don't see what they are)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
