### PR TITLE
fix: parse region in BucketInfo correctly

### DIFF
--- a/stable/cosi-bucket-kit/Chart.yaml
+++ b/stable/cosi-bucket-kit/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - bucket
   - storage
   - ceph
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 maintainers:
   - name: takirala
   - name: mhrabovcin

--- a/stable/cosi-bucket-kit/templates/job-readiness.yaml
+++ b/stable/cosi-bucket-kit/templates/job-readiness.yaml
@@ -180,7 +180,7 @@ spec:
               kubectl create secret generic {{ .credentialsSecretName }} -n {{ $ns }} \
                 --from-literal=REGISTRY_STORAGE_S3_ACCESSKEY=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.accessKeyID') \
                 --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.accessSecretKey') \
-                --from-literal=REGISTRY_STORAGE_S3_REGION=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.region // "none"') \
+                --from-literal=REGISTRY_STORAGE_S3_REGION=$(echo "${bucketInfoJSON}" | jq -r 'if (.spec.secretS3.region // "") == "" then "none" else .spec.secretS3.region end') \
                 --from-literal=REGISTRY_STORAGE_S3_REGIONENDPOINT=$(echo "${bucketInfoJSON}" | jq -r '.spec.secretS3.endpoint') \
                 --from-literal=REGISTRY_STORAGE_S3_BUCKET=$(echo "${bucketInfoJSON}" | jq -r '.spec.bucketName') \
                 --from-literal=REGISTRY_STORAGE_S3_SECURE=false \


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

Tested with following json contents:
```bash
❯ echo '{"metadata": {"name": "valid"},"spec":{"secretS3":{"region":"us-east-1"}}}' | jq -r 'if (.spec.secretS3.region // "") == "" then "none" else .spec.secretS3.region end'                                                                       13:18:04
us-east-1
❯ echo '{"metadata": {"name": "valid"},"spec":{"secretS3":{"region":""}}}' | jq -r 'if (.spec.secretS3.region // "") == "" then "none" else .spec.secretS3.region end'                                                                                13:18:31
none
 ❯ echo '{"metadata": {"name": "valid"},"spec":{"secretS3":{"foo-region":""}}}' | jq -r 'if (.spec.secretS3.region // "") == "" then "none" else .spec.secretS3.region end'                                                                            13:18:42
none
❯ echo '{"metadata": {"name": "valid"},"spec":{"foo-secretS3":{"region":""}}}' | jq -r 'if (.spec.secretS3.region // "") == "" then "none" else .spec.secretS3.region end'                                                                            13:18:49
none
❯ echo '{"metadata": {"name": "valid"},"foo-spec":{"secretS3":{"region":""}}}' | jq -r 'if (.spec.secretS3.region // "") == "" then "none" else .spec.secretS3.region end'                                                                            13:19:02
none
```

This asserts the handing of empty region, non empty region, absence of region key.

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
