### PR TITLE
feat(kube-oidc-proxy): add option to specify system CA certs path

### DIFF
--- a/staging/kube-oidc-proxy/Chart.yaml
+++ b/staging/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/mesosphere/charts
 name: kube-oidc-proxy
-version: 0.3.3
+version: 0.3.4
 sources:
 - https://github.com/jetstack/kube-oidc-proxy
 maintainers:

--- a/staging/kube-oidc-proxy/templates/deployment.yaml
+++ b/staging/kube-oidc-proxy/templates/deployment.yaml
@@ -54,7 +54,11 @@ spec:
           - "--oidc-issuer-url=$(OIDC_ISSUER_URL)"
           - "--oidc-username-claim=$(OIDC_USERNAME_CLAIM)"
           {{- if .Values.oidc.caSystemDefault }}
+          {{- if .Values.oidc.caSystemDefaultPath }}
+          - "--oidc-ca-file={{ .Values.oidc.caSystemDefaultPath }}"
+          {{- else }}
           # Not setting `--oidc-ca-file` to use CA bundle from the image
+          {{- end }}
           {{- else if or .Values.oidc.caPEM .Values.oidc.caSecretName .Values.oidc.caCertPemHostPath }}
           - "--oidc-ca-file=/etc/oidc/oidc-ca.pem"
           {{- else }}

--- a/staging/kube-oidc-proxy/values.yaml
+++ b/staging/kube-oidc-proxy/values.yaml
@@ -40,6 +40,9 @@ oidc:
   # caSystemDefault, will disable (not set) the --oidc-ca-file flag
   # to be able to use container image available root CA's
   caSystemDefault: false
+  # If provided the path will be used as CA certificate in the deployment
+  # container.
+  caSystemDefaultPath: ""
   # CA cert that will verify TLS connection to OIDC issuer URL.
   # If not provided service account CA will be used.
   #


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
In order to use [maintained](https://github.com/TremoloSecurity/kube-oidc-proxy) and updated `kube-oidc-proxy` version we'd need to specify path to CA certs in container as a KOP flag.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://d2iq.atlassian.net/browse/D2IQ-100007

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
