### PR TITLE
feat: add registry-syncer chart

### DIFF
--- a/staging/registry-syncer/Chart.yaml
+++ b/staging/registry-syncer/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: registry-syncer
+description: A chart to deploy registry syncer as Deployment and Job
+version: 0.1.0
+appVersion: "v0.8.3"
+maintainers:
+  - email: dimitri.koshkin@nutanix.com
+    name: dkoshkin
+sources:
+  - https://regclient.org/usage/regsync/

--- a/staging/registry-syncer/README.md
+++ b/staging/registry-syncer/README.md
@@ -1,0 +1,39 @@
+# Registry Syncer Helm Chart
+
+This directory contains the Helm chart for the Registry Syncer,
+which is used to synchronize OCI artifacts between different registries.
+
+It uses https://regclient.org/usage/regsync/.
+
+The chart will deploy both a Job and a Deployment, allowing you to run the syncer initially as a one-time job 
+and then continue to run it periodically as a deployment.
+
+## Installing the Chart
+
+First, add the repo:
+
+```console
+helm repo add mesosphere-staging https://mesosphere.github.io/charts/staging
+```
+
+To install the chart, use the following:
+
+```console
+helm install registry-syncer mesosphere-staging/registry-syncer
+```
+
+### Example Values
+
+```yaml
+deployment:
+  config:
+    creds:
+      - registry: docker-registry.registry-system.svc.cluster.local:443
+        tls: insecure
+        reqPerSec: 1
+    sync:
+      - source: docker-registry.registry-system.svc.cluster.local:443
+        target: another-registry.registry-system.svc.cluster.local:443
+        type: registry
+        interval: 1m
+```

--- a/staging/registry-syncer/templates/_helpers.tpl
+++ b/staging/registry-syncer/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "registry-syncer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "registry-syncer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "registry-syncer.deployment.configmap.name" -}}
+{{- printf "%s-deployment-config" (include "registry-syncer.fullname" .) -}}
+{{- end -}}
+
+{{- define "registry-syncer.job.configmap.name" -}}
+{{- printf "%s-job-config" (include "registry-syncer.fullname" .) -}}
+{{- end -}}
+
+
+{{- define "registry-syncer.deployment.volumeMounts" -}}
+- name: "config"
+  mountPath: "/config/"
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "registry-syncer.deployment.volumes" -}}
+- name: config
+  configMap:
+    name: {{ template "registry-syncer.deployment.configmap.name" . }}
+{{- with .Values.extraVolumes }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "registry-syncer.job.volumeMounts" -}}
+- name: "config"
+  mountPath: "/config/"
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "registry-syncer.job.volumes" -}}
+- name: config
+  configMap:
+    name: {{ template "registry-syncer.job.configmap.name" . }}
+{{- with .Values.extraVolumes }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}

--- a/staging/registry-syncer/templates/configmap-deployment.yaml
+++ b/staging/registry-syncer/templates/configmap-deployment.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.deployment.enabled }}
+{{- if not (hasKey .Values.deployment.config "sync") }}
+{{- fail "The 'deployment.config.sync' field must not be empty" }}
+{{- end }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "registry-syncer.deployment.configmap.name" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+data:
+  config.yml: |-
+    defaults:
+      ratelimit:
+        min: {{ .Values.deployment.config.ratelimit.min }}
+        retry: {{ .Values.deployment.config.ratelimit.retry }}
+      parallel: {{ .Values.deployment.config.parallel }}
+    {{- with .Values.deployment.config.creds }}
+    creds:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.deployment.config.sync }}
+    sync:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/staging/registry-syncer/templates/configmap-job.yaml
+++ b/staging/registry-syncer/templates/configmap-job.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.job.enabled }}
+{{- if not (hasKey .Values.job.config "sync") }}
+{{- fail "The 'job.config.sync' field must not be empty" }}
+{{- end }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "registry-syncer.job.configmap.name" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+data:
+  config.yml: |-
+    defaults:
+      ratelimit:
+        min: {{ .Values.job.config.ratelimit.min }}
+        retry: {{ .Values.deployment.config.ratelimit.retry }}
+      parallel: {{ .Values.deployment.config.parallel }}
+    {{- with .Values.job.config.creds }}
+    creds:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.job.config.sync }}
+    sync:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/staging/registry-syncer/templates/deployment.yaml
+++ b/staging/registry-syncer/templates/deployment.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.deployment.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "registry-syncer.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    app: {{ template "registry-syncer.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "registry-syncer.name" . }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.deployment.replicas | default 1 }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "registry-syncer.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            -  -c
+            - /config/config.yml
+            - server
+          resources: {{ toYaml .Values.deployment.resources | nindent 12 }}
+          volumeMounts: {{ include "registry-syncer.deployment.volumeMounts" . | nindent 12 }}
+      priorityClassName: system-cluster-critical
+      volumes: {{ include "registry-syncer.deployment.volumes" . | nindent 8 }}
+{{- end }}

