### PR TITLE
fix: In cilium-hubble-relay-traefik, deploy IngressRouteTCP in the Service namespace

### DIFF
--- a/staging/cilium-hubble-relay-traefik/Chart.yaml
+++ b/staging/cilium-hubble-relay-traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cilium-hubble-relay-traefik
 description: A Helm chart for Kubernetes that exposes the Cilium Hubble Relay gRPC service over traefik. TLS passthrough is enabled, because Hubble Relay terminates mTLS.
 type: application
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.0.2
+appVersion: "0.0.2"
 maintainers:
 - name: dlipovetsky
   email: daniel.lipovetsky@nutanix.com

--- a/staging/cilium-hubble-relay-traefik/templates/ingressroutetcp.yaml
+++ b/staging/cilium-hubble-relay-traefik/templates/ingressroutetcp.yaml
@@ -4,6 +4,9 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: {{ include "cilium-hubble-relay-traefik.fullname" . }}-ingress
+  # NOTE We use the service namespace, because the default traefik configuration
+  # requires routes to be in the same namespace as their service.
+  namespace: {{ .Values.route.service.namespace }}
   labels:
 {{ include "cilium-hubble-relay-traefik.labels" . | indent 4 }}
 spec:
@@ -11,8 +14,10 @@ spec:
     {{- toYaml .Values.route.endpoints | nindent 4}}
   routes:
     - match: HostSNI(`{{ .Values.route.sni }}`)
-      services:
-      {{- toYaml .Values.route.services | nindent 6 }}
+      service:
+      - name: {{ .Values.route.service.name }}
+        namespace: {{ .Values.route.service.namespace }}
+        port: {{ .Values.route.service.port }}
   tls:
     passthrough: true
 {{ end }}

--- a/staging/cilium-hubble-relay-traefik/values.yaml
+++ b/staging/cilium-hubble-relay-traefik/values.yaml
@@ -19,7 +19,8 @@ route:
   # must send this exact value in the SNI header of its request.
   sni: hubble.hubble-relay.cilium.io
 
-  # The Hubble Cilium Relay Kubernetes Service(s) to which requests are routed.
-  services:
-    - name: hubble-relay
-      port: 443
+  # The Hubble Cilium Relay Kubernetes Service to which requests are routed.
+  service:
+    name: hubble-relay
+    namespace: kube-system
+    port: 443


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The default traefik configuration requires routes to be in the same namespace as their service. Previously, we deployed the route in the kommander namespace.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
