### PR TITLE
fix: set a release tag for docker-registry regsync image

### DIFF
--- a/staging/docker-registry/Chart.yaml
+++ b/staging/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 2.3.0
+version: 2.3.1
 appVersion: 2.8.1
 home: https://hub.docker.com/_/registry/
 icon: https://raw.githubusercontent.com/distribution/distribution/refs/heads/main/distribution-logo.svg

--- a/staging/docker-registry/patch/nutanix/patch_5_update_syncer_image.patch
+++ b/staging/docker-registry/patch/nutanix/patch_5_update_syncer_image.patch
@@ -1,0 +1,27 @@
+From 045f2d011abf0de516e1be43ae8cec3f5cc99d86 Mon Sep 17 00:00:00 2001
+From: Dimitri Koshkin <dimitri.koshkin@nutanix.com>
+Date: Fri, 2 May 2025 11:19:28 -0700
+Subject: [PATCH] chore: apply patch_5_update_syncer_image.patch
+
+---
+ staging/docker-registry/values.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/staging/docker-registry/values.yaml b/staging/docker-registry/values.yaml
+index 40c802aa..052f4f8d 100644
+--- a/staging/docker-registry/values.yaml
++++ b/staging/docker-registry/values.yaml
+@@ -272,8 +272,8 @@ statefulSet:
+   syncer:
+     enabled: true
+     image:
+-      repository: regclient/regsync
+-      tag: latest
++      repository: docker.io/regclient/regsync
++      tag: v0.8.3
+       pullPolicy: IfNotPresent
+     resources: {}
+     # The frequency of syncing the data between the registry instances.
+-- 
+2.47.1
+

--- a/staging/docker-registry/values.yaml
+++ b/staging/docker-registry/values.yaml
@@ -272,8 +272,8 @@ statefulSet:
   syncer:
     enabled: true
     image:
-      repository: regclient/regsync
-      tag: latest
+      repository: docker.io/regclient/regsync
+      tag: v0.8.3
       pullPolicy: IfNotPresent
     resources: {}
     # The frequency of syncing the data between the registry instances.


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Follow up to https://github.com/mesosphere/charts/pull/1578 to set a stable tag for the regsync image.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
