### PR TITLE
fix(cosi-bucket-kit): Correctly parse BucketInfo

### DIFF
--- a/stable/cosi-bucket-kit/Chart.yaml
+++ b/stable/cosi-bucket-kit/Chart.yaml
@@ -8,8 +8,9 @@ keywords:
   - bucket
   - storage
   - ceph
-version: 0.0.3
-appVersion: 0.0.3
+version: 0.0.4
+appVersion: 0.0.4
 maintainers:
   - name: takirala
   - name: mhrabovcin
+  - name: jimmidyson

--- a/stable/cosi-bucket-kit/templates/job-readiness.yaml
+++ b/stable/cosi-bucket-kit/templates/job-readiness.yaml
@@ -167,9 +167,6 @@ spec:
               set -o pipefail
               set -e
 
-              echo() {
-                  command echo $(date) "$@"
-              }
               {{- if gt (len .Values.cosiBucketKit.bucketAccesses) 1 }}
               {{- fail "Error: .Values.cosiBucketKit.bucketAccesses array size must not exceed 1 if harbor transformation is enabled." }}
               {{- end }}
@@ -179,17 +176,18 @@ spec:
               {{- $ns := .Release.Namespace -}}
               {{- range .Values.cosiBucketKit.bucketAccesses }}
               # Update the cosi secret with harbor specific keys.
+              bucketInfoJSON="$(kubectl get secret {{ .credentialsSecretName }} -n {{ $ns }} -o json | jq -r '.data.BucketInfo | @base64d | fromjson')"
               kubectl create secret generic {{ .credentialsSecretName }} -n {{ $ns }} \
-                --from-literal=REGISTRY_STORAGE_S3_ACCESSKEY=$(kubectl get secret {{ .credentialsSecretName }} -n {{ $ns }} -o jsonpath="{.data.BucketInfo}" | jq -r '.spec.secretS3.accessKeyID | @base64d') \
-                --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=$(kubectl get secret {{ .credentialsSecretName }} -n {{ $ns }} -o jsonpath="{.data.BucketInfo}" | jq -r '.spec.secretS3.accessSecretKey | @base64d') \
-                --from-literal=REGISTRY_STORAGE_S3_REGION=$(kubectl get secret {{ .credentialsSecretName }} -n {{ $ns }} -o jsonpath="{.data.BucketInfo}" | jq -r '(.spec.secretS3.region // ("none" | @base64)) | @base64d') \
-                --from-literal=REGISTRY_STORAGE_S3_REGIONENDPOINT=$(kubectl get secret {{ .credentialsSecretName }} -n {{ $ns }} -o jsonpath="{.data.BucketInfo}" | jq -r '.spec.secretS3.endpoint | @base64d') \
-                --from-literal=REGISTRY_STORAGE_S3_BUCKET=$(kubectl get secret {{ .credentialsSecretName }} -n {{ $ns }} -o jsonpath="{.data.BucketInfo}" | jq -r '.spec.bucketName | @base64d') \
+                --from-literal=REGISTRY_STORAGE_S3_ACCESSKEY=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.accessKeyID') \
+                --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.accessSecretKey') \
+                --from-literal=REGISTRY_STORAGE_S3_REGION=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.region // "none"') \
+                --from-literal=REGISTRY_STORAGE_S3_REGIONENDPOINT=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.endpoint') \
+                --from-literal=REGISTRY_STORAGE_S3_BUCKET=$(echo "${bucketInfoJSON}" | jq -r '.spec.bucketName') \
                 --from-literal=REGISTRY_STORAGE_S3_SECURE=false \
                 --from-literal=REGISTRY_STORAGE_REDIRECT_DISABLE=true \
                 --dry-run=client -o yaml | kubectl apply --server-side --force-conflicts -f -
               # Create a configmap with the name of the secret from above.
-              kubectl create configmap {{ $cmName }} -n {{ $cmNamespace }} \
+              kubectl create configmap {{ $cmName }} -n {{ $cmNamespace }} --dry-run=client -o yaml \
                 --from-file=values.yaml=<(cat <<'EOF'
               persistence:
                 imageChartStorage:
@@ -197,8 +195,7 @@ spec:
                   s3:
                     existingSecret: {{ .credentialsSecretName }}
               EOF
-                ) \
-                --dry-run=client -o yaml | kubectl apply -f -
+              ) | kubectl apply --server-side --force-conflicts -f -
               {{- end }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
This fixes a bug that I recently introduced in the parsing of the BucketInfo value in the COSI secret. This commit refactors the fetching of the BucketInfo JSON so it does that only once and then parses the values from that JSON rather than fetching the secret for every field.

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
