### PR TITLE
feat: allow disabling cosi-bucket-kit chart easily

### DIFF
--- a/stable/cosi-bucket-kit/Chart.yaml
+++ b/stable/cosi-bucket-kit/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - bucket
   - storage
   - ceph
-version: 0.0.1-alpha.0
-appVersion: 0.0.1-alpha.0
+version: 0.0.1-alpha.1
+appVersion: 0.0.1-alpha.1
 maintainers:
   - name: takirala

--- a/stable/cosi-bucket-kit/templates/bucketaccessclasses.yaml
+++ b/stable/cosi-bucket-kit/templates/bucketaccessclasses.yaml
@@ -1,4 +1,5 @@
-{{- range .Values.bucketAccessClasses }}
+{{- if .Values.cosiBucketKit.enabled }}
+{{- range .Values.cosiBucketKit.bucketAccessClasses }}
 apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketAccessClass
 metadata:
@@ -8,5 +9,6 @@ authenticationType: {{ .authenticationType }}
 {{- if .parameters }}
 parameters:
 {{ toYaml .parameters | indent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/cosi-bucket-kit/templates/bucketaccesses.yaml
+++ b/stable/cosi-bucket-kit/templates/bucketaccesses.yaml
@@ -1,4 +1,5 @@
-{{- range .Values.bucketAccesses }}
+{{- if .Values.cosiBucketKit.enabled }}
+{{- range .Values.cosiBucketKit.bucketAccesses }}
 apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketAccess
 metadata:
@@ -9,4 +10,5 @@ spec:
   bucketClaimName: {{ .bucketClaimName }}
   protocol: {{ .protocol }}
   credentialsSecretName: {{ .credentialsSecretName }}
+{{- end }}
 {{- end }}

--- a/stable/cosi-bucket-kit/templates/bucketclaims.yaml
+++ b/stable/cosi-bucket-kit/templates/bucketclaims.yaml
@@ -1,4 +1,5 @@
-{{- range .Values.bucketClaims }}
+{{- if .Values.cosiBucketKit.enabled }}
+{{- range .Values.cosiBucketKit.bucketClaims }}
 apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketClaim
 metadata:
@@ -10,4 +11,5 @@ spec:
     {{- range .protocols }}
     - {{ . }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/cosi-bucket-kit/templates/bucketclasses.yaml
+++ b/stable/cosi-bucket-kit/templates/bucketclasses.yaml
@@ -1,4 +1,5 @@
-{{- range .Values.bucketClasses }}
+{{- if .Values.cosiBucketKit.enabled }}
+{{- range .Values.cosiBucketKit.bucketClasses }}
 apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketClass
 metadata:
@@ -8,5 +9,6 @@ deletionPolicy: {{ .deletionPolicy }}
 {{- if .parameters }}
 parameters:
 {{ toYaml .parameters | indent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/cosi-bucket-kit/templates/ceph-provider.yaml
+++ b/stable/cosi-bucket-kit/templates/ceph-provider.yaml
@@ -1,5 +1,6 @@
-{{- if .Values.cosiProviders }}
-{{- with .Values.cosiProviders.ceph }}
+{{- if .Values.cosiBucketKit.enabled }}
+{{- if .Values.cosiBucketKit.cosiProviders }}
+{{- with .Values.cosiBucketKit.cosiProviders.ceph }}
 {{- if .driver.enabled }}
 apiVersion: ceph.rook.io/v1
 kind: CephCOSIDriver
@@ -18,6 +19,7 @@ metadata:
   namespace: {{ .adminuser.namespace }}
 spec:
 {{ toYaml .adminuser.spec | indent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/cosi-bucket-kit/values.yaml
+++ b/stable/cosi-bucket-kit/values.yaml
@@ -1,37 +1,40 @@
-# # Cluster scoped resources
-# bucketClasses:
+cosiBucketKit:
+  # Setting this value to false will disable all the manifests in this chart.
+  # Default to false because this chart assumes CRDs are already installed, and it is the responsibility of the user to ensure the presence of CRDs.
+  enabled: false
+#  # Cluster scoped resources
+#  bucketClasses:
 #   - name: example-bucket-class
 #     driverName: example.driver.com
 #     deletionPolicy: Delete
 #     parameters:
 #       param1: value1
 #       param2: value2
-
-# bucketAccessClasses:
+#  bucketAccessClasses:
 #   - name: example-bucket-class
 #     driverName: example.driver.com
 #     authenticationType: KEY # KEY or IAM (Implicit).
 #     parameters:
 #       param1: value1
 #       param2: value2
-
-# # Namespace scoped resources
-# bucketClaims:
+#
+#  # Namespace scoped resources
+#  bucketClaims:
 #   - name: example-bucket-claim
 #     namespace: default
 #     bucketClassName: example-bucket-class
 #     protocols: # 1 or more of S3, Azure, GCS
 #       - s3
-
-# bucketAccesses:
+#  bucketAccesses:
 #   - name: example-bucket-access
 #     namespace: default
 #     bucketAccessClassName: example-bucket-access-class
 #     bucketClaimName: example-bucket-claim
 #     protocol: s3 # Or azure or gcs
 #     credentialsSecretName: example-credentials-secret
-
-# cosiProviders:
+#
+#  # Drivers for COSI.
+#  cosiProviders:
 #   # Add more supported COSI providers here
 #   ceph:
 #     driver:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

chore: update the `cosi-bucket-kit` chart such that:
- It can be disabled easily with a top level boolean
- Nest all the fields in values.yaml inside a new top level `cosi-bucket-kit` key.  

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

This makes it easy to deploy the cosi-bucket-kit as a chart inside other components (harbor etc.,)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.nutanix.com/browse/NCN-105274

**Special notes for your reviewer**:

Linter is expected to fail cuz upgrades will break from previous version to current version. This is fine cuz the chart is in alpha version and is not used anywhere yet.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
