### PR TITLE
feat: Add cilium-hubble-traefik chart

### DIFF
--- a/staging/cilium-hubble-relay-traefik/.helmignore
+++ b/staging/cilium-hubble-relay-traefik/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/staging/cilium-hubble-relay-traefik/Chart.yaml
+++ b/staging/cilium-hubble-relay-traefik/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: cilium-hubble-relay-traefik
+description: A Helm chart for Kubernetes that exposes the Cilium Hubble Relay gRPC service over traefik. TLS passthrough is enabled, because Hubble Relay terminates mTLS.
+type: application
+version: 0.0.1
+appVersion: "0.0.1"
+maintainers:
+- name: dlipovetsky
+  email: daniel.lipovetsky@nutanix.com

--- a/staging/cilium-hubble-relay-traefik/templates/_helpers.tpl
+++ b/staging/cilium-hubble-relay-traefik/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cilium-hubble-relay-traefik.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cilium-hubble-relay-traefik.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cilium-hubble-relay-traefik.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cilium-hubble-relay-traefik.labels" -}}
+helm.sh/chart: {{ include "cilium-hubble-relay-traefik.chart" . }}
+{{ include "cilium-hubble-relay-traefik.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cilium-hubble-relay-traefik.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cilium-hubble-relay-traefik.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/staging/cilium-hubble-relay-traefik/templates/ingressroutetcp.yaml
+++ b/staging/cilium-hubble-relay-traefik/templates/ingressroutetcp.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.enabled }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ include "cilium-hubble-relay-traefik.fullname" . }}-ingress
+  labels:
+{{ include "cilium-hubble-relay-traefik.labels" . | indent 4 }}
+spec:
+  entryPoints:
+    {{- toYaml .Values.route.endpoints | nindent 4}}
+  routes:
+    - match: HostSNI(`{{ .Values.route.sni }}`)
+      services:
+      {{- toYaml .Values.route.services | nindent 6 }}
+  tls:
+    passthrough: true
+{{ end }}

--- a/staging/cilium-hubble-relay-traefik/values.yaml
+++ b/staging/cilium-hubble-relay-traefik/values.yaml
@@ -1,0 +1,25 @@
+# Default values for cilium-hubble-relay-traefik.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# If true, the chart creates an ingress route for the Cilium Hubble Relay service.
+# Otherwise, the chart does nothing.
+enabled: true
+
+# Configuration options for the route.
+route:
+  # These are the traefik endpoints where the route is configured.
+  endpoints:
+    - websecure
+
+  # Hostname that will be used to match the route. The Cilium Hubble Relay client
+  # must send this exact value in the SNI header of its request.
+  sni: hubble.hubble-relay.cilium.io
+
+  # The Hubble Cilium Relay Kubernetes Service(s) to which requests are routed.
+  services:
+    - name: hubble-relay
+      port: 443

--- a/test/helm3/ct-e2e.yaml
+++ b/test/helm3/ct-e2e.yaml
@@ -29,6 +29,7 @@ excluded-charts:
   - traefik-forward-auth  # D2IQ-62819
   - local-path-provisioner
   - thanos-traefik        # This requires installing dependencies like traefik2
+  - cilium-hubble-relay-traefik # This requires installing dependencies like traefik2
   - vsphere-csi-driver
   - kubefed
   - kommander-cert-federation # Unable to test unless cert-manager is also upgraded


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This chart is used to route requests from outside the cluster to the Cilium Hubble Relay service.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.nutanix.com/browse/NCN-105953

**Special notes for your reviewer**:
* The chart is safe to install, even if Cilium Hubble Relay is not running on the cluster.
* Because the chart requires traefik CRDs, it is excluded from the ct-e2e
tests.
* The chart will be installed by a kommander application.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
