### PR TITLE
fix: registry syncer with TLS

### DIFF
--- a/staging/docker-registry/Chart.yaml
+++ b/staging/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 2.3.1
+version: 2.3.2
 appVersion: 2.8.1
 home: https://hub.docker.com/_/registry/
 icon: https://raw.githubusercontent.com/distribution/distribution/refs/heads/main/distribution-logo.svg

--- a/staging/docker-registry/patch/nutanix/patch_3_sync_data_across_instances.patch
+++ b/staging/docker-registry/patch/nutanix/patch_3_sync_data_across_instances.patch
@@ -1,7 +1,7 @@
 From 26ee45ae522859afbfe962ed592139df049bd236 Mon Sep 17 00:00:00 2001
 From: Dimitri Koshkin <dimitri.koshkin@nutanix.com>
 Date: Wed, 30 Apr 2025 14:07:45 -0700
-Subject: [PATCH] chore: apply patch_3_sync_data_across_instances.patch
+Subject: [PATCH 1/2] chore: apply patch_3_sync_data_across_instances.patch
 
 ---
  .../docker-registry/templates/_helpers.tpl    | 47 ++++++++++++++++++-
@@ -198,6 +198,54 @@ index 034e1c40..5c236da9 100644
 +    resources: {}
 +    # The frequency of syncing the data between the registry instances.
 +    interval: 5m
+-- 
+2.47.1
+
+
+From fa5063151397f3e9b886585e2459af5adeeeb0bc Mon Sep 17 00:00:00 2001
+From: Dimitri Koshkin <dimitri.koshkin@nutanix.com>
+Date: Wed, 14 May 2025 09:16:08 -0700
+Subject: [PATCH 2/2] fix: docker-registry syncer when TLS enabled
+
+---
+ staging/docker-registry/templates/_helpers.tpl | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/staging/docker-registry/templates/_helpers.tpl b/staging/docker-registry/templates/_helpers.tpl
+index f0b7bb30..695a72d0 100644
+--- a/staging/docker-registry/templates/_helpers.tpl
++++ b/staging/docker-registry/templates/_helpers.tpl
+@@ -184,6 +184,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
+ {{- define "docker-registry.syncer.volumeMounts" -}}
+ - name: "{{ template "docker-registry.syncer.config.name" . }}"
+   mountPath: "/config/"
++{{- if .Values.tlsSecretName }}
++{{- $root := . }}
++{{- $name := (include "docker-registry.fullname" $root) }}
++{{- $service := (include "docker-registry.headless-service.name" $root) }}
++{{- $ns := $root.Release.Namespace }}
++{{- $replicas := $root.Values.replicaCount }}
++{{- range $i := until (int $replicas) }}
++- mountPath: {{ printf "/etc/docker/certs.d/%s-%d.%s.%s.svc.cluster.local:5000/" $name $i $service $ns }}
++  name: tls-cert
++  readOnly: true
++{{- end }}
++- mountPath: "/etc/docker/certs.d/127.0.0.1:5000/"
++  name: tls-cert
++  readOnly: true
++{{- end -}}
+ {{- end -}}
+ 
+ {{- define "docker-registry.volumes" -}}
+@@ -251,7 +266,7 @@ sync:
+ {{- $replicas := $root.Values.replicaCount }}
+ {{- range $i := until (int $replicas) }}
+   - source: {{ printf "%s-%d.%s.%s.svc.cluster.local:5000" $name $i $service $ns }}
+-    target: 0.0.0.0:5000
++    target: 127.0.0.1:5000
+     type: registry
+     interval: {{ $root.Values.statefulSet.syncer.interval }}
+ {{- end }}
 -- 
 2.47.1
 


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Fixing the regsync sidecar container to properly support registries with TLS enabled.
1. Using `127.0.0.1:5000` instead of `0.0.0.0:5000` as a target because having 0.0.0.0 in a cert SANs is not recommended.
2. Adding the CA from the TLS secret to `/etc/docker/certs.d/` 

Tested on a live cluster:
```
kubectl logs -n registry-system cncf-distribution-registry-docker-registry-1 -c docker-registry-syncer -f
time=2025-05-14T15:53:06.296Z level=INFO msg="Image sync needed" source=cncf-distribution-registry-docker-registry-0.cncf-distribution-registry-docker-registry-headless.registry-system.svc.cluster.local:5000/library/nginx:dkoshkin target=127.0.0.1:5000/library/nginx:dkoshkin
time=2025-05-14T15:53:06.306Z level=INFO msg="Copy layer" source=cncf-distribution-registry-docker-registry-0.cncf-distribution-registry-docker-registry-headless.registry-system.svc.cluster.local:5000/library/nginx@sha256:10731cc4bb4f62c4ad3239c775012e8920fbfbc6c68cdea348dd5f8878b932fc target=127.0.0.1:5000/library/nginx@sha256:10731cc4bb4f62c4ad3239c775012e8920fbfbc6c68cdea348dd5f8878b932fc layer=sha256:e9a3cfc61c8cc1e4adad85aad31133da8e8264de8009602927592ad03cb4c757
...
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