--- a/staging/registry-syncer/templates/job.yaml
+++ b/staging/registry-syncer/templates/job.yaml
@@ -1,0 +1,48 @@
+{{- /*
+  Render Job when:
+  - installOnly = true AND it's a helm install
+  - OR installOnly = false (always render)
+*/ -}}
+{{- $enabled := .Values.job.enabled }}
+{{- $installOnly := .Values.job.installOnly }}
+{{- $shouldRender := or (and $installOnly .Release.IsInstall) (not $installOnly) }}
+
+{{- if and $enabled $shouldRender }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "registry-syncer.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    app: {{ template "registry-syncer.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.job.annotations }}
+  annotations:
+{{ toYaml .Values.job.annotations | indent 4 }}
+{{- end }}
+spec:
+  {{- if hasKey .Values.job "ttlSecondsAfterFinished" }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    spec:
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -c
+            - /config/config.yml
+            - once
+          resources: {{ toYaml .Values.job.resources | nindent 12 }}
+          volumeMounts: {{ include "registry-syncer.job.volumeMounts" . | nindent 12 }}
+      priorityClassName: system-cluster-critical
+      restartPolicy: {{ .Values.job.restartPolicy }}
+      volumes: {{ include "registry-syncer.job.volumes" . | nindent 8 }}
+{{- end }}

--- a/staging/registry-syncer/values.yaml
+++ b/staging/registry-syncer/values.yaml
@@ -1,0 +1,74 @@
+# namespace:
+
+image:
+  repository: docker.io/regclient/regsync
+  # Defaults to Charts appVersion
+  tag:
+  pullPolicy: IfNotPresent
+
+initContainers: []
+## Init containers to add to the Deployment and Job.
+# - name: init
+#   image: busybox
+#   command: []
+
+extraVolumes: []
+extraVolumeMounts: []
+
+deployment:
+  enabled: true
+  annotations: {}
+  replicas: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 50Mi
+    limits:
+      cpu: 100m
+      memory: 75Mi
+  config:
+    ratelimit:
+      min: 100
+      retry: 15m
+    parallel: 10
+    creds: []
+    # See https://regclient.org/usage/regsync/ for valid configuration.
+    #  - registry: docker-registry.registry-system.svc.cluster.local:443
+    #    reqPerSec: 1
+    sync: []
+    # See https://regclient.org/usage/regsync/ for valid configuration.
+    #  - source: docker-registry.registry-system.svc.cluster.local:443
+    #    target: 127.0.0.1:5000
+    #    type: registry
+    #    interval: 1m
+
+job:
+  enabled: true
+  # If true, the Job will only be created during a Helm install.
+  # If false, the Job will be created on install and Helm upgrade.
+  installOnly: true
+  annotations: {}
+  # Delete a finished Job after 24 hours
+  ttlSecondsAfterFinished: 86400
+  restartPolicy: OnFailure
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+    limits:
+      cpu: 200m
+      memory: 300Mi
+  config:
+    ratelimit:
+      min: 100
+      retry: 15m
+    parallel: 10
+    creds: []
+    # See https://regclient.org/usage/regsync/ for valid configuration.
+    #  - registry: docker-registry.registry-system.svc.cluster.local:443
+    sync: []
+    # See https://regclient.org/usage/regsync/ for valid configuration.
+    #  - source: docker-registry.registry-system.svc.cluster.local:443
+    #    target: 127.0.0.1:5000
+    #    type: registry
+    #    interval: 1m


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Adds a chart to sync OCI artifacts across registries with https://regclient.org/usage/regsync/.
This will be used for the AGF feature to sync OCI artifacts between the management and workload clusters. I've kept the chart flexible enough though where it can be used to sync across any registries.

Tested locally:
```
$ helm install registry-syncer-0197a434-b175-76c0-a016-5d3ffc2ee3e4 /Users/dimitri.koshkin/src/github.com/mesosphere/charts/staging/registry-syncer -f /Users/dimitri.koshkin/src/github.com/mesosphere/charts/staging/registry-syncer/nkp-values.yaml --namespace dk-agf-syncer-chart-wrkld-d94q7
NAME: registry-syncer-0197a434-b175-76c0-a016-5d3ffc2ee3e4
LAST DEPLOYED: Wed Jun 25 08:36:43 2025
NAMESPACE: dk-agf-syncer-chart-wrkld-d94q7
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

```
$ k get pods -n dk-agf-syncer-chart-wrkld-d94q7
NAME                                                              READY   STATUS      RESTARTS      AGE
cluster-autoscaler-0197a442-3eaa-746b-b3f2-4d2dceb3f813-99hqdk7   1/1     Running     1 (15h ago)   16h
cluster-observer-2513620838-56d958d944-5r4j9                      1/1     Running     2 (16h ago)   16h
karma-traefik-certs-dk-agf-syncer-chart-wrkld-d94q7-cert-f2djkl   1/1     Running     0             16h
prometheus-traefik-certs-dk-agf-syncer-chart-wrkld-d94q7-cwkjdw   1/1     Running     0             16h
registry-syncer-0197a434-b175-76c0-a016-5d3ffc2ee3e4-8bb5fqvsrx   2/2     Running     0             18s
registry-syncer-0197a434-b175-76c0-a016-5d3ffc2ee3e4-d57wr        0/2     Completed   0             18s
```

Here is what those values would look like for the AGF usecase. It will mostly be the same with things like source and destination services and cluster name being templated based on the cluster.
```yaml
initContainers:
  - name: port-forward-registry
    image: ghcr.io/d2iq-labs/kubectl-betterwait:v1.33.1
    command:
      - /bin/kubectl
    args:
      - port-forward
      - --address=127.0.0.1
      - --namespace=registry-system
      - --kubeconfig=/kubeconfig/admin.conf
      # This will port-forward to a single Pod in the Service.
      - service/cncf-distribution-registry-docker-registry-headless
      - 5000:5000
    resources:
      requests:
        cpu: 25m
        memory: 32Mi
      limits:
        cpu: 100m
        memory: 50Mi
    volumeMounts:
      - mountPath: /kubeconfig
        name: kubeconfig
        readOnly: true
    # Kubernetes will treat this as a Sidecar container
    # https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
    restartPolicy: Always

extraVolumes:
  - name: kubeconfig
    secret:
      items:
        - key: value
          path: admin.conf
      secretName: dk-agf-syncer-chart-wrkld-kubeconfig
  - name: tls-cert
    secret:
      secretName: dk-agf-syncer-chart-wrkld-registry-addon-ca

extraVolumeMounts:
  # Assume both the source and the target registries have the same CA.
  # Source registry running in the cluster.
  - mountPath: /etc/docker/certs.d/cncf-distribution-registry-docker-registry.registry-system.svc.cluster.local:443/
    name: tls-cert
    readOnly: true
  # Destination registry running in the remote cluster being port-forwarded.
  - mountPath: /etc/docker/certs.d/127.0.0.1:5000/
    name: tls-cert
    readOnly: true

deployment:
  config:
    creds:
      - registry: cncf-distribution-registry-docker-registry.registry-system.svc.cluster.local:443
        reqPerSec: 1
    sync:
      - source: cncf-distribution-registry-docker-registry.registry-system.svc.cluster.local:443
        target: 127.0.0.1:5000
        type: registry
        interval: 1m

job:
  enabled: true
  config:
    sync:
      - source: cncf-distribution-registry-docker-registry.registry-system.svc.cluster.local:443
        target: 127.0.0.1:5000
        type: registry
        interval: 1m
```


**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
