### PR TITLE
feat: remove deprecated thanos traefik api

### DIFF
--- a/staging/thanos-traefik/Chart.yaml
+++ b/staging/thanos-traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: thanos-traefik
 description: A Helm chart for Kubernetes that exposes thanos GRPC service over traefik with mTLS termination
 type: application
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.0.2
+appVersion: "0.0.2"
 maintainers:
 - name: mhrabovcin
   email: mhrabovcin.c@d2iq.com

--- a/staging/thanos-traefik/templates/ingressroutetcp.yaml
+++ b/staging/thanos-traefik/templates/ingressroutetcp.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.enabled }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: {{ include "thanos-traefik.fullname" . }}-ingress
@@ -21,7 +21,7 @@ spec:
     passthrough: false
 
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: TLSOption
 metadata:
   name: {{ include "thanos-traefik.fullname" . }}-tls-options


### PR DESCRIPTION
**What this PR does/ why we need it**:
Remove use of deprecated Traefik k8s APIs [thanos-traefik]

**Which issue(s) this PR fixes**:
https://jira.nutanix.com/browse/NCN-104783