### PR TITLE
fix: Template resource names of cosi nutanix driver

### DIFF
--- a/staging/cosi-driver-nutanix/Chart.yaml
+++ b/staging/cosi-driver-nutanix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cosi-driver-nutanix
 description: A Helm chart to deploy Nutanix COSI driver
 type: application
-version: 0.0.5
-appVersion: "v0.0.5"
+version: 0.0.6
+appVersion: "v0.0.6"
 icon: https://www.nutanix.com/content/dam/nutanix/global/icons/products/svg/Nutanix-Objects-40.svg
 maintainers:
   - name: nutanix-cloud-native-bot

--- a/staging/cosi-driver-nutanix/templates/_helpers.tpl
+++ b/staging/cosi-driver-nutanix/templates/_helpers.tpl
@@ -55,9 +55,9 @@ Create the name of the service account to use
 */}}
 {{- define "cosi-driver-nutanix.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "cosi-driver-nutanix.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "cosi-driver-nutanix.name" .) .Values.serviceAccount.nameOverride }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.nameOverride }}
 {{- end }}
 {{- end }}
 

--- a/staging/cosi-driver-nutanix/templates/deploy.yaml
+++ b/staging/cosi-driver-nutanix/templates/deploy.yaml
@@ -5,7 +5,7 @@ metadata:
 {{ include "cosi-driver-nutanix.resource.annotations" . | indent 4 }}
   labels:
 {{ include "cosi-driver-nutanix.resource.labels" . | indent 4 }}
-  name: objectstorage-provisioner
+  name: {{ include "cosi-driver-nutanix.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minReadySeconds: 30
@@ -53,7 +53,7 @@ spec:
         volumeMounts:
           - mountPath: /var/lib/cosi
             name: socket
-      serviceAccountName: objectstorage-provisioner-sa
+      serviceAccountName: {{ include "cosi-driver-nutanix.serviceAccountName" . }}
       volumes:
       - emptyDir: {}
         name: socket

--- a/staging/cosi-driver-nutanix/templates/rbac.yaml
+++ b/staging/cosi-driver-nutanix/templates/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
 {{ include "cosi-driver-nutanix.resource.annotations" . | indent 4 }}
   labels:
 {{ include "cosi-driver-nutanix.resource.labels" . | indent 4 }}
-  name: objectstorage-provisioner-role
+  name: {{ include "cosi-driver-nutanix.name" . }}-role
 rules:
   - apiGroups: ["objectstorage.k8s.io"]
     resources: ["buckets", "bucketaccesses","buckets/status", "bucketaccesses/status", "bucketaccessclasses", "bucketaccessclasses/status", "bucketclaims", "bucketclaims/status"]
@@ -24,12 +24,12 @@ metadata:
 {{ include "cosi-driver-nutanix.resource.annotations" . | indent 4 }}
   labels:
 {{ include "cosi-driver-nutanix.resource.labels" . | indent 4 }}
-  name: objectstorage-provisioner-role-binding
+  name: {{ include "cosi-driver-nutanix.name" . }}-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: objectstorage-provisioner-role
+  name: {{ include "cosi-driver-nutanix.name" . }}-role
 subjects:
 - kind: ServiceAccount
-  name: objectstorage-provisioner-sa
+  name: {{ include "cosi-driver-nutanix.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/staging/cosi-driver-nutanix/templates/sa.yaml
+++ b/staging/cosi-driver-nutanix/templates/sa.yaml
@@ -5,5 +5,5 @@ metadata:
 {{ include "cosi-driver-nutanix.resource.annotations" . | indent 4 }}
   labels:
 {{ include "cosi-driver-nutanix.resource.labels" . | indent 4 }}
-  name: objectstorage-provisioner-sa
+  name: {{ include "cosi-driver-nutanix.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/staging/cosi-driver-nutanix/templates/secret.yaml
+++ b/staging/cosi-driver-nutanix/templates/secret.yaml
@@ -6,11 +6,11 @@ metadata:
 {{ include "cosi-driver-nutanix.resource.annotations" . | indent 4 }}
   labels:
 {{ include "cosi-driver-nutanix.resource.labels" . | indent 4 }}
-  name: objectstorage-provisioner
+  name: {{ include "cosi-driver-nutanix.name" . }}
   namespace: {{ .Release.Namespace }}
 stringData:
   ACCESS_KEY: {{ required "access_key is required." .Values.secret.access_key | quote }}
-  ACCOUNT_NAME: {{ .Values.account_name | quote }}
+  ACCOUNT_NAME: {{ .Values.secret.account_name | quote }}
   ENDPOINT: {{ required "endpoint is required." .Values.secret.endpoint | quote }}
   PC_SECRET: "{{ required "pc_ip is required." .Values.secret.pc_ip }}:{{ required "pc_port is required." .Values.secret.pc_port }}:{{ required "pc_username is required." .Values.secret.pc_username }}:{{ required "pc_password is required." .Values.secret.pc_password }}"
   SECRET_KEY: {{ required "secret_key is required." .Values.secret.secret_key | quote }}

--- a/staging/cosi-driver-nutanix/values.yaml
+++ b/staging/cosi-driver-nutanix/values.yaml
@@ -2,6 +2,10 @@
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  create: true
+  nameOverride: ""
+
 # cosi-driver-nutanix sidecar image.
 image:
   registry: ghcr.io
@@ -9,6 +13,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   pullPolicy: IfNotPresent
+
+replicas: 1
 
 # Secret used by the cosi-driver-nutanix sidecar for objects management.
 secret:
@@ -32,6 +38,7 @@ secret:
 
 # COSI central controller specifications.
 cosiController:
+  replicas: 1
   enabled: true
   logLevel: 5
   image:


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
We need to template resource names to prevent resource clashing and make them distinguishable.

**Which issue(s) this PR fixes**:
no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
