### PR TITLE
chore(kommander-cert-federation): bump kubefed cli version to v0.10.4

### DIFF
--- a/stable/kommander-cert-federation/Chart.yaml
+++ b/stable/kommander-cert-federation/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: "0.0.8"
+appVersion: "0.0.9"
 description: A Helm chart to create and federate TLS certificates used by kommander internals
 home: https://github.com/mesosphere/charts
 name: kommander-cert-federation
 type: application
-version: 0.0.8
+version: 0.0.9
 maintainers:
   - name: mikolajb
   - name: takirala

--- a/stable/kommander-cert-federation/templates/cert-federation.yaml
+++ b/stable/kommander-cert-federation/templates/cert-federation.yaml
@@ -124,7 +124,7 @@ spec:
             echo "{{ .Values.secretName }} secret patched"
             EOF
       - name: federate-secret
-        image: quay.io/kubernetes-multicluster/kubefed:v0.9.1
+        image: ghcr.io/mesosphere/kubefed:v0.10.4
         command:
           - sh
           - "-c"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Bumps `kubefed` container image to latest built by d2iq

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://d2iq.atlassian.net/browse/D2IQ-100008

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
