### PR TITLE
fix: registry headless service port

### DIFF
--- a/staging/docker-registry/Chart.yaml
+++ b/staging/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 2.3.4
+version: 2.3.5
 appVersion: 2.8.3
 home: https://hub.docker.com/_/registry/
 icon: https://raw.githubusercontent.com/distribution/distribution/refs/heads/main/distribution-logo.svg

--- a/staging/docker-registry/patch/nutanix/patch_2_support_statefulset.patch
+++ b/staging/docker-registry/patch/nutanix/patch_2_support_statefulset.patch
@@ -263,3 +263,33 @@ index ef8f0414..034e1c40 100644
 -- 
 2.47.1
 
+From e85be4a32282907fdd85343e142f44f78cff1db4 Mon Sep 17 00:00:00 2001
+From: Dimitri Koshkin <dimitri.koshkin@nutanix.com>
+Date: Fri, 13 Jun 2025 11:07:11 -0700
+Subject: [PATCH] fix: use correct port in headless Service
+
+The port here needs to match the targetPort,
+in order for things like kubectl port-forward to work correctly.
+---
+ staging/docker-registry/templates/service-headless.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/staging/docker-registry/templates/service-headless.yaml b/staging/docker-registry/templates/service-headless.yaml
+index 221defe8..8e2dd2d5 100644
+--- a/staging/docker-registry/templates/service-headless.yaml
++++ b/staging/docker-registry/templates/service-headless.yaml
+@@ -27,9 +27,9 @@ spec:
+   {{- end -}}
+ {{- end }}
+   ports:
+-    - port: {{ .Values.service.port }}
++    - port: 5000
+       protocol: TCP
+-      name: {{ if .Values.tlsSecretName }}https{{ else }}http{{ end }}-{{ .Values.service.port }}
++      name: {{ if .Values.tlsSecretName }}https{{ else }}http{{ end }}
+       targetPort: 5000
+   selector:
+     app: {{ template "docker-registry.name" . }}
+-- 
+2.47.1
+

--- a/staging/docker-registry/templates/service-headless.yaml
+++ b/staging/docker-registry/templates/service-headless.yaml
@@ -27,9 +27,9 @@ spec:
   {{- end -}}
 {{- end }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: 5000
       protocol: TCP
-      name: {{ if .Values.tlsSecretName }}https{{ else }}http{{ end }}-{{ .Values.service.port }}
+      name: {{ if .Values.tlsSecretName }}https{{ else }}http{{ end }}
       targetPort: 5000
   selector:
     app: {{ template "docker-registry.name" . }}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The port here needs to match the targetPort, in order for things like kubectl port-forward to work correctly.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
