### PR TITLE
fix: download deps before linting

### DIFF
--- a/hack/charts/publish.sh
+++ b/hack/charts/publish.sh
@@ -160,12 +160,12 @@ run_cmd() {
     exit 0
   fi
 
-  if [[ "${HELM_LINT}" == "true" ]]; then
-    lint
-  fi
-
   if [[ "${HELM_DEP_UPDATE}" == "true" ]]; then
     depUpdate
+  fi
+
+  if [[ "${HELM_LINT}" == "true" ]]; then
+    lint
   fi
 
   package


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Run deps download before linting to avoid issues with `kube-prometheus-stack` publishing.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
