### PR TITLE
fix: Add watch federatedsecret capability to cert federation role

### DIFF
--- a/stable/kommander-cert-federation/Chart.yaml
+++ b/stable/kommander-cert-federation/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: "0.0.12"
+appVersion: "0.0.13"
 description: A Helm chart to create and federate TLS certificates used by kommander internals
 home: https://github.com/mesosphere/charts
 name: kommander-cert-federation
 type: application
-version: 0.0.12
+version: 0.0.13
 maintainers:
   - name: mikolajb
   - name: takirala

--- a/stable/kommander-cert-federation/templates/cert-federation.yaml
+++ b/stable/kommander-cert-federation/templates/cert-federation.yaml
@@ -33,7 +33,7 @@ metadata:
 rules:
   - apiGroups: ["types.kubefed.io"]
     resources: ["federatedsecrets"]
-    verbs: ["get", "list", "create", "update", "delete"]
+    verbs: ["get", "list", "create", "update", "delete", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "create", "update", "patch"]


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
```bash
kubectl logs -n kommander deployment/prometheus-traefik-certs-kommander-cert-federation patch-secret
+ echo 'ensuring federatedsecret kommander-thanos-server-tls does not exist'
ensuring federatedsecret kommander-thanos-server-tls does not exist
+ kubectl delete federatedsecret kommander-thanos-server-tls --ignore-not-found=true
federatedsecret.types.kubefed.io "kommander-thanos-server-tls" deleted
E0512 12:38:01.555782       8 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/tools/watch/informerwatcher.go:146: Failed to watch *unstructured.Unstructured: federatedsecrets.types.kubefed.io \"kommander-thanos-server-tls\" is forbidden: User \"system:serviceaccount:kommander:prometheus-traefik-certs-kommander-secret-edit\" cannot watch resource \"federatedsecrets\" in API group \"types.kubefed.io\" in the namespace \"kommander\""
```

**Which issue(s) this PR fixes**:
https://jira.nutanix.com/browse/NCN-104628

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
