### PR TITLE
Adding helm charts for k8s agent addon

### DIFF
--- a/stable/k8s-agent/.helmignore
+++ b/stable/k8s-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/k8s-agent/Chart.yaml
+++ b/stable/k8s-agent/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: nutanix-k8s-agent
+description: A Helm chart for onboarding a Kubernetes cluster created on Nutanix Infrastructure onto Prism Central.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1-alpha.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1-alpha.1"

--- a/stable/k8s-agent/Nutanix-core_k8s-agent Notice.txt
+++ b/stable/k8s-agent/Nutanix-core_k8s-agent Notice.txt
@@ -1,0 +1,8591 @@
+Nutanix-core_k8s-agent
+Copyright 2023 Nutanix Inc.
+
+
+This notices file applies to the Nutanix product offering it is distributed with and as may be published in the Nutanix portal.
+
+Nutanix product offerings may include open source software, including without limitation, a Linux distribution base image or utilities, that is copyrighted by the respective authors.  The components and their licenses listed in this Notice are provided for notification as required by the various open source licenses.  Where more than one license is stated for an open source component, Nutanix elects the most permissive license. 
+ 
+If required by an open source license, Nutanix will provide a copy of the open source component source code upon request,  within a reasonable period of time, and for a reasonable fee.  You may send a request to: Nutanix, Inc.,1740 Technology Dr Ste 150, San Jose, CA 95110;  Attention: Legal.  All requests for source code must include (i) the applicable Nutanix product offering name and version containing the open source component, (ii) the open source component name and version for which the source code is being requested, (iii) your name, (iv) your organization or company’s name (if applicable), (v) your return mailing and email address (if available). 
+
+Components: 
+
+agnivade/levenshtein v1.1.1 : MIT License
+alecthomas-kingpin v2.2.6 : MIT License
+alecthomas-kingpin v2.3.2 : MIT License
+alecthomas-template 20160405-snapshot-a0175ee3 : BSD 3-clause "New" or "Revised" License
+alecthomas-units 20211218-snapshot-b94a6e3c : MIT License
+antlr runtime/Go/antlr/v1.4.10 : BSD 3-clause "New" or "Revised" License
+araddon-dateparse 20210429-snapshot-6b43995a : MIT License
+armon-consul-api 20180202-snapshot-eb2c6b5b : Mozilla Public License 2.0
+armon-go-metrics 20180917-snapshot-f0300d17 : MIT License
+armon-go-radix v1.0.0 : MIT License
+armon/circbuf 20150827-snapshot-bbbad097 : MIT License
+armon/go-socks5 20160902-snapshot-e7533296 : MIT License
+benbjohnson-clock v1.1.0 : MIT License
+beorn7-perks v1.0.1 : MIT License
+bgentry-speakeasy 0.1.0 : Apache License 2.0
+bketelsen/crypt v0.0.4 : MIT License
+blackfriday v1.6.0 : BSD 2-clause "Simplified" License
+blackfriday v2.1.0 : BSD 2-clause "Simplified" License
+blang-semver v4.0.0 : MIT License
+bshuster-repo/logrus-logstash-hook v1.0.0 : MIT License
+btree v1.1.2 : Apache License 2.0
+bugsnag-bugsnag-go 20141110-snapshot-b1d15302 : MIT License
+bugsnag-osext 20130617-snapshot-0dd3f918 : zlib License
+bugsnag/panicwrap 20160225-snapshot-e2c28503 : MIT License
+BurntSushi/toml 1.2.1 : (MIT License AND BSD 2-clause "Simplified" License AND Creative Commons Attribution 3.0 AND BSD 3-clause "New" or "Revised" License)
+cenkalti/backoff v4.2.1 : MIT License
+census-instrumentation/opencensus-go v0.24.0 : Apache License 2.0
+cespare/xxhash v1.1.0 : MIT License
+cespare/xxhash v2.2.0 : MIT License
+chai2010-gettext-go v1.0.2 : BSD 3-clause "New" or "Revised" License
+chzyer-readline 20180828-snapshot-2972be24 : MIT License
+chzyer/logex v1.1.10 : MIT License
+chzyer/test 20190214-snapshot-a1ea475d : MIT License
+cilium/ebpf v0.9.1 : MIT License
+client-go v0.28.1 : Apache License 2.0
+client9/misspell v0.3.4 : (MIT License AND BSD 3-clause "New" or "Revised" License)
+client_golang v1.16.0 : Apache License 2.0
+cncf/udpa 20220112-snapshot-c52dc94e : Apache License 2.0
+Consul api/v1.1.0 : Mozilla Public License 2.0
+Consul sdk/v0.1.1 : Mozilla Public License 2.0
+container-orchestrated-devices/container-device-interface v0.5.4 : Apache License 2.0
+containerd/btrfs v2.0.0 : Apache License 2.0
+containerd/cgroups v1.1.0 : Apache License 2.0
+containerd/cgroups v3.0.1 : Apache License 2.0
+containerd/console 1.0.3 : Apache License 2.0
+containerd/containerd v1.7.0 : Apache License 2.0
+containerd/continuity v0.3.0 : Apache License 2.0
+containerd/fifo v1.1.0 : Apache License 2.0
+containerd/go-runc v1.0.0 : Apache License 2.0
+containerd/nri v0.3.0 : Apache License 2.0
+containerd/typeurl 1.0.2 : Apache License 2.0
+containerd/typeurl v2.1.0 : Apache License 2.0
+containernetworking/plugins v1.2.0 : Apache License 2.0
+containers/ocicrypt v1.1.6 : Apache License 2.0
+CoreOS v0.3.0 : Apache License 2.0
+coreos-go-oidc v2.1.0 : Apache License 2.0
+coreos-pkg 20181023-snapshot-399ea9e2 : Apache License 2.0
+coreos/bbolt v1.3.2 : MIT License
+cpuguy83-go-md2man 2.0.2 : MIT License
+creack/pty v1.1.18 : MIT License
+creasty/defaults v1.5.2 : MIT License
+cyphar/filepath-securejoin v0.2.3 : BSD 3-clause "New" or "Revised" License
+danieljoos/wincred v1.1.2 : MIT License
+DATA-DOG-go-sqlmock v1.5.0 : BSD 3-clause "New" or "Revised" License
+daviddengcn/go-colortext 1.0.0 : (MIT License AND BSD 3-clause "New" or "Revised" License)
+diskv v2.0.1 : MIT License
+docker v23.0.1 : Apache License 2.0
+docker-cli v23.0.1 : Apache License 2.0
+docker-go-units v0.5.0 : Apache License 2.0
+docker-org 20190806-snapshot-e31b211e : Apache License 2.0
+docker-org v0.7.0 : MIT License
+docker-registry 2.8.2 : Apache License 2.0
+docker/go-metrics v0.0.1 : (Apache License 2.0 AND Creative Commons Attribution Share Alike 4.0)
+dominikh/go-tools v0.0.1-2020.1.4 : MIT License
+envoyproxy/go-control-plane v0.10.3 : Apache License 2.0
+envoyproxy/protoc-gen-validate 0.9.1 : Apache License 2.0
+errcheck v1.5.0-alpha : MIT License
+errwrap v1.1.0 : Mozilla Public License 2.0
+etcd-io/etcd v3.5.7 : Apache License 2.0
+evanphx/json-patch v5.6.0 : BSD 3-clause "New" or "Revised" License
+exp 20200223-snapshot-6cc2880d : BSD 3-clause "New" or "Revised" License
+exponent-io/jsonpath 20210407-snapshot-1de76d71 : MIT License
+fatih-camelcase v1.0.0 : MIT License
+fatih-color v1.13.0 : MIT License
+felixge/httpsnoop v1.0.3 : MIT License
+foxcpp/go-mockdns v1.0.0 : MIT License
+frankban/quicktest v1.14.3 : MIT License
+fsnotify-fsnotify v1.6.0 : BSD 3-clause "New" or "Revised" License
+fvbommel/sortorder 1.1.0 : MIT License
+gengo 20220902-snapshot-c0856e24 : Apache License 2.0
+github.com/99designs/gqlgen v0.15.1 : MIT License
+github.com/AdaLogics/go-fuzz-headers 20230106-snapshot-43070de9 : Apache License 2.0
+github.com/antihax/optional 1.0.0 : MIT License
+github.com/containerd/aufs v1.0.0 : Apache License 2.0
+github.com/containerd/go-cni v1.1.9 : Apache License 2.0
+github.com/containerd/ttrpc v1.2.1 : Apache License 2.0
+github.com/containerd/zfs v1.0.0 : Apache License 2.0
+github.com/containernetworking/cni v1.1.2 : Apache License 2.0
+github.com/go-kit/log v0.2.1 : MIT License
+github.com/go-logr/zapr v1.2.3 : Apache License 2.0
+github.com/gobuffalo/logger v1.0.6 : MIT License
+github.com/gobuffalo/packd 1.0.1 : MIT License
+github.com/gofrs/flock v0.8.1 : BSD 3-clause "New" or "Revised" License
+github.com/golang-jwt/jwt v4.4.2 : MIT License
+github.com/gomodule/redigo v1.8.2 : Apache License 2.0
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 : MIT License
+github.com/markbates/oncer v1.0.0 : MIT License
+github.com/markbates/safe v1.0.1 : MIT License
+github.com/moby/locker 1.0.1 : Apache License 2.0
+github.com/moby/spdystream v0.2.0 : Apache License 2.0
+github.com/munnerz/goautoneg 20191010-snapshot-a7dc8b61 : BSD 3-clause "New" or "Revised" License
+github.com/rivo/uniseg v0.4.2 : MIT License
+github.com/rogpeppe/fastuuid v1.2.0 : BSD 3-clause "New" or "Revised" License
+github.com/spf13/jwalterweatherman v1.1.0 : MIT License
+github.com/vektah/gqlparser v2.2.0 : MIT License
+github.com/xdg-go/pbkdf2 1.0.0 : Apache License 2.0
+glfw 20190408-snapshot-e6da0acd : BSD 3-clause "New" or "Revised" License
+glfw 20200222-snapshot-6f7a984d : BSD 3-clause "New" or "Revised" License
+Go CLI v1.1.5 : Mozilla Public License 2.0
+go humanize v1.0.0 : MIT License
+Go Logrus v1.9.0 : MIT License
+Go support for Mobile devices 20190704-snapshot-d2bd2a29 : BSD 3-clause "New" or "Revised" License
+Go Testify v1.8.2 : MIT License
+go-ansiterm d185dfc1b5a126116ea5a19e148e29d16b4574c9 : MIT License
+go-check-check 20201130-snapshot-10cb9826 : BSD 2-clause "Simplified" License
+go-chi v1.5.4 : MIT License
+go-chi/render v1.0.1 : MIT License
+go-cli v2.3.0 : MIT License
+go-errgo-errgo v2.1.0 : BSD 3-clause "New" or "Revised" License
+go-errors-errors v1.4.2 : MIT License
+go-etcd v3.3.10 : Apache License 2.0
+go-flowrate 20140419-snapshot-cca7078d : BSD 3-clause "New" or "Revised" License
+go-gorp/gorp v3.1.0 : MIT License
+go-immutable-radix v1.0.0 : Mozilla Public License 2.0
+go-inf-inf v0.9.1 : BSD 3-clause "New" or "Revised" License
+go-ini-ini v1.62.0 : Apache License 2.0
+go-jose v2.6.0 : Apache License 2.0
+go-kit-kit v0.8.0 : MIT License
+go-logfmt-logfmt v0.5.1 : MIT License
+go-logr/logr v1.2.4 : Apache License 2.0
+go-logr/stdr v1.2.2 : Apache License 2.0
+go-mssqldb 0.9.0 : BSD 3-clause "New" or "Revised" License
+go-oci8 v0.1.1 : MIT License
+go-openapi/jsonpointer v0.19.6 : Apache License 2.0
+go-playground-universal-translator v0.18.0 : MIT License
+go-playground/locales v0.14.0 : MIT License
+go-restful v3.10.1 : MIT License
+go-resty/resty v1.12.0 : MIT License
+go-spew v1.1.1 : ISC License
+go-sql-driver v1.6.0 : Mozilla Public License 2.0
+go-stack-stack v1.8.1 : MIT License
+go-systemd 20190321-snapshot-95778dfb : Apache License 2.0
+go-systemd v22.5.0 : Apache License 2.0
+go-task/slim-sprig 20230315-snapshot-52ccab3e : MIT License
+go-toml v1.9.5 : MIT License
+go-viper v1.8.1 : MIT License
+go-zap v1.24.0 : MIT License
+go-zfs 20190419-snapshot-f784269b : Apache License 2.0
+go.etcd.io/bbolt v1.3.7 : MIT License
+go.opentelemetry.io/proto otlp/v0.19.0 : Apache License 2.0
+go.uber.org/goleak v1.2.1 : MIT License
+go.uber.org/multierr v1.11.0 : MIT License
+gobuffalo/packr v2.8.3 : MIT License
+gobwas-glob 0.2.3 : MIT License
+goconvey v1.6.4 : MIT License
+godbus-dbus v5.1.0 : BSD 2-clause "Simplified" License
+GoDoc Text v0.2.0 : MIT License
+godror/godror v0.24.2 : (Universal Permissive License v1.0 AND Apache License 2.0)
+gogo/protobuf v1.3.2 : BSD 3-clause "New" or "Revised" License
+Golang Protobuf v1.30.0 : BSD 3-clause "New" or "Revised" License
+Golang Protobuf v1.5.3 : BSD 3-clause "New" or "Revised" License
+golang-github-docker-go-connections-dev 0.4.0 : Apache License 2.0
+golang-github-docker-libtrust-dev 20160225-snapshot-fa567046 : Apache License 2.0
+golang-github-ghodss-yaml-dev 1.0.0 : MIT License
+golang-github-hashicorp-memberlist v0.1.3 : Mozilla Public License 2.0
+golang-github-magiconair-properties v1.8.5 : BSD 2-clause "Simplified" License
+golang-github-ryanuber-columnize 20180625-snapshot-9b3edd62 : MIT License
+golang-github-shopify-logrus-bugsnag-dev 20171204-snapshot-577dee27 : MIT License
+golang-github-spf13-pflag-dev v1.0.5 : BSD 3-clause "New" or "Revised" License
+golang-mock v1.6.0 : Apache License 2.0
+golang-snappy-go-dev v0.0.4 : BSD 3-clause "New" or "Revised" License
+golang-sql/civil 20190719-snapshot-cb61b32a : Apache License 2.0
+golang.org/x/crypto v0.11.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/image 20190704-snapshot-cff245a6 : BSD 3-clause "New" or "Revised" License
+golang.org/x/lint 20210508-snapshot-6edffad5 : BSD 3-clause "New" or "Revised" License
+golang.org/x/mod v0.9.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/net v0.13.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/oauth2 v0.8.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/sync v0.2.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/sys v0.10.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/term v0.10.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/time v0.3.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/tools v0.8.0 : BSD 3-clause "New" or "Revised" License
+golang.org/x/xerrors 20220907-snapshot-04be3eba : BSD 3-clause "New" or "Revised" License
+golang/appengine v1.6.7 : Apache License 2.0
+golang/glog v1.0.0 : Apache License 2.0
+golang/text v0.11.0 : BSD 3-clause "New" or "Revised" License
+gomega v1.27.6 : MIT License
+google-cloud-go bigquery/v1.8.0 : Apache License 2.0
+google-cloud-go compute/metadata/v0.2.3 : Apache License 2.0
+google-cloud-go compute/v1.15.1 : Apache License 2.0
+google-cloud-go datastore/v1.1.0 : Apache License 2.0
+google-cloud-go firestore/v1.1.0 : Apache License 2.0
+google-cloud-go pubsub/v1.3.1 : Apache License 2.0
+google-cloud-go storage/v1.10.0 : Apache License 2.0
+google-cloud-go v0.97.0 : Apache License 2.0
+google-gofuzz v1.2.0 : Apache License 2.0
+google-shlex 20191202-snapshot-e7afc7fb : Apache License 2.0
+google/cel-go v0.12.6 : Apache License 2.0
+google/gnostic v0.6.9 : Apache License 2.0
+google/gnostic-models v0.6.8 : Apache License 2.0
+google/go-cmp v0.5.9 : BSD 3-clause "New" or "Revised" License
+google/pprof 20210720-snapshot-4bb14d4b : Apache License 2.0
+google/renameio v0.1.0 : Apache License 2.0
+google/starlark-go 20230525-snapshot-a134d8f9 : BSD 3-clause "New" or "Revised" License
+google/uuid v1.3.0 : BSD 3-clause "New" or "Revised" License
+googleapis/gax-go v2.0.5 : BSD 3-clause "New" or "Revised" License
+googleapis/go-genproto 20230525-snapshot-28d5490b : Apache License 2.0
+googleapis/go-genproto 20230525-snapshot-dd9d6828 : Apache License 2.0
+googleapis/go-genproto 20230526-snapshot-0005af68 : Apache License 2.0
+googleapis/google-api-go-client v0.44.0 : BSD 3-clause "New" or "Revised" License
+gopherjs 20181205-snapshot-0766667c : BSD 2-clause "Simplified" License
+gorelic 20141212-snapshot-a9bba5b9 : BSD 2-clause "Simplified" License
+gorilla/handlers v1.5.1 : BSD 2-clause "Simplified" License
+gorilla/mux v1.8.0 : BSD 3-clause "New" or "Revised" License
+gorilla/websocket v1.4.2 : BSD 2-clause "Simplified" License
+gosuri/uitable v0.0.4 : MIT License
+gotest.tools v3.4.0 : Apache License 2.0
+govalidator 20210307-snapshot-f21760c4 : MIT License
+gregjones/httpcache 20190611-snapshot-901d9072 : MIT License
+groupcache 20210331-snapshot-41bb18bf : Apache License 2.0
+grpc-ecosystem/go-grpc-middleware v1.3.0 : Apache License 2.0
+grpc-ecosystem/go-grpc-prometheus v1.2.0 : Apache License 2.0
+grpc-gateway v1.16.0 : BSD 3-clause "New" or "Revised" License
+grpc-gateway v2.7.0 : BSD 3-clause "New" or "Revised" License
+grpc-go v1.54.0 : Apache License 2.0
+hashicorp serf v0.8.2 : Mozilla Public License 2.0
+hashicorp-go-cleanhttp v0.5.2 : Mozilla Public License 2.0
+hashicorp-go-msgpack v0.5.3 : BSD 3-clause "New" or "Revised" License
+hashicorp-go-multierror v1.1.1 : Mozilla Public License 2.0
+hashicorp-go-rootcerts v1.0.0 : Mozilla Public License 2.0
+hashicorp-go-syslog v1.0.0 : MIT License
+hashicorp-go-uuid v1.0.1 : Mozilla Public License 2.0
+hashicorp-go.net v0.0.1 : BSD 3-clause "New" or "Revised" License
+hashicorp-golang-lru v0.5.4 : Mozilla Public License 2.0
+hashicorp-logutils v1.0.0 : Mozilla Public License 2.0
+hashicorp-mdns v1.0.0 : MIT License
+hashicorp/go-sockaddr v1.0.0 : Mozilla Public License 2.0
+hashicorp/hcl v1.0.0 : Mozilla Public License 2.0
+helm/helm v3.12.3 : Apache License 2.0
+huandu/xstrings v1.4.0 : MIT License
+ianlancetaylor/demangle 20200824-snapshot-28f6c0f3 : BSD 3-clause "New" or "Revised" License
+inconshreveable/mousetrap v1.1.0 : Apache License 2.0
+intel/goresctrl v0.3.0 : Apache License 2.0
+itchyny/gojq v0.12.11 : MIT License
+itchyny/timefmt-go v0.1.5 : MIT License
+jonboulle-clockwork v0.2.2 : Apache License 2.0
+josharian/intern v1.0.0 : MIT License
+jpillora-backoff 1.0.0 : MIT License
+jsoniter-go v1.1.12 : MIT License
+jsonreference v0.20.2 : Apache License 2.0
+jstemmer/go-junit-report v0.9.1 : MIT License
+jtolds-gls v4.20.0 : MIT License
+julienschmidt/httprouter v1.3.0 : BSD 3-clause "New" or "Revised" License
+jwt-go v3.2.0 : MIT License
+k0kubun-pp v3.1.0 : MIT License
+k3s-io/klog v2.100.1-k3s1 : Apache License 2.0
+k8s.io/cli-runtime v0.28.1 : Apache License 2.0
+k8s.io/code-generator v0.27.3 : Apache License 2.0
+k8s.io/component-helpers v0.28.1 : Apache License 2.0
+k8s.io/kube-openapi 20230717-snapshot-26953613 : Apache License 2.0
+k8s.io/utils 20230406-snapshot-d93618cf : Apache License 2.0
+karrick/godirwalk v1.16.1 : BSD 2-clause "Simplified" License
+Keploy.io v0.7.12 : Apache License 2.0
+kisielk-gotool v1.0.0 : (MIT License AND BSD 3-clause "New" or "Revised" License)
+klauspost-compress v1.16.0 : BSD 3-clause "New" or "Revised" License
+klauspost-cpuid v2.0.4 : MIT License
+kr-fs v0.1.0 : BSD 3-clause "New" or "Revised" License
+kr/pretty v0.3.1 : MIT License
+kubectl v0.28.1 : Apache License 2.0
+kubernetes-sigs/apiserver-network-proxy konnectivity-client/v0.1.2 : Apache License 2.0
+kubernetes-sigs/structured-merge-diff v4.2.3 : Apache License 2.0
+kubernetes/api v0.28.1 : Apache License 2.0
+kubernetes/apiextensions-apiserver v0.27.3 : Apache License 2.0
+kubernetes/apimachinery v0.28.1 : Apache License 2.0
+kubernetes/apiserver v0.27.3 : Apache License 2.0
+kubernetes/component-base v0.28.1 : Apache License 2.0
+kubernetes/cri-api v0.26.2 : Apache License 2.0
+kubernetes/metrics v0.28.1 : Apache License 2.0
+kustomize 20230601-snapshot-6ce0bf39 : Apache License 2.0
+lann-builder 20181203-snapshot-47ae3079 : MIT License
+lann-ps 20180517-snapshot-62de8c46 : MIT License
+leodido/go-urn v1.2.1 : MIT License
+liggitt/tabwriter 20181228-snapshot-89fcab3d : BSD 3-clause "New" or "Revised" License
+lithammer/dedent v1.1.0 : MIT License
+logfmt 20140226-snapshot-b84e30ac : MIT License
+mailru/easyjson v0.7.7 : MIT License
+MakeNowJust-heredoc v1.0.0 : MIT License
+mapstructure v1.4.3 : MIT License
+markbates/errx v1.1.0 : MIT License
+martian v2.1.0 : Apache License 2.0
+martian v3.1.0 : Apache License 2.0
+Masterminds-semver v3.2.1 : MIT License
+Masterminds-squirrel v1.5.4 : MIT License
+Masterminds/goutils v1.1.1 : Apache License 2.0
+Masterminds/sprig v3.2.3 : MIT License
+matryer/moq v0.2.5 : MIT License
+mattn-go-colorable 0.1.13 : (MIT License AND BSD 3-clause "New" or "Revised" License)
+mattn-go-isatty v0.0.17 : MIT License
+mattn-go-runewidth v0.0.14 : MIT License
+mattn-go-shellwords v1.0.12 : MIT License
+mattn-go-sqlite3 v1.14.15 : MIT License
+matttproud-golang_protobuf_extensions v1.0.4 : Apache License 2.0
+mergo v0.3.13 : BSD 3-clause "New" or "Revised" License
+Microsoft-go-winio v0.6.0 : MIT License
+Microsoft-hcsshim v0.10.0-rc.7 : MIT License
+miekg/dns v1.1.25 : BSD 3-clause "New" or "Revised" License
+miekg/pkcs11 v1.1.1 : BSD 3-clause "New" or "Revised" License
+minio/sha256-simd v1.0.0 : Apache License 2.0
+mitchellh-copystructure v1.2.0 : MIT License
+mitchellh-go-homedir v1.1.0 : MIT License
+mitchellh-go-wordwrap v1.0.1 : MIT License
+mitchellh-iochan v1.0.0 : MIT License
+mitchellh-reflectwalk v1.0.2 : MIT License
+mitchellh/go-testing-interface v1.0.0 : MIT License
+mitchellh/gox v0.4.0 : Mozilla Public License 2.0
+mittwald/go-helm-client v0.11.5 : MIT License
+moby/sys mountinfo/v0.6.2 : Apache License 2.0
+moby/sys sequential/v0.5.0 : Apache License 2.0
+moby/sys signal/v0.7.0 : Apache License 2.0
+moby/sys symlink/v0.2.0 : Apache License 2.0
+modern-go/concurrent 20180305-snapshot-bacd9c7e : Apache License 2.0
+modern-go/reflect2 v1.0.2 : Apache License 2.0
+mongodb/mongo-go-driver v1.8.3 : Apache License 2.0
+monochromegane/go-gitignore 20200625-snapshot-205db1a8 : MIT License
+morikuni/aec v1.0.0 : MIT License
+mozilla-services/pkcs7 20200128-snapshot-432b2356 : MIT License
+murmur3 20181015-snapshot-f09979ec : BSD 3-clause "New" or "Revised" License
+mwitkow/go-conntrack 20190716-snapshot-2f068394 : Apache License 2.0
+natefinch/lumberjack v2.0.0 : MIT License
+nelsam/hel v2.3.3 : The Unlicense
+newrelic_platform_go 20161221-snapshot-b21fdbd4 : BSD 2-clause "Simplified" License
+niemeyer/pretty 20200227-snapshot-a10e7cae : MIT License
+NYTimes-gziphandler v1.1.1 : Apache License 2.0
+oklog/ulid v1.3.1 : Apache License 2.0
+olekukonko-tablewriter v0.0.5 : MIT License
+OneOfOne/xxhash v1.2.2 : Apache License 2.0
+onsi/ginkgo v2.9.4 : MIT License
+open-telemetry/opentelemetry-go exporters/otlp/internal/retry/v1.14.0 : Apache License 2.0
+open-telemetry/opentelemetry-go exporters/otlp/otlptrace/otlptracegrpc/v1.14.0 : Apache License 2.0
+open-telemetry/opentelemetry-go exporters/otlp/otlptrace/otlptracehttp/v1.14.0 : Apache License 2.0
+open-telemetry/opentelemetry-go exporters/otlp/otlptrace/v1.14.0 : Apache License 2.0
+open-telemetry/opentelemetry-go metric/v0.37.0 : Apache License 2.0
+open-telemetry/opentelemetry-go sdk/v1.14.0 : Apache License 2.0
+open-telemetry/opentelemetry-go trace/v1.14.0 : Apache License 2.0
+open-telemetry/opentelemetry-go v1.14.0 : Apache License 2.0
+open-telemetry/opentelemetry-go-contrib instrumentation/google.golang.org/grpc/otelgrpc/v0.40.0 : Apache License 2.0
+open-telemetry/opentelemetry-go-contrib instrumentation/net/http/otelhttp/v0.35.1 : Apache License 2.0
+OpenCensus v0.4.1 : Apache License 2.0
+opencontainers-runtime-spec v1.1.0-rc.1 : Apache License 2.0
+opencontainers/go-digest 1.0.0 : Apache License 2.0
+opencontainers/selinux v1.11.0 : Apache License 2.0
+oras.land/oras-go v1.2.3 : Apache License 2.0
+PaesslerAG/gval v1.0.0 : BSD 3-clause "New" or "Revised" License
+PaesslerAG/jsonpath 0.1.1 : BSD 3-clause "New" or "Revised" License
+pascaldekloe/goe 20180627-snapshot-57f6aae5 : Public Domain
+phayes/freeport 20220201-snapshot-74d24b5a : BSD 3-clause "New" or "Revised" License
+pkg/diff 20210226-snapshot-20ebb0f2 : BSD 3-clause "New" or "Revised" License
+pkg/errors v0.9.1 : BSD 2-clause "Simplified" License
+pmezard-go-difflib 1.0.0 : BSD 3-clause "New" or "Revised" License
+posener/complete v1.2.3 : MIT License
+poy/onpar v1.1.2 : MIT License
+pq v1.10.9 : MIT License
+pquerna/cachecontrol v0.1.0 : Apache License 2.0
+prometheus-client_model v0.4.0 : Apache License 2.0
+prometheus-common v0.44.0 : Apache License 2.0
+prometheus-procfs v0.10.1 : Apache License 2.0
+prometheus/tsdb v0.7.1 : Apache License 2.0
+pty v1.1.1 : MIT License
+rogpeppe/go-internal v1.10.0 : BSD 3-clause "New" or "Revised" License
+rsc/binaryregexp v0.2.0 : BSD 3-clause "New" or "Revised" License
+rsc/quote v3.1.0 : BSD 3-clause "New" or "Revised" License
+rsc/sampler v1.3.0 : BSD 3-clause "New" or "Revised" License
+runc v1.1.4 : Apache License 2.0
+sean-/seed 20170313-snapshot-e2103e2c : (MIT License AND BSD 3-clause "New" or "Revised" License)
+sergi/go-diff v1.1.0 : (MIT License AND Apache License 2.0)
+sftp v1.10.1 : BSD 2-clause "Simplified" License
+shopspring-decimal v1.3.1 : MIT License
+shurcooL-sanitized_anchor_name 1.0.0 : MIT License
+sigs.k8s.io/json 20221116-snapshot-bc3834ca : (Apache License 2.0 AND BSD 3-clause "New" or "Revised" License)
+sigs.k8s.io/yaml v1.3.0 : Apache License 2.0
+smartystreets-assertions 20180927-snapshot-b2de0cb4 : MIT License
+soheilhy/cmux v0.1.5 : Apache License 2.0
+spf13-afero v1.6.0 : Apache License 2.0
+spf13-cast v1.5.0 : MIT License
+spf13-cobra v1.7.0 : Apache License 2.0
+sql-migrate v1.3.1 : MIT License
+sqlx v1.3.5 : MIT License
+stefanberger/go-pkcs11uri 20201008-snapshot-78d3cae3 : Apache License 2.0
+stoewer/go-strcase v1.2.0 : MIT License
+stretchr/objx v0.5.0 : MIT License
+subosito/gotenv v1.2.0 : MIT License
+swag v0.22.3 : Apache License 2.0
+syndtr-gocapability 20200815-snapshot-42c35b43 : BSD 2-clause "Simplified" License
+tchap-go-patricia v2.3.1 : MIT License
+tidwall/gjson v1.14.0 : MIT License
+tidwall/match v1.1.1 : MIT License
+tidwall/pretty v1.2.0 : MIT License
+tmc/grpc-websocket-proxy 20220101-snapshot-673ab2c3 : MIT License
+uber-go/atomic v1.10.0 : MIT License
+ugorji's go v1.1.4 : MIT License
+urfave-cli v1.22.12 : MIT License
+utter v1.0.1 : ISC License
+vcs-go v1.13.3 : MIT License
+vishvananda-netlink v1.2.1-beta.2 : Apache License 2.0
+vishvananda-netns 20210104-snapshot-2eb08e3e : Apache License 2.0
+wI2L/jsondiff v0.2.0 : MIT License
+xdg-go/scram v1.1.0 : Apache License 2.0
+xdg-go/stringprep v1.0.2 : Apache License 2.0
+xeipuuv-gojsonpointer 20190904-snapshot-02993c40 : Apache License 2.0
+xeipuuv-gojsonreference 20180127-snapshot-bd5ef7bd : Apache License 2.0
+xeipuuv/gojsonschema v1.2.0 : Apache License 2.0
+xgb 20160522-snapshot-27f12275 : BSD 3-clause "New" or "Revised" License
+xhit/go-str2duration v2.1.0 : BSD 3-clause "New" or "Revised" License
+xiang90-probing 20190116-snapshot-43a291ad : MIT License
+xlab/treeprint v1.2.0 : MIT License
+xordataexchange-crypt 20180613-snapshot-b2862e3d : MIT License
+yaml for Go v2.4.0 : Apache License 2.0
+yaml for Go v3.0.1 : (MIT License AND Apache License 2.0)
+yuin/goldmark v1.4.13 : MIT License
+yvasiyarov-go-metrics 20161221-snapshot-57bccd1c : BSD 2-clause "Simplified" License
+
+
+Copyright Text: 
+
+BurntSushi/toml 1.2.1 github:BurntSushi/toml:v1.2.1
+	Copyright (c) 2013 TOML authors
+	Copyright (c) 2018 TOML authors
+	Copyright 2010 The Go Authors.  All rights reserved
+DATA-DOG-go-sqlmock v1.5.0 github:DATA-DOG/go-sqlmock:v1.5.0
+	Copyright (c) 2013-2019, DATA-DOG teamAll rights reserved
+Go CLI v1.1.5 github:mitchellh/cli:v1.1.5
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+Go Logrus v1.9.0 github:sirupsen/logrus:v1.9.0
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright (c) 2014 Simon Eskildsen
+Go Testify v1.8.2 github:stretchr/testify:v1.8.2
+	Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+GoDoc Text v0.2.0 github:kr/text:v0.2.0
+	Copyright 2012 Keith Rarick
+Golang Protobuf v1.30.0 long_tail:go.googlesource.com/protobuf#v1.30.0
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2008 Google Inc.  All rights reserved
+	Copyright \d\d\d\d The Go Authors\. All rights reserved
+	Copyright 2023 The Go Authors. All rights reserved
+	copyright headers:\n	}
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright \d\d\d\d Google Inc\.  All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright 2022 The Go Authors. All rights reserved
+Golang Protobuf v1.5.3 github:golang/protobuf:v1.5.3
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2015 The Go Authors.  All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+Keploy.io v0.7.12 github:keploy/keploy:v0.7.12
+	Copyright 2022 Keploy Inc
+Masterminds-squirrel v1.5.4 github:Masterminds/squirrel:v1.5.4
+	Copyright (c) 2014-2015, Lann Martin. Copyright (C) 2015-2016, Google. Copyright (C) 2015, Matt Farina and Matt Butcher.
+Masterminds/goutils v1.1.1 github:Masterminds/goutils:v1.1.1
+	Copyright 2014 Alexander Okoli
+Microsoft-go-winio v0.6.0 github:Microsoft/go-winio:v0.6.0
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2015 Microsoft
+Microsoft-hcsshim v0.10.0-rc.7 github:Microsoft/hcsshim:v0.10.0-rc.7
+	Copyright (c) 2018 lestrrat
+	Copyright (c) 2019 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2018 Klaus Post. All rights reserved
+	Copyright 2018 gRPC authors.
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright 2022 The Linux Foundation
+	Copyright 2016 Docker, Inc.
+	Copyright 2018 The Go Authors.  All rights reserved
+	Copyright 2020 The OPA Authors.  All rights reserved
+	Copyright 2016 The filepathx Authors
+	Copyright 2016 Google LLC
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright 2013-2015 CoreOS, Inc.
+	Copyright of the binary if any
+	Copyright (c) 2015-2016 The Decred developers
+	Copyright 2019, OpenCensus Authors
+	Copyright (c) 2013-2014 The btcsuite developers
+	Copyright (c) 2015 Klaus Post
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2016 The Snappy-Go Authors. All rights reserved
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright (c) 2017 Yasuhiro Matsumoto
+	Copyright 2013 MongoDB, Inc.
+	Copyright (c) 2013-2017 The btcsuite developers
+	Copyright 2020, OpenCensus Authors
+	Copyright (c) 2020 Masaaki Goshima
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright © 2011 Russ Ross <russ@russross.com>.
+	Copyright 2021 icza
+	Copyright 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright 2017 The OPA Authors.  All rights reserved
+	Copyright (c) 2016 Jeremy Saenz
+	Copyright 2016 The Linux Foundation.
+	Copyright (c) 2013 Ben Johnson
+	Copyright (c) 2014-2015 The btcsuite developers
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright 2020-2021 The Decred developers
+	Copyright 2021 The OPA Authors.  All rights reserved
+	Copyright 2014 Docker, Inc.
+	Copyright (c) 2020 The Go Authors. All rights reserved
+	Copyright 2012 Richard Crowley. All rights reserved
+	Copyright 2017 gRPC authors.
+	Copyright (c) 2016, The GoGo Authors. All rights reserved
+	Copyright (c) 2014 Cenk Alt
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright (c) 2019 Klaus Post. All rights reserved
+	Copyright 2012 The Gorilla Authors. All rights reserved
+	Copyright (c) 2018, The GoGo Authors. All rights reserved
+	Copyright (c) 2015, Dave Cheney <dave@cheney.net>All rights reserved
+	Copyright 2018 CoreOS, Inc
+	Copyright 2015 The Linux Foundation.
+	Copyright (c) 2013-2020 Dave Collins
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2015 gRPC authors.
+	Copyright 2016-2017 The New York Times Company
+	(C) Then compare this fragment with all other fragments found in this			// selection set to collect conflicts between fragments spread together.			// This compares each item in the list of fragment 
+	Copyright 2015 Docker, Inc.
+	Copyright (c) Faye Amacker. All rights reserved
+	Copyright 2020
+	Copyright (c) 2018 Adam Scarr
+	Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+	Copyright (c) 2013, Yann Collet, released under BSD License.
+	Copyright 2018 The OPA Authors.  All rights reserved
+	Copyright 2015, 2018 CoreOS, Inc.
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2022 The OPA Authors.  All rights reserved
+	Copyright 2019
+	Copyright (c) 2012 Rodrigo Moraes. All rights reserved
+	Copyright (c) 2021 The Go Authors. All rights reserved
+	Copyright The containerd Authors.
+	Copyright (c) 2013, The GoGo Authors. All rights reserved
+	Copyright 2015 CoreOS, Inc.
+	Copyright 2008 Google Inc.  All rights reserved
+	Copyright (c) 2020 The Decred developers
+	Copyright 2010 Google Inc.
+	Copyright (c) 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2018 johandorland ( https://github.com/johandorland )
+	Copyright 2022 Google LLC All Rights Reserved
+	Copyright}}{{end`
+	Copyright 2016 gRPC authors.
+	Copyright 2018 Google LLC All Rights Reserved
+	Copyright 2020, The Go Authors. All rights reserved
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright (c) 2016 David Calavera
+	Copyright (c) 2020 lestrrat-go
+	Copyright 2017 Docker, Inc.
+	Copyright 2016 The Linux Foundation
+	Copyright (c) 2021 lestrrat-go
+	Copyright 2016-2017 The authors
+	Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
+	Copyright (c) 2015 lestrrat
+	Copyright 2019, 2020 OCI Contributors
+	Copyright 2016-2022 The Linux Foundation
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	copyright message.(! git grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)\|DO NOT EDIT" -- '*.go')
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright 2019 Montgomery Edwards
+	Copyright 2019 gRPC authors.
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright (c) 2014 Sam Ghods
+	Copyright (c) 2019 Montgomery Edwards
+	Copyright 2019 The OPA Authors.  All rights reserved
+	copyright doctrines of fair use, fair dealing, or otherequivalents.
+	Copyright (c) 2015-2019 The Decred developers
+	Copyright 2013-2018 Docker, Inc.
+	Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+	Copyright 2020 Google LLC All Rights Reserved
+	Copyright string	// Name of Author (Note: Use App.Authors, this is deprecated)	Author string	// Email of Author (Note: Use App.Authors, this is deprecated)	Email string	// Writer writer to write 
+	Copyright (c) 2015-2020 The Decred developers
+	Copyright (c) 2016 Sergey Kamardin
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright 2011 Google Inc.
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2015 The btcsuite developers
+	Copyright 2017 The Go Authors.  All rights reserved
+	Copyright 2017, OpenCensus Authors
+	Copyright 2017-2020 Authors of Cilium
+	Copyright 2019 Google LLC All Rights Reserved
+	Copyright {yyyy
+	Copyright 2012-2017 Docker, Inc.
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2018, The Go Authors. All rights reserved
+	copyright is held by the Go authors.
+	Copyright (c) 2017 The Lightning Network Developers
+	Copyright 2013 Google Inc.
+	Copyright 2014 Vishvananda Ishaya.
+	Copyright (c) 2015 The btcsuite developers
+	Copyright 2013-2017 Docker, Inc.
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright (c) 2015-2021 The Decred developers
+	Copyright 2013-2014 The btcsuite developers
+	Copyright (c) 2015 Microsoft
+	Copyright 2012-2015 Docker, Inc.
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2019-present Faye Amacker
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright (c) 2013 Mitchell Hashimoto
+	Copyright 2014 gRPC authors.
+	Copyright The containerd Authors
+	Copyright 2018, OpenCensus Authors
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), GoogleAll rights reserved
+	Copyright 2016 The OPA Authors.  All rights reserved
+	Copyright (c) 2015 Vincent Batts, Raleigh, NC, USA
+OpenCensus v0.4.1 github:census-instrumentation/opencensus-proto:v0.4.1
+	Copyright 2016-18, OpenCensus Authors
+	Copyright 2017, OpenCensus Authors
+	Copyright 2018, OpenCensus Authors
+	Copyright 2019, OpenCensus Authors
+PaesslerAG/gval v1.0.0 github:PaesslerAG/gval:v1.0.0
+	Copyright (c) 2017, Paessler AG <support@paessler.com>All rights reserved
+PaesslerAG/jsonpath 0.1.1 github:PaesslerAG/jsonpath:v0.1.1
+	Copyright (c) 2017, Paessler AG <support@paessler.com>All rights reserved
+agnivade/levenshtein v1.1.1 github:agnivade/levenshtein:v1.1.1
+	Copyright (c) 2015 Agniva De Sarker
+alecthomas-kingpin v2.2.6 github:alecthomas/kingpin:v2.2.6
+	Copyright (C) 2014 Alec Thomas
+alecthomas-kingpin v2.3.2 github:alecthomas/kingpin:v2.3.2
+	Copyright (C) 2014 Alec Thomas
+alecthomas-template 20160405-snapshot-a0175ee3 github:alecthomas/template:a0175ee3bccc567396460bf5acd36800cb10c49c
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+antlr runtime/Go/antlr/v1.4.10 github:antlr/antlr4:runtime/Go/antlr/v1.4.10
+	(C) to the screen. If the printer flip-flop flag; is set, we will send character to printer also. The console; will be checked in the process.;OUTCHAR	LDA	OUTFLAG	;check output flag.	ORA	A	;anyth
+	Copyright 2021 The ANTLR Project
+	(C) contains (FF)
+	Copyright (c) 2012-2022 The ANTLR Project Contributors. All rights reserved
+	Copyright (c) 2012 Terence Parr
+	Copyright (c) 2013 Dan McLaughlin#   All rights reserved
+	(C) to indicate writing to un-used disk space.WTSEQ6	LDA	STATUS	;are we ok so far?	ORA	A	RNZ	PUSH	B	;yes, save write flag for bios (register C).	CALL	LOGICAL	;convert (BLKNMBR) over to loical sec
+	(C) contains (FE) then; this is a status request. Otherwise we are to output (C).;DIRCIO	MOV	A,C	;test for (FF).	INR	A	JZ	DIRC1	INR	A	;test for (FE).	JZ	CONST	JMP	CONOUT	;just output (C).DIRC
+	(C) contains the; byte, and (A) the 'r2' byte.;;   On return, the zero flag is set if the record is within; bounds. Otherwise, an overflow occured.
+	(C) contains 0ffh if this is a read; and thus we can not access unwritten disk space. Otherwise,; another extent will be opened (for writing) if required.;POSITION:XRA	A	;set random i/o flag.	STA
+	Copyright (c) 2012-2022 The ANTLR Project. All rights reserved
+	Copyright (c) 2012-2021 The ANTLR Project. All rights reserved
+	(C) bits.;SHIFTR	INR	CSHIFTR1	DCR	C	RZ	MOV	A,H	ORA	A	RAR	MOV	H,A	MOV	A,L	RAR	MOV	L,A	JMP	SHIFTR1
+	Copyright (c) 2012-2019 The ANTLR Project. All rights reserved
+	Copyright (c) 2012-2017 The ANTLR Project. All rights reserved
+	(C) should contain the number of bytes of the fcb; that must match.;FINDFST	MVI	A,0FFH	STA	FNDSTAT	LXI	H,COUNTER;save character count.	MOV	M,C	LHLD	PARAMS	;get filename to match.	SHLD	SAVEFCB	
+	Copyright (c) 2011 Cay Horstmann	 All rights reserved
+	(C) ha been completed.	MOV	A,B	;is there a better way of doing this?	RRC	RRC	RRC	ANI	1FH	MOV	B,A	;and now (B) is completed.;;   use this as an offset into the disk space allocation; table.
+	Copyright (c) 2012 Sam Harwell *  All rights reserved
+	(C) characters have been checked.;FNDNXT4	INX	D	;bump pointers.	INX	H	INR	B	DCR	C	;adjust character counter.	JMP	FNDNXT2FNDNXT5	LDA	FILEPOS	;return the position of this entry.	ANI	03H	STA	STA
+	(C) should be equal to:	MOV	A,C	;(uuuudddd) where 'uuuu' is the user number	RAR		;and 'dddd' is the drive number.	RAR	RAR	RAR	ANI	0FH	;isolate the user number.	MOV	E,A	CALL	GETSETUC;and set it
+	(C) to the screen.	POP	B	PUSH	B	LDA	PRTFLAG	;check printer flip-flop flag.	ORA	A	CNZ	LIST	;print it also if non-zero.	POP	BOUTCHR1	MOV	A,C	;update cursors position.	LXI	H,CURPOS	CPI	DEL	;rubo
+	Copyright (c) 2021 The ANTLR Project. All rights reserved
+	(C) to number of bytes to change.	CALL	DE2HLUPDATE1	CALL	TRKSEC	;determine the track and sector affected.	JMP	DIRWRITE	;then write this sector out.;;   Routine to change the name of all files on 
+	(C) to the console device and expand tabs; if necessary.;OUTCON	MOV	A,C	CPI	TAB	;is it a tab?	JNZ	OUTCHAR	;use regular output.OUTCON1	MVI	C,' '	;yes it is, use spaces instead.	CALL	OUTCHAR	LDA
+	(C) bytes total.;DE2HL	INR	C	;is count down to zero?DE2HL1	DCR	C	RZ		;yes, we are done.	LDAX	D	;no, move one more byte.	MOV	M,A	INX	D	INX	H	JMP	DE2HL1	;and repeat.
+	(C) bits.;SHIFTL	INR	CSHIFTL1	DCR	C	RZ	DAD	H	;shift left 1 bit.	JMP	SHIFTL1
+	Copyright (c) 2015 Dan McLaughlin *  All rights reserved
+	Copyright (c) 2013 Terence Parr
+	Copyright>Copyright (c) 2012-2020 The ANTLR Project. All rights reserved
+	Copyright Mathias Bynens <https://mathiasbynens.be/>
+	Copyright (c) 2016 Mike Lischke *  All rights reserved
+	Copyright © 2016 Mike Lischke. All rights reserved
+	Copyright 2012-2022 The ANTLR Project
+	(C) and get the byte that;EXTRACT	LXI	H,TBUFF	ADD	C	CALL	ADDHL	MOV	A,M	RET
+	(C) register is set to the command number; that matched (or NUMCMDS+1 if no match).;SEARCH	LXI	H,CMDTBL	MVI	C,0SEARCH1	MOV	A,C	CPI	NUMCMDS	;this commands exists.	RNC	LXI	D,FCB+1	;check this on
+araddon-dateparse 20210429-snapshot-6b43995a github:araddon/dateparse:6b43995a97dee4b2c7fc0bdff8e124da9f31a57e
+	Copyright (c) 2015-2017 Aaron Raddon
+armon-consul-api 20180202-snapshot-eb2c6b5b github:armon/consul-api:eb2c6b5be1b66bab83016e0b05f01b8d5496ffbd
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+armon-go-metrics 20180917-snapshot-f0300d17 github:armon/go-metrics:f0300d1749da6fa982027e449ec0c7a145510c3c
+	Copyright (c) 2013 Armon Dadgar
+armon-go-radix v1.0.0 github:armon/go-radix:v1.0.0
+	Copyright (c) 2014 Armon Dadgar
+armon/circbuf 20150827-snapshot-bbbad097 github:armon/circbuf:bbbad097214e2918d8543d5201d12bfd7bca254d
+	Copyright (c) 2013 Armon Dadgar
+armon/go-socks5 20160902-snapshot-e7533296 github:armon/go-socks5:e75332964ef517daa070d7c38a9466a0d687e0a5
+	Copyright (c) 2014 Armon Dadgar
+benbjohnson-clock v1.1.0 github:benbjohnson/clock:v1.1.0
+	Copyright (c) 2014 Ben Johnson
+beorn7-perks v1.0.1 github:beorn7/perks:v1.0.1
+	Copyright (C) 2013 Blake Mizerany
+bgentry-speakeasy 0.1.0 github:bgentry/speakeasy:v0.1.0
+	Copyright (c) 2017 Blake Gentry
+bketelsen/crypt v0.0.4 github:bketelsen/crypt:v0.0.4
+	Copyright 2015 Google LLC.
+	Copyright 2016, Google Inc.All rights reserved
+	Copyright 2017 Google LLC.
+	Copyright (c) 2019 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2014 Google Inc. All rights reserved
+	Copyright 2018 gRPC authors.
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright (c) 2012 Joel Stemmer
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2019 The etcd Authors
+	Copyright 2019 Google LLC.
+	Copyright 2018 The gRPC Authors
+	Copyright 2020 gRPC authors.
+	Copyright 2008 Google Inc.  All rights reserved
+	Copyright 2012 Google LLC. All rights reserved
+	Copyright 2014 Google LLC
+	Copyright 2016, Google Inc.// All rights reserved
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright 2013-2015 CoreOS, Inc.
+	Copyright 2016 gRPC authors.
+	Copyright 2020, The Go Authors. All rights reserved
+	Copyright (c) 2013 Joshua Tacoma. All rights reserved
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+	Copyright 2019, OpenCensus Authors
+	Copyright 2015 The etcd Authors
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright (c) 2014 XOR Data Exchange, Inc.
+	Copyright 2013 Google Inc. All rights reserved
+	Copyright 2011 Google LLC. All rights reserved
+	Copyright (c) 2013 The Go Authors. All rights reserved
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2020, OpenCensus Authors
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright 2016 The etcd Authors
+	Copyright 2019 gRPC authors.
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright 2018 Google LLC. All rights reserved
+	Copyright 2013 Joshua Tacoma. All rights reserved
+	Copyright 2018, Google Inc.// All rights reserved
+	Copyright 2021 gRPC authors.
+	Copyright 2016 Google LLC.
+	Copyright 2020 Google LLC
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+	Copyright 2021 Google LLC
+	copyright message.not git grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)\|DO NOT EDIT" -- '*.go'
+	Copyright 2018 Google LLC.
+	Copyright 2015 The gRPC Authors
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright 2017, OpenCensus Authors
+	Copyright 2017 gRPC authors.
+	Copyright 2012 Google Inc. All rights reserved
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2015 Google Inc. All rights reserved
+	Copyright 2018, The Go Authors. All rights reserved
+	Copyright (c) 2013 Armon Dadgar
+	Copyright (c) 2016 json-iterator
+	Copyright 2013 Google Inc.
+	Copyright 2018 CoreOS, Inc
+	Copyright 2019 Google LLC
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2020 Google LLC.
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright 2015 gRPC authors.
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2011 Google Inc. All rights reserved
+	Copyright 2014 gRPC authors.
+	Copyright (c) 2013 Mitchell Hashimoto
+	Copyright 2018, OpenCensus Authors
+	Copyright 2013 Google LLC. All rights reserved
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright 2011 Google Inc. All rights reserved
+blackfriday v1.6.0 github:russross/blackfriday:v1.6.0
+	(C)|d\n---		"<table>\n<thead>\n<tr>\n<th><em>a</em></th>\n<th><strong>b</strong></th>\n<th><a href=\"C\">c</a></th>\n<th>d</th>\n</tr>\n</thead>\n\n" +			"<tbody>\n<tr>\n<td>e</td>\n<td>f</td>\n<td>
+	Copyright © 2011 Russ RossAll rights reserved
+	Copyright © 2011 Russ Ross <russ@russross.com>.
+blang-semver v4.0.0 github:blang/semver:v4.0.0
+	Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+bshuster-repo/logrus-logstash-hook v1.0.0 github:bshuster-repo/logrus-logstash-hook:v1.0.0
+	Copyright (c) 2016 Boaz Shuster
+btree v1.1.2 github:google/btree:v1.1.2
+	Copyright 2014 Google Inc.
+	Copyright 2014-2022 Google Inc.
+bugsnag-osext 20130617-snapshot-0dd3f918 github:bugsnag/osext:0dd3f918b21bec95ace9dc86c7e70266cfc5c702
+	Copyright (c) 2012 Daniel Theophanes
+	Copyright 2012 The Go Authors. All rights reserved
+bugsnag/panicwrap 20160225-snapshot-e2c28503 github:bugsnag/panicwrap:e2c28503fcd0675329da73bf48b33404db873782
+	Copyright (c) 2013 Mitchell Hashimoto
+cenkalti/backoff v4.2.1 github:cenkalti/backoff:v4.2.1
+	Copyright (c) 2014 Cenk Alt
+census-instrumentation/opencensus-go v0.24.0 github:census-instrumentation/opencensus-go:v0.24.0
+	Copyright 2020, OpenCensus Authors
+	Copyright 2017, OpenCensus Authors
+	Copyright 2018, OpenCensus Authors
+	Copyright 2019, OpenCensus Authors
+cespare/xxhash v1.1.0 github:cespare/xxhash:v1.1.0
+	Copyright (c) 2016 Caleb Spare
+chai2010-gettext-go v1.0.2 github:chai2010/gettext-go:v1.0.2
+	Copyright (C) YEAR THE PACKAGE
+	Copyright 2013 ChaiShushan <chaishushan
+	Copyright 2019 <chaishushan
+	Copyright 2020 ChaiShushan <chaishushan
+	Copyright 2013 ChaiShushan <chaishushan
+	Copyright 2013 <chaishushan
+chzyer-readline 20180828-snapshot-2972be24 github:chzyer/readline:2972be24d48e78746da79ba8e24e8b488c9880de
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+	Copyright (c) 2015 Chzyer
+chzyer/test 20190214-snapshot-a1ea475d github:chzyer/test:a1ea475d72b168a29f44221e0ad031a842642302
+	Copyright (c) 2016 chzyer
+cilium/ebpf v0.9.1 github:cilium/ebpf:v0.9.1
+	Copyright (c) 2017 Nathan Sweet
+	Copyright (c) 2018, 2019 Cloudflare
+	Copyright (c) 2015-2017 Cloudflare, Inc. All rights reserved
+	Copyright (c) 2019 Authors of Cilium
+client-go v0.28.1 github:kubernetes/client-go:v0.28.1
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+client9/misspell v0.3.4 github:client9/misspell:v0.3.4
+	Copyright 2011 The Go Authors. All rights reserved
+	copyright Nick Galbreath and distribution is allowed under a
+	Copyright (c) 2015-2017 Nick Galbreath
+	Copyright (c) 2009 The Go Authors. All rights reserved
+client_golang v1.16.0 github:prometheus/client_golang:v1.16.0
+	Copyright 2015 The Prometheus Authors
+	Copyright 2013 Matt T. Proud
+	Copyright 2017 The Prometheus Authors
+	Copyright 2021 The Prometheus Authors
+	Copyright 2012-2015 The Prometheus Authors
+	copyright of the original repo.// https://github.com/beorn7/floatspackage internal
+	Copyright 2013-2015 Blake Mizerany, Bj
+	Copyright 2019 The Prometheus Authors
+	Copyright 2022 The Prometheus Authors
+	Copyright (c) 2013, The Prometheus Authors
+	Copyright (c) 2015 Bj
+	Copyright 2016 The Prometheus Authors
+	Copyright 2018 The Prometheus Authors
+	Copyright 2020 The Prometheus Authors
+	Copyright 2010 The Go Authors
+	Copyright 2014 The Prometheus Authors
+	Copyright 2023 The Prometheus Authors
+container-orchestrated-devices/container-device-interface v0.5.4 github:container-orchestrated-devices/container-device-interface:v0.5.4
+	Copyright © The CDI Authors
+	Copyright © 2021-2022 The CDI Authors
+	Copyright © 2021 The CDI Authors
+	Copyright © 2022 The CDI Authors
+containerd/btrfs v2.0.0 github:containerd/btrfs:v2.0.0
+	Copyright The containerd Authors
+	Copyright {yyyy
+	Copyright The containerd Authors.
+containerd/cgroups v1.1.0 github:containerd/cgroups:v1.1.0
+	Copyright The containerd Authors.
+containerd/cgroups v3.0.1 github:containerd/cgroups:v3.0.1
+	Copyright The containerd Authors.
+containerd/console 1.0.3 github:containerd/console:v1.0.3
+	Copyright The containerd Authors
+	Copyright The containerd Authors.
+containerd/containerd v1.7.0 github:containerd/containerd:v1.7.0
+	Copyright 2013 Miek Gieben. All rights reserved
+	Copyright 2018 Klaus Post. All rights reserved
+	Copyright 2018 gRPC authors.
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright 2018 Square Inc.
+	Copyright 2023 The Go Authors. All rights reserved
+	Copyright (c) 2013 Dario Casta
+	Copyright 2016 Docker, Inc.
+	Copyright (C) Docker/Moby authors.
+	Copyright 2015-2017 CNI authors
+	Copyright 2019 Intel Corporation
+	Copyright (c) 2014 The go-patricia AUTHORS
+	Copyright 2016 The filepathx Authors
+	Copyright 2010 The Go Authors
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2014-2021 Docker Inc.
+	Copyright 2013 Google Inc. All Rights Reserved
+	Copyright 2021 Intel Corporation. All Rights Reserved
+	Copyright 2019 The logr Authors.
+	Copyright (c) 2015 Klaus Post
+	(C) 2019 Minio, Inc.
+	Copyright 2013 Matt T. Proud
+	Copyright 2022 ADA Logics Ltd
+	Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+	Copyright 2020 The logr Authors.
+	Copyright 2016 The Snappy-Go Authors. All rights reserved
+	Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright © 2022 The CDI Authors
+	Copyright The ocicrypt Authors.
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright © 2011 Russ Ross <russ@russross.com>.
+	Copyright 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright 2016 The Linux Foundation.
+	Copyright (c) 2013 Ben Johnson
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright © 2012 The Go Authors. All rights reserved
+	Copyright 2015 The Prometheus Authors
+	Copyright 2015 CNI authors
+	Copyright © 2021-2022 The CDI Authors
+	Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
+	Copyright 2019 The Prometheus Authors
+	Copyright 2017 gRPC authors.
+	Copyright 2014 The Prometheus Authors
+	Copyright (c) 2016, The GoGo Authors. All rights reserved
+	Copyright 2022 Intel Corporation
+	Copyright (c) 2014 Cenk Alt
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright 2020 Intel Corporation
+	Copyright © 2021 The CDI Authors
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2015 Docker, Inc.
+	Copyright (c) 2011-2019 Canonical Ltd
+	Copyright 2013-2015 Blake Mizerany, Bj
+	Copyright 2019 The Kubernetes Authors.
+	Copyright 2016 CoreOS, Inc.
+	Copyright 2020 The Prometheus Authors
+	Copyright 2014 Prometheus Team
+	Copyright 2020
+	Copyright (c) 2009,2014 Google Inc. All rights reserved
+	Copyright 2011 Google Inc. All rights reserved
+	Copyright 2015 The Prometheus Authors
+	Copyright 2021 The Prometheus Authors
+	Copyright 2015, 2018 CoreOS, Inc.
+	Copyright (C) 2017 SUSE LLC. All rights reserved
+	Copyright 2016 CNI authors
+	Copyright 2019
+	Copyright (c) 2012,2013 Ernest Micklei
+	Copyright (c) 2011 The Snappy-Go Authors. All rights reserved
+	Copyright}}{{end`
+	Copyright 2016 gRPC authors.
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright The runc Authors.
+	(C) 2017 Minio, Inc.
+	Copyright 2017 Docker, Inc.
+	Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
+	(C) 2016 Minio, Inc.
+	Copyright 2016 The Linux Foundation
+	Copyright 2021 Google Inc.  All rights reserved
+	Copyright The Moby Authors.
+	Copyright 2019, 2020 OCI Contributors
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright 2019 gRPC authors.
+	Copyright (c) 2006-2011 Kirill Simonov
+	Copyright 2018 Google Inc.  All rights reserved
+	Copyright (c) 2012 Alex Ogier. All rights reserved
+	Copyright 2015-2018 CoreOS, Inc.
+	Copyright 2013-2018 Docker, Inc.
+	Copyright 2020 Google LLC
+	Copyright (c) 2018, 2019 Cloudflare
+	Copyright 2019, OpenTelemetry Authors
+	Copyright 2020, 2020 OCI Contributors
+	Copyright 2017, OpenCensus Authors
+	Copyright 2022 Google LLC
+	Copyright 2020 Intel Corporation. All Rights Reserved
+	Copyright {yyyy
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2018, The Go Authors. All rights reserved
+	Copyright (c) 2016 json-iterator
+	Copyright 2014 Ernest Micklei. All rights reserved
+	Copyright 2017 The Prometheus Authors
+	Copyright 2019-2021 Intel Corporation
+	Copyright 2012-2015 The Prometheus Authors
+	Copyright 2012-2015 Docker, Inc.
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright 2013-2016 Docker, Inc.
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), GoogleAll rights reserved
+	copyright message.# (Done in two parts because Darwin "git grep" has broken support for compound# exclusion matches.)(grep -L "DO NOT EDIT" $(git grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)" --
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright (c) 2013-2016 Dave Collins <dave@davec.name> * * Permission to use, copy, modify, and distribute this software for any * purpose with or without fee is hereby granted, provided that the a
+	Copyright 2022 The Linux Foundation
+	Copyright 2023 The go-fuzz-headers Authors.
+	copyright of the original repo.// https://github.com/beorn7/floatspackage internal
+	Copyright 2018 The Go Authors.  All rights reserved
+	Copyright © fsnotify Authors. All rights reserved
+	Copyright 2020 gRPC authors.
+	Copyright 2018 The Prometheus Authors
+	Copyright 2021 Ernest Micklei. All rights reserved
+	Copyright (c) 2006-2010 Kirill Simonov
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright (c) 2017, Intel Corporation
+	Copyright (c) 2014, OmniTI Computer Consulting, Inc.
+	Copyright of the binary if any
+	Copyright 2021 Intel Corporation
+	Copyright 2019, OpenCensus Authors
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+	Copyright The OpenTelemetry Authors
+	Copyright 2013 The Prometheus Authors
+	Copyright 2014-2021 Docker Inc.
+	Copyright 2021 The logr Authors.
+	Copyright (c) 2023 Jeremy Saenz
+	Copyright 2013 Dario Casta
+	Copyright 2020, OpenCensus Authors
+	copyright staring in 2011 when the project was ported over:
+	Copyright The Kubernetes Authors.
+	Copyright 2014 Square Inc.
+	Copyright (c) 2017 Nathan Sweet
+	Copyright 2021 gRPC authors.
+	Copyright (C) 2014-2015 Docker Inc
+	Copyright (c) 2020 Klaus Post, released under MIT License. See LICENSE file.
+	Copyright (c) 2011, Open Knowledge Foundation Ltd.All rights reserved
+	Copyright 2021 ADA Logics Ltd
+	Copyright 2014-2015 The Prometheus Authors
+	Copyright 2014 Docker, Inc.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright (c) 2019 Klaus Post. All rights reserved
+	Copyright 2017 The Kubernetes Authors.
+	Copyright (c) 2018, The GoGo Authors. All rights reserved
+	Copyright 2018 The Kubernetes Authors.
+	Copyright (c) 2015, Dave Cheney <dave@cheney.net>All rights reserved
+	Copyright 2018 CoreOS, Inc
+	Copyright 2015 The Linux Foundation.
+	Copyright 2017 Prometheus Team
+	Copyright 2015 gRPC authors.
+	Copyright 2016-2017 The New York Times Company
+	(c) Copyright IBM Corporation, 2020
+	Copyright (c) 2014 The AUTHORS
+	Copyright 2017 Google Inc.  All rights reserved
+	Copyright 2018 Ernest Micklei. All rights reserved
+	Copyright 2016 Michal Witkowski. All Rights Reserved
+	Copyright (c) 2013, Yann Collet, released under BSD License.
+	Copyright The docker Authors.
+	Copyright 2019 CNI authors
+	Copyright (c) 2009 The GoAuthors. All rights reserved
+	Copyright 2014 Google Inc. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2022 gRPC authors.
+	Copyright The containerd Authors.
+	Copyright 2018 The gRPC Authors
+	Copyright (c) 2013, The GoGo Authors. All rights reserved
+	Copyright (c) 2015 Bj
+	Copyright 2015 CoreOS, Inc.
+	Copyright 2008 Google Inc.  All rights reserved
+	Copyright 2022 The Kubernetes Authors.
+	Copyright 2020, The Go Authors. All rights reserved
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+	Copyright 2014 Dario Casta
+	Copyright (c) 2015 Andrew Smith
+	Copyright 2013 Ernest Micklei. All rights reserved
+	Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
+	Copyright 2016 The Prometheus Authors
+	Copyright 2016-2022 The Linux Foundation
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright (c) 2013 Miek Gieben. All rights reserved
+	Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+	Copyright 2020-2021 Intel Corporation. All Rights Reserved
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2016 Google Inc.  All rights reserved
+	Copyright (c) 2014 Sam Ghods
+	Copyright 2018 Google LLC. All rights reserved
+	Copyright (c) 2019 Authors of Cilium
+	Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+	Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+	Copyright string	// Name of Author (Note: Use App.Authors, this is deprecated)	Author string	// Email of Author (Note: Use App.Authors, this is deprecated)	Email string	// Writer writer to write 
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2015 The gRPC Authors
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2017 The Go Authors.  All rights reserved
+	Copyright 2014-2016 CNI authors
+	Copyright (c) 2012 P
+	Copyright 2012-2017 Docker, Inc.
+	Copyright © The CDI Authors
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2015 Google Inc. All rights reserved
+	copyright is held by the Go authors.
+	Copyright 2013 Google Inc.
+	Copyright 2014 Vishvananda Ishaya.
+	Copyright (c) OASIS Open 2016. All Rights Reserved
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2013 Suryandaru Triandana <syndtr@gmail.com>All rights reserved
+	Copyright (c) 2015 Microsoft
+	Copyright 2022 The Prometheus Authors
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright (C) 2013 Blake Mizerany
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2014 gRPC authors.
+	Copyright The containerd Authors
+	Copyright 2018, OpenCensus Authors
+	Copyright 2015 Ernest Micklei. All rights reserved
+	Copyright 2018 CNI authors
+	(C) 2021 Minio, Inc.
+containerd/continuity v0.3.0 github:containerd/continuity:v0.3.0
+	Copyright The containerd Authors
+	Copyright The containerd Authors.
+containerd/fifo v1.1.0 github:containerd/fifo:v1.1.0
+	Copyright The containerd Authors.
+containerd/go-runc v1.0.0 github:containerd/go-runc:v1.0.0
+	Copyright The containerd Authors.
+containerd/nri v0.3.0 github:containerd/nri:v0.3.0
+	Copyright The containerd Authors.
+containerd/typeurl 1.0.2 github:containerd/typeurl:v1.0.2
+	Copyright The containerd Authors
+	Copyright The containerd Authors.
+containerd/typeurl v2.1.0 github:containerd/typeurl:v2.1.0
+	Copyright The containerd Authors
+	Copyright The containerd Authors.
+containernetworking/plugins v1.2.0 github:containernetworking/plugins:v1.2.0
+	Copyright (c) 2014 ActiveState
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright (c) 2019 FOSS contributors of https://github.com/nxadm/tail
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2016 CNI authors
+	Copyright 2018 The Go Authors.  All rights reserved
+	Copyright The containerd Authors.
+	Copyright 2015-2017 CNI authors
+	Copyright (c) 2013, The GoGo Authors. All rights reserved
+	Copyright 2014 CNI authors
+	Copyright 2015 CoreOS, Inc.
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright (c) 2006-2010 Kirill Simonov
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright 2020, The Go Authors. All rights reserved
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+	Copyright 2017-2018 CNI authors
+	Copyright 2019, OpenCensus Authors
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright (c) 2019 FOSS contributors of https://github.com/nxadm/tail// +build windows
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2020 CNI authors
+	Copyright 2022 CNI authors
+	Copyright (c) 2015 HPE Software Inc. All rights reserved
+	Copyright 2021 CNI authors
+	© Copyright 2015 Hewlett Packard Enterprise Development LP
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright (c) 2012-2019 fsnotify Authors. All rights reserved
+	Copyright (c) 2017 Yasuhiro Matsumoto
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	copyright staring in 2011 when the project was ported over:
+	Copyright (c) 2011 - Gustavo Niemeyer <gustavo@niemeyer.net>// // All rights reserved
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright (c) 2013 Skagerrak Software Limited. All rights reserved
+	Copyright (c) 2016 Yasuhiro Matsumoto
+	Copyright (c) 2010-2017 Alex Flint.
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright (c) 2006-2011 Kirill Simonov
+	Copyright (c) 2019 FOSS contributors of https://github.com/nxadm/tailpackage watch
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright (c) 2016 Leonid Bugaev
+	Copyright 2015 CNI authors
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2013 ActiveState Software Inc. All rights reserved
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2014 Docker, Inc.
+	Copyright 2017 The Go Authors.  All rights reserved
+	Copyright 2017, OpenCensus Authors
+	Copyright 2014-2016 CNI authors
+	Copyright {yyyy
+	Copyright (c) 2016, The GoGo Authors. All rights reserved
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2018, The Go Authors. All rights reserved
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright 2013 Google Inc.
+	Copyright 2014 Vishvananda Ishaya.
+	Copyright (c) 2018, The GoGo Authors. All rights reserved
+	Copyright (c) 2010-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
+	Copyright (c) 2015, Dave Cheney <dave@cheney.net>All rights reserved
+	Copyright 2018 CoreOS, Inc
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright 2016-2018 CNI authors
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2017-2020 CNI authors
+	Copyright (c) 2015 Microsoft
+	Copyright (C) 2013 99designs
+	Copyright (c) 2011-2019 Canonical Ltd
+	Copyright (c) 2019 FOSS contributors of https://github.com/nxadm/tail// +build !windows
+	Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright (c) 2013-2014 Onsi Fakhouri
+	Copyright 2015-2018 CNI authors
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2021 Red Hat, Inc. *
+	Copyright 2018, OpenCensus Authors
+	Copyright 2017 CNI authors
+	Copyright 2022 Arista Networks
+	Copyright 2018 CNI authors
+	Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), GoogleAll rights reserved
+	Copyright 2019 CNI authors
+containers/ocicrypt v1.1.6 github:containers/ocicrypt:v1.1.6
+	Copyright The ocicrypt Authors.
+	Copyright The containerd Authors.
+coreos-go-oidc v2.1.0 github:coreos/go-oidc:v2.1.0
+	Copyright {yyyy
+	Copyright 2014 CoreOS, Inc
+coreos-pkg 20181023-snapshot-399ea9e2 github:coreos/pkg:399ea9e2e55f791b6e3d920860dbecb99c3692f0
+	Copyright 2016 CoreOS, Inc.
+	Copyright {yyyy
+	Copyright 2014 CoreOS, Inc
+	Copyright 2015 CoreOS, Inc.
+coreos/bbolt v1.3.2 github:coreos/bbolt:v1.3.2
+	Copyright (c) 2013 Ben Johnson
+creack/pty v1.1.18 github:creack/pty:v1.1.18
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright (c) 2011 Keith Rarick
+creasty/defaults v1.5.2 github:creasty/defaults:v1.5.2
+	Copyright (c) 2017-present Yuki Iwanaga
+cyphar/filepath-securejoin v0.2.3 github:cyphar/filepath-securejoin:v0.2.3
+	Copyright (C) 2014-2015 Docker Inc
+	Copyright (C) 2017 SUSE LLC. All rights reserved
+danieljoos/wincred v1.1.2 github:danieljoos/wincred:v1.1.2
+	Copyright (c) 2014 Daniel Joos
+daviddengcn/go-colortext 1.0.0 github:daviddengcn/go-colortext:v1.0.0
+	Copyright (c) 2016 David Deng
+	Copyright (c) 2016, David DengAll rights reserved
+diskv v2.0.1 github:peterbourgon/diskv:v2.0.1
+	Copyright (c) 2011-2012 Peter Bourgon
+docker v23.0.1 github:docker/docker:v23.0.1
+	Copyright 2015 Google LLC.
+	Copyright 2013-2022 The Cobra Authors
+	Copyright (c) 2019 The Go Authors. All rights reserved
+	Copyright The BuildKit Authors.
+	Copyright 2018 Klaus Post. All rights reserved
+	Copyright 2011 Miek Gieben. All rights reserved
+	Copyright 2018 gRPC authors.
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright (c) 2013 Dario Casta
+	Copyright 2016 Docker, Inc.
+	Copyright (c) 2017 Sean Chittenden
+	Copyright 2017 Google LLC. All Rights Reserved
+	Copyright (c) 2014 The go-patricia AUTHORS
+	Copyright 2014 Google LLC
+	Copyright 2016 The filepathx Authors
+	Copyright 2017 T
+	Copyright 2010 The Go Authors
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2013 Google Inc. All Rights Reserved
+	Copyright 2016 ALRUX Inc.
+	Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
+	Copyright 2015 The etcd Authors
+	Copyright 2019 The logr Authors.
+	Copyright (c) 2015 Klaus Post
+	Copyright 2013 Matt T. Proud
+	Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+	Copyright 2020 The logr Authors.
+	Copyright 2016 The Snappy-Go Authors. All rights reserved
+	Copyright 2017 Google Inc.
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright 2016 The etcd Authors
+	Copyright (c) 2016 Uber Technologies, Inc.
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright (c) 2016 Taihei Morikuni
+	Copyright 2016 The Linux Foundation.
+	Copyright (c) 2013 Ben Johnson
+	Copyright 2014 CloudFlare. All rights reserved
+	Copyright 2013 Joshua Tacoma. All rights reserved
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright 2015 The Prometheus Authors
+	copyright message.not git grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)\|DO NOT EDIT" -- '*.go'
+	Copyright 2019 The Prometheus Authors
+	Copyright 2017 gRPC authors.
+	Copyright 2015 James Saryerwinnie
+	Copyright 2012 Google Inc. All rights reserved
+	Copyright 2014 The Prometheus Authors
+	Copyright (c) 2016, The GoGo Authors. All rights reserved
+	Copyright 2012 The Gorilla Authors. All rights reserved
+	Copyright 2014-2022 Google Inc.
+	Copyright 2019 Google LLC
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2020 Google LLC.
+	Copyright 2018 Google LLC
+	Copyright 2015 Docker, Inc.
+	Copyright 2013-2015 Blake Mizerany, Bj
+	Copyright (C) 1999-2008 Novell Inc.
+	Copyright 2016 CoreOS, Inc.
+	Copyright 2020 The Prometheus Authors
+	Copyright The containerd Authors.func compareSymlinkTarget(p1, p2 string) (bool, error) {	t1, err := os.Readlink(p1)	if err != nil {		return false, err	}	t2, err := os.Readlink(p2)	if err != ni
+	Copyright 2014 Prometheus Team
+	Copyright 2020
+	Copyright (c) 2009,2014 Google Inc. All rights reserved
+	Copyright (c) 2017 Gal Ben-Haim
+	Copyright (c) 2013 Ralph Caraveo (deckarep@gmail.com)
+	Copyright 2011 Google Inc. All rights reserved
+	Copyright (c) 2020-2021 Uber Technologies, Inc.
+	Copyright 2015 The Prometheus Authors
+	Copyright 2016, Google Inc.All rights reserved
+	Copyright 2021 The Prometheus Authors
+	Copyright 2015, 2018 CoreOS, Inc.
+	Copyright (C) 2017 SUSE LLC. All rights reserved
+	Copyright 2019
+	Copyright (c) 2021 The Go Authors. All rights reserved
+	Copyright (c) 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 gRPC authors.
+	Copyright 2014 Google Inc.
+	Copyright 2015 Google LLC. All Rights Reserved
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright The runc Authors.
+	Copyright 2017 Docker, Inc.
+	Copyright 2016 The Linux Foundation
+	Copyright 2021 Google Inc.  All rights reserved
+	(C)		currPre :=		currPost := current		currPost.count -= precBlocks		newSequence.next = currPost		if currPost == head {			newHead = currPre		} else {			previous.next = currPre		}		// No mergi
+	Copyright (c) 2017 Uber Technologies, Inc.
+	Copyright (c) 2016 Alex Dadgar
+	Copyright 2011 Google LLC. All rights reserved
+	Copyright 2019, 2020 OCI Contributors
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright 2014 Google LLC. All Rights Reserved
+	Copyright 2009-2012 Canonical Ltd.
+	Copyright The containerd Authors.func compareSysStat(s1, s2 interface{}) (bool, error) {	ls1, ok := s1.(*syscall.Stat_t)	if !ok {		return false, nil	}	ls2, ok := s2.(*syscall.Stat_t)	if !ok {	
+	Copyright 2019 gRPC authors.
+	Copyright 2018 Google Inc.  All rights reserved
+	copyright doctrines of fair use, fair dealing, or otherequivalents.
+	Copyright (c) 2012 Alex Ogier. All rights reserved
+	Copyright 2015-2018 CoreOS, Inc.
+	Copyright 2013-2018 Docker, Inc.
+	Copyright 2012 Google Inc. All Rights Reserved
+	Copyright 2020 Google LLC
+	Copyright (c) 2018, 2019 Cloudflare
+	Copyright 2015 Tim Heckman. All rights reserved
+	Copyright 2019, OpenTelemetry Authors
+	Copyright 2020, 2020 OCI Contributors
+	Copyright (c) 2005-2008  Dustin Sallings <dustin@spy.net>
+	Copyright 2017, OpenCensus Authors
+	Copyright 2022 Google LLC
+	Copyright {yyyy
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright (c) 2022 T
+	Copyright 2018, The Go Authors. All rights reserved
+	copyright (c) 2011 Miek Gieben
+	Copyright 2017 The Prometheus Authors
+	Copyright 2012-2015 The Prometheus Authors
+	Copyright (c) 2012, 2013 Ugorji Nwoke.All rights reserved
+	Copyright (c) 2021 Uber Technologies, Inc.
+	Copyright 2012-2015 Docker, Inc.
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2015 Rackspace. All rights reserved
+	Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved
+	Copyright (c) 2012, 2013 Ugorji Nwoke. All rights reserved
+	Copyright 2013 Google LLC. All rights reserved
+	Copyright 2013-2016 Docker, Inc.
+	Copyright 2016-2018 Docker Inc.
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright 2016 Google LLC. All Rights Reserved
+	Copyright 2021 Google LLC. All Rights Reserved
+	Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), GoogleAll rights reserved
+	Copyright (c) 2017-2021 Uber Technologies, Inc.
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2022, Google Inc.// All rights reserved
+	copyright of the original repo.// https://github.com/beorn7/floatspackage internal
+	Copyright 2018 The Go Authors.  All rights reserved
+	Copyright 2019 Google LLC.
+	Copyright (c) 2014 Philip Hofer
+	Copyright 2020 gRPC authors.
+	Copyright 2016, Google Inc.// All rights reserved
+	Copyright 2018 The Prometheus Authors
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright (c) 2014, OmniTI Computer Consulting, Inc.
+	Copyright (c) 2013 Joshua Tacoma. All rights reserved
+	Copyright 2019, OpenCensus Authors
+	Copyright 2009-2018 Canonical Ltd.`,			version: 300000,
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+	Copyright (c) 2015 John Howard (Microsoft)
+	Copyright The OpenTelemetry Authors
+	Copyright 2013 The Prometheus Authors
+	Copyright 2018, GoGo Authors
+	Copyright 2021 The logr Authors.
+	Copyright (c) 2017 T
+	Copyright (c) 2013 The Go Authors. All rights reserved
+	Copyright (c) "*" Uber Technologies, Inc.")			# everything's cool			;;
+	Copyright 2013 Dario Casta
+	Copyright 2020, OpenCensus Authors
+	Copyright 2012 SocialCode. All rights reserved
+	Copyright 2022 Alan Shreve (@inconshreveable)
+	Copyright (c) 2014 Armon Dadgar
+	Copyright (c) 2017 Nathan Sweet
+	Copyright 2018, Google Inc.// All rights reserved
+	Copyright 2021 gRPC authors.
+	Copyright (C) 2014-2015 Docker Inc
+	Copyright (c) 2011, Open Knowledge Foundation Ltd.All rights reserved
+	Copyright 2014-2015 The Prometheus Authors
+	Copyright 2014 Docker, Inc.
+	Copyright (c) 2020 The Go Authors. All rights reserved
+	Copyright (c) 2014 CloudFlare Inc.
+	Copyright (c) 2019 Klaus Post. All rights reserved
+	Copyright 2022 Google LLC.
+	Copyright (c) 2018, The GoGo Authors. All rights reserved
+	Copyright (c) 2015, Dave Cheney <dave@cheney.net>All rights reserved
+	Copyright 2018 CoreOS, Inc
+	copyright (c) 2011 Miek Gieben
+	Copyright 2015 The Linux Foundation.
+	Copyright 2017 Prometheus Team
+	Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated
+	Copyright 2015 gRPC authors.
+	Copyright 2016-2017 The New York Times Company
+	Copyright (c) 2014 The AUTHORS
+	Copyright (c) 2011 Keith Rarick
+	Copyright 2017 Google Inc.  All rights reserved
+	Copyright 2016 Michal Witkowski. All Rights Reserved
+	Copyright (c) 2013, Yann Collet, released under BSD License.
+	Copyright 2021, Google Inc.// All rights reserved
+	Copyright 2017 Google LLC.
+	Copyright 2014 Google Inc. All rights reserved
+	Copyright 2013 The Go Authors.  All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2019 The etcd Authors
+	Copyright 2022 gRPC authors.
+	Copyright The containerd Authors.
+	Copyright 2018 The gRPC Authors
+	Copyright (c) 2013, The GoGo Authors. All rights reserved
+	Copyright (c) 2015 Bj
+	Copyright 2015 CoreOS, Inc.
+	Copyright © 2013 Keith Rarick
+	Copyright 2008 Google Inc.  All rights reserved
+	Copyright (c) 2015 Microsoft Corporation
+	Copyright 2022 Google LLC. All rights reserved
+	Copyright 2022 The Kubernetes Authors.
+	Copyright 2020, The Go Authors. All rights reserved
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+	Copyright 2022 The etcd Authors
+	Copyright 2018 The etcd Authors
+	Copyright The containerd Authors.func compareCapabilities(p1, p2 string) (bool, error) {	c1, err := sysx.LGetxattr(p1, "security.capability")	if err != nil && err != sysx.ENODATA {		return false, 
+	Copyright 2014 Dario Casta
+	Copyright (c) 2015 Pivotal Software, Inc.
+	Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
+	Copyright 2013 Google Inc. All rights reserved
+	Copyright The containerd Authors.func compareFileContent(p1, p2 string) (bool, error) {	f1, err := os.Open(p1)	if err != nil {		return false, err	}	defer f1.Close()	if stat, err := f1.Stat(); e
+	Copyright 2016 The Prometheus Authors
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2015, Google Inc
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2016 Google Inc.  All rights reserved
+	Copyright 2018 Google LLC. All rights reserved
+	Copyright (c) 2019 Authors of Cilium
+	Copyright 2019 Tim Heckman. All rights reserved
+	Copyright 2016 Google LLC.
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+	Copyright 2021 Google LLC
+	Copyright 2012 SocialCode
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2015 The gRPC Authors
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2017 The Go Authors.  All rights reserved
+	Copyright 2012-2017 Docker, Inc.
+	Copyright (c) 2013 Armon Dadgar
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2015 Google Inc. All rights reserved
+	copyright is held by the Go authors.
+	Copyright (c) 2015-2020, Tim HeckmanAll rights reserved
+	Copyright 2013 Google Inc.
+	Copyright 2014 Vishvananda Ishaya.
+	Copyright 2016 ALRUX Inc.
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright 2019 Wataru Ishida. All rights reserved
+	Copyright (c) 2020 Uber Technologies, Inc.
+	Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved
+	Copyright (c) 2015 Microsoft
+	Copyright 2018 gotest.tools authors
+	Copyright (c) 2011 Google Inc. All rights reserved
+	Copyright 2022 The Prometheus Authors
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright (C) 2013 Blake Mizerany
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2014 gRPC authors.
+	Copyright The containerd Authors
+	Copyright (c) 2014 youmark
+	Copyright 2018, OpenCensus Authors
+	Copyright (c) 2015 Vincent Batts, Raleigh, NC, USA
+docker-cli v23.0.1 github:docker/cli:v23.0.1
+	Copyright 2013-2022 The Cobra Authors
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2013 Miek Gieben. All rights reserved
+	Copyright 2018 Klaus Post. All rights reserved
+	Copyright 2018 gRPC authors.
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright (c) 2013 Dario Casta
+	copyright of the original repo.// https://github.com/beorn7/floatspackage internal
+	Copyright 2016 Docker, Inc.
+	Copyright 2018 The Go Authors.  All rights reserved
+	Copyright 2020 gRPC authors.
+	Copyright 2018 The Prometheus Authors
+	Copyright 2016 The filepathx Authors
+	Copyright 2010 The Go Authors
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright (c) 2020 T
+	Copyright (c) 2015 Klaus Post
+	Copyright 2013 Matt T. Proud
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+	Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+	Copyright 2013 The Prometheus Authors
+	Copyright 2016 The Snappy-Go Authors. All rights reserved
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright 2013 Dario Casta
+	Copyright 2013 MongoDB, Inc.
+	Copyright 2022 Alan Shreve (@inconshreveable)
+	Copyright (c) 2016 Yasuhiro Matsumoto
+	©️)       copyright	{0x00AD, 0x00AD, prControl	{0x00AE, 0x00AE, prExtendedPictographic},   //  1.1  [1] (®️)       registered	{0x0300, 0x036F, prExtend},                 // Mn [112] COMBINING GRAVE
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright (c) 2016 Taihei Morikuni
+	Copyright 2016 The Linux Foundation.
+	Copyright 2021 gRPC authors.
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright 2015 The Prometheus Authors
+	copyright message.not git grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)\|DO NOT EDIT" -- '*.go'
+	Copyright (c) 2011, Open Knowledge Foundation Ltd.All rights reserved
+	Copyright 2019 The Prometheus Authors
+	Copyright 2014-2015 The Prometheus Authors
+	Copyright 2014 Docker, Inc.
+	Copyright (c) 2015, Docker Inc.
+	Copyright 2017 gRPC authors.
+	Copyright 2014 The Prometheus Authors
+	Copyright (c) 2016, The GoGo Authors. All rights reserved
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright (c) 2019 Klaus Post. All rights reserved
+	Copyright 2012 The Gorilla Authors. All rights reserved
+	Copyright (c) 2018, The GoGo Authors. All rights reserved
+	Copyright (c) 2015, Dave Cheney <dave@cheney.net>All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2017 Prometheus Team
+	Copyright 2015 gRPC authors.
+	Copyright 2016-2017 The New York Times Company
+	Copyright 2015 Docker, Inc.
+	Copyright 2013-2015 Blake Mizerany, Bj
+	Copyright (c) 2011 Keith Rarick
+	Copyright 2020 The Prometheus Authors
+	Copyright 2014 Prometheus Team
+	Copyright 2020
+	Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+	Copyright (c) 2013, Yann Collet, released under BSD License.
+	Copyright 2015 The Prometheus Authors
+	Copyright 2021 The Prometheus Authors
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2019 The etcd Authors
+	Copyright 2022 gRPC authors.
+	Copyright 2019
+	Copyright The containerd Authors.
+	Copyright 2018 The gRPC Authors
+	Copyright (c) 2013, The GoGo Authors. All rights reserved
+	Copyright (c) 2015 Bj
+	Copyright 2008 Google Inc.  All rights reserved
+	Copyright (c) 2011 The Snappy-Go Authors. All rights reserved
+	Copyright (c) 2015 Microsoft Corporation
+	Copyright 2018 johandorland ( https://github.com/johandorland )
+	Copyright 2016 gRPC authors.
+	Copyright 2020, The Go Authors. All rights reserved
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright (c) 2016 David Calavera
+	Copyright 2017 Docker, Inc.
+	Copyright 2016 The Linux Foundation
+	Copyright 2014 Dario Casta
+	Copyright 2019, 2020 OCI Contributors
+	Copyright (c) 2014-2015 Prime Directive, Inc.
+	Copyright 2016 The Prometheus Authors
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright (c) 2013 Miek Gieben. All rights reserved
+	Copyright 2019 gRPC authors.
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright (c) 2012 Alex Ogier. All rights reserved
+	Copyright 2013-2018 Docker, Inc.
+	Copyright 2012 Google Inc. All Rights Reserved
+	Copyright 2020 Google LLC
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2017 The Go Authors.  All rights reserved
+	Copyright {yyyy
+	Copyright 2012-2017 Docker, Inc.
+	Copyright (c) 2015 Frits van Bommel
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2018, The Go Authors. All rights reserved
+	Copyright 2013-2017 Docker, Inc.
+	Copyright (c) OASIS Open 2016. All Rights Reserved
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright 2017 The Prometheus Authors
+	Copyright 2012-2015 The Prometheus Authors
+	Copyright (c) 2015 Microsoft
+	Copyright 2012-2015 Docker, Inc.
+	Copyright 2018 gotest.tools authors
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright 2022 The Prometheus Authors
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright (C) 2013 Blake Mizerany
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright (c) 2013 Mitchell Hashimoto
+	Copyright 2014 gRPC authors.
+	Copyright The containerd Authors
+	Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved
+	Copyright (c) 2014 youmark
+	Copyright 2013-2016 Docker, Inc.
+	Copyright 2016-2018 Docker Inc.
+	Copyright (c) 2018 The Go Authors. All rights reserved
+docker-go-units v0.5.0 github:docker/go-units:v0.5.0
+	Copyright 2015 Docker, Inc.
+docker-org 20190806-snapshot-e31b211e github:docker/go-events:e31b211e4f1cd09aa76fe4ac244571fab96ae47f
+	Copyright 2016 Docker, Inc.
+docker-org v0.7.0 github:docker/docker-credential-helpers:v0.7.0
+	Copyright (c) 2016 David Calavera
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright (c) 2014 Daniel Joos
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+docker-registry 2.8.2 github:docker/distribution:v2.8.2
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2015 Unknwon
+	copyright including, without limitation,
+	Copyright 2014 Gary Burd
+	Copyright 2016 Docker, Inc.
+	Copyright (c) 2013 Joshua Tacoma
+	Copyright 2016, Google Inc. * All rights reserved
+	Copyright 2018 The Prometheus Authors
+	Copyright 2010 The Go Authors
+	Copyright (C) 2012 by Nick Craig-Wood http://www.craig-wood.com/nick/
+	Copyright 2014-2017 Microsoft
+	Copyright (c) 2006 Kirill Simonov
+	Copyright 2013 Matt T. Proud
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+	Copyright 2013 The Prometheus Authors
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright 2010 The Go Authors.https://github.com/golang/protobuf
+	Copyright 2015 The oauth2 Authors. All rights reserved
+	Copyright 2014 Square Inc.
+	Copyright (c) 2013 Yuriy Vasiyarov. All rights reserved
+	Copyright 2014 Unknwon
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright 2016 The Linux Foundation.
+	Copyright 2013 Joshua Tacoma. All rights reserved
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright 2015 The Prometheus Authors
+	Copyright (c) 2011, Open Knowledge Foundation Ltd.All rights reserved
+	Copyright 2014-2015 The Prometheus Authors
+	Copyright 2015 Google Inc. All Rights Reserved
+	copyright     resulting from Directive 96/9/EC of the European Parliament and of
+	Copyright 2014 Docker, Inc.
+	Copyright 2012 Richard Crowley. All rights reserved
+	Copyright 2015 James Saryerwinnie
+	Copyright 2012 Google Inc. All rights reserved
+	Copyright 2014 The Prometheus Authors
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright 2012 The Gorilla Authors. All rights reserved
+	Copyright 2014, Google Inc. * All rights reserved
+	Copyright (c) 2013 Damien Le Berrigaud and Nick Wade
+	copyright 2014 Docker, inc. Code released under the Apache 2.0 license.
+	copyright (c) 2011 Miek Gieben
+	Copyright (c) 2016 Shopify
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2017 Prometheus Team
+	Copyright 2014 Alan Shreve
+	Copyright 2017 Microsoft Corporation
+	Copyright 2012 Gary Burd
+	Copyright 2013-2015 Blake Mizerany, Bj
+	Copyright (c) 2021 golang-jwt maintainers
+	Copyright 2014 Google Inc. All Rights Reserved
+	Copyright 2015, Google Inc. * All rights reserved
+	Copyright 2014 Prometheus Team
+	Copyright (c) 2016 Boaz Shuster
+	Copyright 2011 Google Inc. All rights reserved
+	Copyright 2015 The Prometheus Authors
+	Copyright 2014, Google Inc.All rights reserved
+	copyright--then that use is not regulated by the license. Our
+	Copyright 2014 Google Inc. All rights reserved
+	Copyright 2016 Microsoft Corporation
+	Copyright 2013 The Go Authors.  All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright (c) 2012 Daniel Theophanes
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright (c) 2012 Rodrigo Moraes. All rights reserved
+	Copyright 2013 The Gorilla Authors. All rights reserved
+	Copyright (c) 2009 The oauth2 Authors. All rights reserved
+	Copyright 2014 Google Inc.
+	Copyright (c) 2012 Dave Grijalva
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright 2015 Microsoft Corporation
+	Copyright 2016 The Linux Foundation
+	Copyright 2013 Google Inc. All rights reserved
+	Copyright 2016 The Prometheus Authors
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2010-2013 Gustavo Niemeyer <gustavo@niemeyer.net>
+	Copyright (c) Microsoft and contributors.  All rights reserved
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright (c) 2012 Alex Ogier. All rights reserved
+	Copyright © 2013 Steve Francia <spf@spf13.com>.
+	copyright or other
+	Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright {yyyy
+	Copyright 2015 Red Hat Inc. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2015 Google Inc. All rights reserved
+	Copyright (c) 2015 Sebastian Erhart
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright 2017 The Prometheus Authors
+	Copyright © 2016 Docker, Inc. All rights reserved
+	Copyright 2012-2015 The Prometheus Authors
+	Copyright 2012-2015 Docker, Inc.
+	Copyright (c) 2011 Google Inc. All rights reserved
+	Copyright (C) 2013 Blake Mizerany
+	Copyright 2016 Unknwon
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright (c) 2013 Mitchell Hashimoto
+	Copyright (c) 2013 The Gorilla Handlers Authors. All rights reserved
+	Copyright 2013-2016 Docker, Inc.
+	Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+docker/go-metrics v0.0.1 github:docker/go-metrics:v0.0.1
+	Copyright 2013-2016 Docker, Inc.
+	Copyright 2012-2015 Docker, Inc.
+dominikh/go-tools v0.0.1-2020.1.4 github:dominikh/go-tools:v0.0.1-2020.1.4
+	Copyright 2019 Dominik Honnef. All rights reserved
+	Copyright (c) 2013 The Go Authors,
+	Copyright (c) 2016 Dominik Honnef
+	Copyright (c) 2017, Daniel Mart
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2018 Google Inc.
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2013 Kamil Kisiel <kamil@kamilkisiel.net>
+	Copyright (c) 2013 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2014 Dmitry Vyukov. All rights reserved
+	(C) returns all currently known interfaces implemented by C.func (r *rta) interfaces(C types.Type) []*types.Interface {	// Ascertain set of interfaces C implements	// and update 'implements' relati
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2013 TOML authors
+	Copyright (c) 2016 Dominik Honnef. All rights reserved
+	Copyright 2016 Dominik Honnef. All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	(C) MarshalText() (
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright (c) 2018 Dominik Honnef. All rights reserved
+	(C) f()func (*C) g()
+envoyproxy/go-control-plane v0.10.3 github:envoyproxy/go-control-plane:v0.10.3
+	Copyright 2018 Envoyproxy Authors
+	Copyright 2020 Envoyproxy Authors
+	Copyright {yyyy
+	Copyright 2019 Envoyproxy Authors
+envoyproxy/protoc-gen-validate 0.9.1 github:envoyproxy/protoc-gen-validate:v0.9.1
+	Copyright 2019 Envoy Project Authors
+errcheck v1.5.0-alpha github:kisielk/errcheck:v1.5.0-alpha
+	Copyright (c) 2013 Kamil Kisiel
+errwrap v1.1.0 github:hashicorp/errwrap:v1.1.0
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+etcd-io/etcd v3.5.7 github:etcd-io/etcd:v3.5.7
+	Copyright 2021 The etcd Authors
+	Copyright 2018 The etcd Authors
+	Copyright 2017 The etcd Lockors
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2019 The etcd Authors
+	Copyright 2014 The etcd Authors
+	Copyright 2013 The etcd Authors
+	Copyright|generated
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2016 The etcd Authors
+	Copyright 2017 The etcd Authors
+	Copyright 2020 The etcd Authors
+	Copyright 2022 The etcd Authors
+	Copyright 2015 The etcd Authors
+foxcpp/go-mockdns v1.0.0 github:foxcpp/go-mockdns:v1.0.0
+	Copyright © 2019 Max Mazurov <fox.cpp@disroot.org>
+fsnotify-fsnotify v1.6.0 github:fsnotify/fsnotify:v1.6.0
+	Copyright © 2012 The Go Authors. All rights reserved
+	Copyright © fsnotify Authors. All rights reserved
+fvbommel/sortorder 1.1.0 github:fvbommel/sortorder:v1.1.0
+	Copyright (c) 2015 Frits van Bommel
+github.com/AdaLogics/go-fuzz-headers 20230106-snapshot-43070de9 github:AdaLogics/go-fuzz-headers:43070de90fa134c9ea55cd6de4308a2ae59658d3
+	Copyright 2023 The go-fuzz-headers Authors.
+github.com/containerd/aufs v1.0.0 github:containerd/aufs:v1.0.0
+	Copyright The containerd Authors.
+github.com/containerd/go-cni v1.1.9 github:containerd/go-cni:v1.1.9
+	Copyright 2018 CNI authors
+	Copyright The containerd Authors.
+github.com/containerd/ttrpc v1.2.1 github:containerd/ttrpc:v1.2.1
+	Copyright The containerd Authors.
+github.com/containerd/zfs v1.0.0 github:containerd/zfs:v1.0.0
+	Copyright The containerd Authors.
+github.com/go-kit/log v0.2.1 github:go-kit/log:v0.2.1
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2021 Go kit
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright (c) 2014 Simon Eskildsen
+github.com/go-logr/zapr v1.2.3 github:go-logr/zapr:v1.2.3
+	Copyright 2019 The logr Authors.
+	Copyright 2018 Solly Ross
+	Copyright 2020 The Kubernetes Authors.
+	Copyright {yyyy
+	Copyright 2021 The logr Authors.
+github.com/gofrs/flock v0.8.1 github:gofrs/flock:v0.8.1
+	Copyright 2018 The Gofrs. All rights reserved
+	Copyright 2019 Tim Heckman. All rights reserved
+	Copyright 2015 Tim Heckman. All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2015-2020, Tim HeckmanAll rights reserved
+github.com/golang-jwt/jwt v4.4.2 github:golang-jwt/jwt:v4.4.2
+	Copyright (c) 2012 Dave Grijalva
+	Copyright (c) 2021 golang-jwt maintainers
+github.com/gomodule/redigo v1.8.2 github:gomodule/redigo:v1.8.2
+	Copyright 2017 Gary Burd
+	Copyright 2018 Gary Burd
+	Copyright 2013 Gary Burd
+	Copyright 2014 Gary Burd
+	Copyright 2012 Gary Burd
+	Copyright 2011 Gary Burd
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 github:konsorten/go-windows-terminal-sequences:v1.0.1
+	Copyright (c) 2017 marvin
+github.com/markbates/oncer v1.0.0 github:markbates/oncer:v1.0.0
+	Copyright (c) 2019 Mark Bates
+github.com/markbates/safe v1.0.1 github:markbates/safe:v1.0.1
+	Copyright (c) 2018 Mark Bates
+github.com/moby/locker 1.0.1 github:moby/locker:v1.0.1
+	Copyright 2013-2018 Docker, Inc.
+github.com/moby/spdystream v0.2.0 github:moby/spdystream:v0.2.0
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2014-2021 Docker Inc.
+	Copyright 2014-2021 Docker Inc.
+github.com/munnerz/goautoneg 20191010-snapshot-a7dc8b61 github:munnerz/goautoneg:a7dc8b61c822528f973a5e4e7b272055c6fdb43e
+	Copyright (c) 2011, Open Knowledge Foundation Ltd.All rights reserved
+github.com/rogpeppe/fastuuid v1.2.0 github:rogpeppe/fastuuid:v1.2.0
+	Copyright © 2014, Roger PeppeAll rights reserved
+github.com/spf13/jwalterweatherman v1.1.0 github:spf13/jwalterweatherman:v1.1.0
+	Copyright (c) 2014 Steve Francia
+	Copyright © 2016 Steve Francia <spf@spf13.com>.
+github.com/vektah/gqlparser v2.2.0 github:vektah/gqlparser:v2.2.0
+	Copyright (c) 2015, Facebook, Inc. All rights reserved
+	Copyright (c) 2018 Adam Scarr
+	(C) Then compare this fragment with all other fragments found in this			// selection set to collect conflicts between fragments spread together.			// This compares each item in the list of fragment 
+github.com/xdg-go/pbkdf2 1.0.0 github:xdg-go/pbkdf2:v1.0.0
+	Copyright 2021 by David A. Golden. All rights reserved
+go humanize v1.0.0 github:dustin/go-humanize:v1.0.0
+	Copyright (c) 2005-2008  Dustin Sallings <dustin@spy.net>
+go-ansiterm d185dfc1b5a126116ea5a19e148e29d16b4574c9 github:Azure/go-ansiterm:d185dfc1b5a126116ea5a19e148e29d16b4574c9
+	Copyright (c) 2015 Microsoft Corporation
+go-chi v1.5.4 github:go-chi/chi:v1.5.4
+	Copyright (c) 2015-present Peter Kieltyka (https://github.com/pkieltyka), Google Inc.
+go-chi/render v1.0.1 github:go-chi/render:v1.0.1
+	Copyright (c) 2016-Present https://github.com/go-chi authors
+go-cli v2.3.0 github:codegangsta/cli:v2.3.0
+	Copyright (c) 2016 Jeremy Saenz
+	Copyright string	// Reader reader to write input to (useful for tests)	Reader io.Reader	// Writer writer to write output to	Writer io.Writer	// ErrWriter writes error output	ErrWriter io.Writer
+	Copyright}}{{end`
+	Copyright of the binary if any
+go-errgo-errgo v2.1.0 github:go-errgo/errgo:v2.1.0
+	Copyright © 2013, Roger PeppeAll rights reserved
+	Copyright 2014 Roger Peppe.// See LICENCE file for details.
+go-etcd v3.3.10 github:coreos/etcd:v3.3.10
+	Copyright 2015 The Prometheus Authors
+	Copyright 2014 Oleku Konko All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2014 The etcd Authors
+	Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved
+	Copyright (c) 2013, The GoGo Authors. All rights reserved
+	Copyright 2015 CoreOS, Inc.
+	Copyright 2010 The Go Authors
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright 2013-2015 CoreOS, Inc.
+	Copyright 2016 gRPC authors.
+	Copyright 2014 CoreOS, Inc
+	Copyright of the binary if any
+	Copyright (c) 2015 Xiang Li
+	Copyright 2014 Google Inc.
+	Copyright (c) 2012 Dave Grijalva
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright 2015 The etcd Authors
+	Copyright 2018 The etcd Authors
+	Copyright 2013 Matt T. Proud
+	Copyright (C) 2016 Travis Cline
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+	Copyright 2013 The Prometheus Authors
+	Copyright 2017 The etcd Lockors
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright © 2011 Russ Ross> All rights reserved
+	Copyright (c) 2017 Uber Technologies, Inc.
+	Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved
+	Copyright 2016 The Prometheus Authors
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2016 The Gorilla WebSocket Authors. All rights reserved
+	Copyright 2016 The etcd Authors
+	Copyright (c) 2016 Yasuhiro Matsumoto
+	Copyright 2017 The etcd Authors
+	Copyright (c) 2016 Uber Technologies, Inc.
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright (c) 2014 Sam Ghods
+	Copyright © 2011 Russ Ross <russ@russross.com>.
+	Copyright (c) 2012 Alex Ogier. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright}}   {{end`
+	Copyright (c) 2016 Jeremy Saenz
+	Copyright (c) 2017 Blake Gentry
+	Copyright © 2013 Steve Francia <spf@spf13.com>.
+	Copyright (c) 2013 Ben Johnson
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright (c) 2015, Gengo, Inc.All rights reserved
+	Copyright 2015 The Prometheus Authors
+	Copyright string	// Name of Author (Note: Use App.Authors, this is deprecated)	Author string	// Email of Author (Note: Use App.Authors, this is deprecated)	Email string	// Writer writer to write 
+	Copyright 2013 The Gorilla WebSocket Authors. All rights reserved
+	Copyright (c) 2011, Open Knowledge Foundation Ltd.All rights reserved
+	Copyright (c) 2005-2008  Dustin Sallings <dustin@spy.net>
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2014-2015 The Prometheus Authors
+	Copyright (c) 2012-2015 Ugorji Nwoke.
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2014 Docker, Inc.
+	Copyright 2017 The Go Authors.  All rights reserved
+	Copyright 2017 gRPC authors.
+	Copyright {yyyy
+	Copyright 2014 The Prometheus Authors
+	Copyright 2015 Red Hat Inc. All rights reserved
+	Copyright (c) 2016, The GoGo Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright 2013 Google Inc.
+	Copyright 2016 The CMux Authors. All rights reserved
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright 2017 The Prometheus Authors
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2017 Prometheus Team
+	Copyright 2014 Alan Shreve
+	Copyright 2012-2015 The Prometheus Authors
+	Copyright}}COPYRIGHT:
+	Copyright 2015 gRPC authors.
+	Copyright 2017 The Gorilla WebSocket Authors. All rights reserved
+	Copyright (c) 2016-2017 Uber Technologies, Inc.
+	Copyright 2013-2015 Blake Mizerany, Bj
+	Copyright (C) 2013 Blake Mizerany
+	Copyright (c) 2011 Keith Rarick
+	Copyright 2013 The etcd Authors
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2016 CoreOS, Inc.
+	Copyright 2014 gRPC authors.
+	Copyright 2014 Prometheus Team
+	Copyright 2014 The Go Authors.  All rights reserved
+	Copyright 2009 The Go Authors.  All rights reserved
+	Copyright 2016 Michal Witkowski. All Rights Reserved
+	Copyright 2015 The Go Authors.  All rights reserved
+	Copyright (c) 2012-2015, Sergey CherepanovAll rights reserved
+go-flowrate 20140419-snapshot-cca7078d github:mxk/go-flowrate:cca7078d478f8520f85629ad7c68962d31ed7682
+	Copyright (c) 2014 The Go-FlowRate Authors. All rights reserved
+go-gorp/gorp v3.1.0 github:go-gorp/gorp:v3.1.0
+	Copyright (c) 2012 James Cooper <james@bitmechanic.com>
+	Copyright 2012 James Cooper. All rights reserved
+go-immutable-radix v1.0.0 github:hashicorp/go-immutable-radix:v1.0.0
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+go-inf-inf v0.9.1 github:go-inf/inf:v0.9.1
+	Copyright (c) 2009 The GoAuthors. All rights reserved
+	Copyright (c) 2012 P
+go-ini-ini v1.62.0 github:go-ini/ini:v1.62.0
+	Copyright 2017 Unknwon
+	Copyright 2015 Unknwon
+	Copyright 2019 Unknwon
+	Copyright 2014 Unknwon
+	Copyright 2016 Unknwon
+go-jose v2.6.0 github:square/go-jose:v2.6.0
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2018 Square Inc.
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2014 Square Inc.
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright 2016 Zbigniew Mandziejewicz
+	Copyright 2017 Square Inc.
+	Copyright 2016 Square, Inc.
+	(C) MarshalJSON() (	return []byte(`"<&>"`), nil}
+go-kit-kit v0.8.0 github:go-kit/kit:v0.8.0
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2015 Peter Bourgon
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright (c) 2014 Simon Eskildsen
+go-logr/logr v1.2.4 github:go-logr/logr:v1.2.4
+	Copyright 2019 The logr Authors.
+	Copyright 2022 The logr Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2020 The logr Authors.
+	Copyright {yyyy
+	Copyright 2021 The logr Authors.
+go-logr/stdr v1.2.2 github:go-logr/stdr:v1.2.2
+	Copyright 2019 The logr Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2021 The logr Authors.
+go-oci8 v0.1.1 github:mattn/go-oci8:v0.1.1
+	Copyright (c) 2014-2018 Yasuhiro Matsumoto, http://mattn.kaoriya.net <mattn.jp@gmail.com>
+go-openapi/jsonpointer v0.19.6 github:go-openapi/jsonpointer:v0.19.6
+	Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
+go-restful v3.10.1 github:emicklei/go-restful:v3.10.1
+	Copyright 2013 Ernest Micklei. All rights reserved
+	Copyright 2021 Ernest Micklei. All rights reserved
+	Copyright 2015 Ernest Micklei. All rights reserved
+	Copyright 2018 Ernest Micklei. All rights reserved
+	Copyright 2014 Ernest Micklei. All rights reserved
+	Copyright (c) 2012,2013 Ernest Micklei
+go-resty/resty v1.12.0 github:go-resty/resty:v1.12.0
+	Copyright (c) 2015-2019 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
+	Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com)
+	Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved
+	Copyright (c) 2015-2019 Jeevanandam M. (jeeva@myjeeva.com), All rights reserved
+go-spew v1.1.1 github:davecgh/go-spew:v1.1.1
+	Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+	Copyright (c) 2013-2016 Dave Collins <dave@davec.name> * * Permission to use, copy, modify, and distribute this software for any * purpose with or without fee is hereby granted, provided that the a
+	Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
+	Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
+	Copyright (c) 2013 Dave Collins <dave@davec.name>
+go-sql-driver v1.6.0 github:go-sql-driver/mysql:v1.6.0
+	Copyright 2012 The Go-MySQL-Driver Authors. All rights reserved
+	Copyright 2018 The Go-MySQL-Driver Authors. All rights reserved
+	Copyright 2017 The Go-MySQL-Driver Authors. All rights reserved
+	Copyright 2020 The Go-MySQL-Driver Authors. All rights reserved
+	Copyright 2013 The Go-MySQL-Driver Authors. All rights reserved
+	Copyright 2019 The Go-MySQL-Driver Authors. All rights reserved
+	Copyright 2016 The Go-MySQL-Driver Authors. All rights reserved
+	Copyright 2014 The Go-MySQL-Driver Authors. All rights reserved
+go-systemd v22.5.0 github:coreos/go-systemd:v22.5.0
+	Copyright 2018 CoreOS, Inc
+	Copyright 2020 CoreOS, Inc.
+	Copyright 2018 CoreOS, Inc.
+	Copyright 2015 RedHat, Inc.
+	Copyright 2015, 2018 CoreOS, Inc.
+	Copyright 2022 CoreOS, Inc.
+	Copyright 2015 CoreOS, Inc.
+	Copyright|generated
+	Copyright 2014 Docker, Inc.
+	Copyright 2016 CoreOS, Inc.
+	Copyright 2019 CoreOS, Inc.
+	Copyright 2015-2018 CoreOS, Inc.
+	Copyright 2015 CoreOS Inc.
+go-toml v1.9.5 github:pelletier/go-toml:v1.9.5
+	Copyright 2016 Google LLC
+	Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
+go-zap v1.24.0 github:uber-go/zap:v1.24.0
+	Copyright (c) 2022 Uber Technologies, Inc.
+	Copyright (c) 2018 Uber Technologies, Inc.
+	Copyright (c) 2020 Uber Technologies, Inc.
+	Copyright (c) 2016-2022 Uber Technologies, Inc.
+	Copyright (c) 2019 Uber Technologies, Inc.
+	Copyright (c) 2016 Uber Technologies, Inc.
+	Copyright (c) 2021 Uber Technologies, Inc.
+	Copyright (c) 2017 Uber Technologies, Inc.
+	Copyright (c) 2016, 2017 Uber Technologies, Inc.
+	Copyright (c) "*" Uber Technologies, Inc.")			# everything's cool			;;
+go-zfs 20190419-snapshot-f784269b github:mistifyio/go-zfs:f784269be439d704d3dfa1906f45dd848fed2beb
+	Copyright (c) 2014, OmniTI Computer Consulting, Inc.
+go.etcd.io/bbolt v1.3.7 github:etcd-io/bbolt:v1.3.7
+	Copyright (c) 2013 Ben Johnson
+go.uber.org/goleak v1.2.1 github:uber-go/goleak:v1.2.1
+	Copyright (c) 2018 Uber Technologies, Inc.
+	Copyright (c) 2017-2023 Uber Technologies, Inc.
+	Copyright (c) 2021 Uber Technologies, Inc.
+	Copyright (c) 2023 Uber Technologies, Inc.
+	Copyright (c) 2017 Uber Technologies, Inc.
+go.uber.org/multierr v1.11.0 github:uber-go/multierr:v1.11.0
+	Copyright (c) 2020 Uber Technologies, Inc.
+	Copyright (c) 2017-2023 Uber Technologies, Inc.
+	Copyright (c) 2021 Uber Technologies, Inc.
+	Copyright (c) 2023 Uber Technologies, Inc.
+	Copyright (c) 2017-2021 Uber Technologies, Inc.
+	Copyright (c) 2017 Uber Technologies, Inc.
+	Copyright (c) 2019-2021 Uber Technologies, Inc.
+gobuffalo/packr v2.8.3 github:gobuffalo/packr:v2.8.3
+	Copyright (c) 2016 Mark Bates
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright © 2018 Mark Bates
+gobwas-glob 0.2.3 github:gobwas/glob:v0.2.3
+	Copyright (c) 2016 Sergey Kamardin
+	Copyright (c) 2016 Sergey Kamardin
+goconvey v1.6.4 github:smartystreets/goconvey:v1.6.4
+	Copyright (C) 2011 by Maciej Ma
+	(C) // nil means skipped	FailMode  FailureMode}
+	Copyright 2006 Google Inc.
+	Copyright 2013 jQuery Foundation, Inc. and other contributors
+	copyright:before  content: "\f1f9";}.fa-at:before {  content: "\f1fa";
+	Copyright 2014 jQuery Foundation and other contributors; Licensed MIT
+	Copyright 2013 jQuery Foundation and other contributors
+	Copyright 2005, 2014 jQuery Foundation, Inc. and other contributors
+godbus-dbus v5.1.0 github:godbus/dbus:v5.1.0
+	Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), GoogleAll rights reserved
+godror/godror v0.24.2 github:godror/godror:v0.24.2
+	Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved
+	Copyright 2021 The Godror Authors
+	Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved
+	Copyright 2020 The Godror Authors
+	Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved
+	Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved
+	Copyright 2020 The Godror Authors
+	Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved
+	Copyright 2019, 2020 The Godror Authors
+	Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved
+	Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved
+	Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved
+	(C) type of data    int requiresPreFetch;               // requires prefetch processing?    int isArray;                        // is an index-by table (array)?    uint32_t sizeInBytes;            
+	Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved
+	Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved
+	Copyright 2019 Tam
+	Copyright 2020 Tam
+	(C) type    uint16_t oracleType;                // OCI type code    uint8_t charsetForm;                // specifies CHAR or NCHAR encoding    uint32_t sizeInBytes;               // buffer size (fi
+	Copyright 2018, 2020 The Godror Authors
+	Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved
+	Copyright 2017, 2020 The Godror Authors
+	Copyright 2016 Tam
+golang-github-docker-go-connections-dev 0.4.0 github:docker/go-connections:v0.4.0
+	Copyright 2015 Docker, Inc.
+golang-github-docker-libtrust-dev 20160225-snapshot-fa567046 github:docker/libtrust:fa567046d9b14f6aa788882a950d69651d230b21
+	Copyright 2014 Docker, Inc.
+golang-github-ghodss-yaml-dev 1.0.0 github:ghodss/yaml:v1.0.0
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright (c) 2014 Sam Ghods
+golang-github-hashicorp-memberlist v0.1.3 github:hashicorp/memberlist:v0.1.3
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+golang-github-magiconair-properties v1.8.5 github:magiconair/properties:v1.8.5
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2018 Frank Schroeder. All rights reserved
+	Copyright 2013-2014 Frank Schroeder. All rights reserved
+golang-github-shopify-logrus-bugsnag-dev 20171204-snapshot-577dee27 github:Shopify/logrus-bugsnag:577dee27f20dd8f1a529f82210094af593be12bd
+	Copyright (c) 2016 Shopify
+golang-github-spf13-pflag-dev v1.0.5 github:spf13/pflag:v1.0.5
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright (c) 2012 Alex Ogier. All rights reserved
+golang-mock v1.6.0 github:golang/mock:v1.6.0
+	Copyright 2011 Google Inc.
+	Copyright 2012 Google Inc.
+	Copyright 2010 Google Inc.
+	Copyright file used to add copyright header")
+	Copyright 2019 Google LLC
+	Copyright 2020 Google Inc.
+	copyright file:		}
+	Copyright 2020 Google LLC
+	copyright header.
+	Copyright 2010 Google LLC.
+golang-snappy-go-dev v0.0.4 github:golang/snappy:v0.0.4
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright (c) 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Snappy-Go Authors. All rights reserved
+	Copyright 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+golang.org/x/mod v0.9.0 long_tail:go.googlesource.com/mod#v0.9.0
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+golang.org/x/net v0.13.0 long_tail:go.googlesource.com/net#v0.13.0
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2023 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright (C) 2009 Apple Inc. All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	copyright header while we		if !bytes.Contains(b, []byte("The Go Authors.")) {			t.Errorf("%v: missing copyright", name)		}		// doc.go doesn't need a build constraint.		if name == "doc.go" {			co
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	(C) Chinese (traditional).		"\u4ED6\u5011\u7232\u4EC0\u9EBD\u4E0D\u8AAA\u4E2D\u6587",		"ihqwctvzc91f659drss3x8bo0yb",	},
+	Copyright 2016 The Go Authors. All rights reserved
+golang.org/x/time v0.3.0 long_tail:go.googlesource.com/time#v0.3.0
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+golang.org/x/tools v0.8.0 long_tail:go.googlesource.com/tools#v0.8.0
+	Copyright © 2000-2007 Vita Nuova Holdings Limited (www.vitanuova.com)
+	Copyright (c) Microsoft Corporation
+	Copyright (c) 2015, Daniel Mart
+	Copyright 2011 The Go Authors. All rights reserved
+	(C) f()type D struct{C}var _ I = D{}`),			from: "(main.C).f", to: "F",			want: `renaming this method "f" to "F".*` +				`would make main.D no longer assignable to interface I.*` +				`(rename m
+	(C) f()type J interface{	f()int}var _ = I(C(0)).(J)
+	Copyright 2023 The Go Authors. All rights reserved
+	Copyright © 1994-1999 Lucent Technologies Inc.  All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright © 1997-1999 Vita Nuova Limited
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright (c) 2012-2016 The go-diff Authors. All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright\x202009\x20The\x20Go\x20Authors.\x20All\x20rights\x20reserved.\x0a\x09Use\x20of\x20this\x20source\x20code\x20is\x20governed\x20by\x20a\x20BSD-style\x0a\x09license\x20that\x20can\x20be\x20fou
+	(C) g() intvar _ int = C{}.g()`,
+	Copyright © 1995-1997 C H Forsyth (forsyth@terzarima.net)
+	Copyright (c) 2019, Daniel Mart
+	Copyright := true	for _, c := range parsed.Comments {
+	(C) f()func (*C) g()
+	(C) g()var _, _ I = A(0), B(0)var _, _ J = B(0), C(0)`,
+	Copyright 2010 The Go Authors. All rights reserved
+	(C) g()type D intfunc (*D) f()func (*D) g()type I interface { f(); g() }type J interface { I; h() }var _ I = new(D)var _ interface {f()} = C(0)`),			from: "(main.I).f", to: "g",			want: `ren
+	Copyright © 2005-2007 C H Forsyth (forsyth@terzarima.net)
+	(C) g()			//      var _ I = C{} // here			// yields abstract method I.f.  This can make error			// messages less than obvious.			//			if !types.IsInterface(key.RHS) {				// The logic below was d
+	Copyright(tools)	if err != nil {		t.Fatal(err)	}	if len(files) > 0 {		t.Errorf("The following files are missing copyright notices:\n%s", strings.Join(files, "\n"))
+	(C) Foo(x)type C b
+	Copyright\x202012\x20The\x20Go\x20Authors.\x20All\x20rights\x20reserved.\x0a//\x20Use\x20of\x20this\x20source\x20code\x20is\x20governed\x20by\x20a\x20BSD-style\x0a//\x20license\x20that\x20can\x20be\x2
+	(C) f()		//	type D struct{C}		//	var _ I = D{}		//		for key := range r.satisfy() {			// key = (lhs, rhs) where lhs is always an interface.			if types.IsInterface(key.RHS) {				continue
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright(t	cwd, err := os.Getwd()	if err != nil {		t.Fatal(err)	}	tools := filepath.Dir(cwd)	if !strings.HasSuffix(filepath.Base(tools), "tools") {		t.Fatalf("current working directory is %s, 
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2013 TOML authors
+	copyright checks that files have the correct copyright notices.
+	(C) f()type D intfunc (D) g()type E struct{C;D}var _ I = E{}`),			from: "main.I.f", to: "g",			want: `renaming this method "f" to "g".*` +				`would make the g method of main.E invoked via int
+	(C) f(m map	fmt.Println("C.f()")}
+	Copyright 2019 The Go Authors. All rights reserved
+	(C) // @pointsto var-ref-i-C "i"	if i != nil {		i = D{} // @pointsto var-ref-i-D "i"	}	print(i) // @pointsto var-ref-i "\\bi\\b"
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright {			files = append(files, path)		}		return nil
+	copyright header.	if strings.HasSuffix(normalized, "cmd/goyacc/yacc.go") {		return false, nil	}	content, err := ioutil.ReadFile(filename)	if err != nil {		return false, err
+	(C) // @describe var-ref-i-C "i"	if i != nil {		i = D{} // @describe var-ref-i-D "i"	}	print(i) // @describe var-ref-i "\\bi\\b"
+	(C) f()		//	type D struct{C}		//	var _ I = D{}		//		for key := range r.satisfy() {			// key = (lhs, rhs) where lhs is always an interface.			if isInterface(key.RHS) {				continue
+	(C) f()type D struct{C}var _ I = D{}`,
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright\x202018\x20The\x20Go\x20Authors.\x20All\x20rights\x20reserved.\x0a\x09Use\x20of\x20this\x20source\x20code\x20is\x20governed\x20by\x20a\x20BSD-style\x0a\x09license\x20that\x20can\x20be\x20fou
+	(C) g()			//      var _ I = C{} // here			// yields abstract method I.f.  This can make error			// messages less than obvious.			//			if !isInterface(key.RHS) {				// The logic below was derived
+	Copyright © 2000-2007 Lucent Technologies Inc. and others
+	copyright should appear before the package declaration.		if c.Pos() > parsed.Package {			break		}		if copyrightRe.MatchString(c.Text()) {
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2013 jQuery Foundation and other contributors Licensed MIT
+	Copyright = false			break		}
+	Copyright © 2009 The Go Authors. All rights reserved
+	(C) g() intvar _ I = C{}`),			from: "main.I.f", to: "g",			want: `renaming this method "f" to "g".*` +				`would change the g method of main.C invoked via interface main.I.*` +				`from \(main.I
+	Copyright (c) 2016 Dominik Honnef
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright\x20J\xc3\xb6rn\x20Zaefferer\x0a\x20
+	Copyright 2018 The Go Authors. All rights reserved
+	(C) returns all currently known interfaces implemented by C.func (r *rta) interfaces(C types.Type) []*types.Interface {	// Ascertain set of interfaces C implements	// and update 'implements' relati
+	Copyright 2022 The Go Authors. All rights reserved
+	Copyright(dir string) (	var files []string	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {		if err != nil {			return err		}		if d.IsDir() {			// Skip directorie
+	Copyright © 2004,2006 Bruce Ellis
+golang/appengine v1.6.7 github:golang/appengine:v1.6.7
+	Copyright 2019 Google Inc. All Rights Reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2012 Google Inc. All Rights Reserved
+	Copyright 2014 Google Inc. All rights reserved
+	Copyright 2016 Google Inc. All Rights Reserved
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright 2011 Google Inc. All Rights Reserved
+	Copyright 2013 Google Inc. All rights reserved
+	Copyright 2016 Google Inc. All rights reserved
+	Copyright 2019 Google Inc. All rights reserved
+	Copyright 2012 Google Inc. All rights reserved
+	Copyright 2015 Google Inc. All rights reserved
+	Copyright 2018 Google LLC. All rights reserved
+	Copyright 2011 Google Inc. All rights reserved
+gomega v1.27.6 github:onsi/gomega:v1.27.6
+	Copyright (c) 2013-2014 Onsi Fakhouri
+google-cloud-go bigquery/v1.8.0 github:googleapis/google-cloud-go:bigquery/v1.8.0
+	Copyright 2017, Google Inc. All rights reserved
+	Copyright 2019 Google LLC
+	Copyright 2020 Google LLC
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2014 Google LLC
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+	Copyright 2020, Google LLC
+google-cloud-go compute/metadata/v0.2.3 github:googleapis/google-cloud-go:compute/metadata/v0.2.3
+	Copyright %v Google LLC
+	Copyright 2020 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright 2021 Google LLC
+	Copyright 2019 Google LLC.
+	Copyright 2014 Google LLC
+	copyright	// declarations, banners) should be handled for this document. If not	// specified, boilerplate will be treated the same as content.	BoilerplateHandling Document_BoilerplateHandling `prot
+	Copyright 2022 Google LLC
+	Copyright (c) 2020 The Go Authors. All rights reserved
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+	(C) Copied	// - (M) Modified	// - (R) Renamed	c := execv.Command("git", "diff-tree", "--no-commit-id", "--name-only", "--diff-filter=ACMR", "-r", fmt.Sprintf("%s..HEAD", hash))	c.Dir = gitDir	b, 
+	Copyright %d Google LLC
+	Copyright 2019 Google LLC
+	Copyright 2017 Google Inc.
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright 2018 The Grafeas Authors. All rights reserved
+	Copyright 2020 Google Inc. All Rights Reserved
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2020, Google LLC
+google-cloud-go compute/v1.15.1 github:googleapis/google-cloud-go:compute/v1.15.1
+	Copyright %v Google LLC
+	Copyright 2020 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright 2021 Google LLC
+	Copyright 2019 Google LLC.
+	Copyright 2014 Google LLC
+	Copyright 2023 Google LLC
+	copyright	// declarations, banners) should be handled for this document. If not	// specified, boilerplate will be treated the same as content.	BoilerplateHandling Document_BoilerplateHandling `prot
+	Copyright (c) 2020 The Go Authors. All rights reserved
+	Copyright 2022 Google LLC
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+	(C) Copied	// - (M) Modified	// - (R) Renamed	c := execv.Command("git", "diff-tree", "--no-commit-id", "--name-only", "--diff-filter=ACMR", "-r", fmt.Sprintf("%s..HEAD", hash))	c.Dir = gitDir	b, 
+	Copyright %d Google LLC
+	Copyright 2019 Google LLC
+	Copyright 2017 Google Inc.
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright 2018 The Grafeas Authors. All rights reserved
+	Copyright 2020 Google Inc. All Rights Reserved
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2020, Google LLC
+google-cloud-go datastore/v1.1.0 github:googleapis/google-cloud-go:datastore/v1.1.0
+	Copyright 2017, Google Inc. All rights reserved
+	Copyright 2019 Google LLC
+	Copyright 2020 Google LLC
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2014 Google LLC
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+	Copyright 2020, Google LLC
+google-cloud-go firestore/v1.1.0 github:googleapis/google-cloud-go:firestore/v1.1.0
+	Copyright 2017, Google Inc. All rights reserved
+	Copyright 2019 Google LLC
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright 2019 Google Inc.
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2014 Google LLC
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+google-cloud-go pubsub/v1.3.1 github:googleapis/google-cloud-go:pubsub/v1.3.1
+	Copyright 2017, Google Inc. All rights reserved
+	Copyright 2019 Google LLC
+	Copyright 2020 Google LLC
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2014 Google LLC
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+	Copyright 2020, Google LLC
+google-cloud-go storage/v1.10.0 github:googleapis/google-cloud-go:storage/v1.10.0
+	Copyright 2019 Google LLC
+	Copyright 2020 Google LLC
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2014 Google LLC
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+	Copyright 2020, Google LLC
+google-cloud-go v0.97.0 github:googleapis/google-cloud-go:v0.97.0
+	Copyright %v Google LLC
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2020 Google LLC
+	Copyright (c) 2001 David E. O
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2021 Google LLC
+	Copyright 2014 Google LLC
+	Copyright (c) 2020 The Go Authors. All rights reserved
+	Copyright 2015 Google LLC
+	Copyright 2016 Google LLC
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2018 Google Inc. All Rights Reserved
+	Copyright 2018 Google LLC.
+	(C) Copied	// - (M) Modified	// - (R) Renamed	c := execv.Command("git", "diff-tree", "--no-commit-id", "--name-only", "--diff-filter=ACMR", "-r", fmt.Sprintf("%s..HEAD", hash))	c.Dir = gitDir	b, 
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2012 Google, Inc. Package foo does bar.", 27, ""	{"All Rights reserved
+	copyright comment if present.	comments := file.Comments	if len(comments) > 0 && strings.HasPrefix(comments[0].Text(), "Copyright") {		comments = comments[1:]	}
+	Copyright 2019 Google LLC
+	Copyright 2017 Google LLC
+	Copyright 2018 Google LLC
+	Copyright 2020 Google Inc. All Rights Reserved
+	Copyright (c) 1996-1998 John D. Polstra.  All rights reserved
+	Copyright 2017, Google LLC
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2020, Google LLC
+google-gofuzz v1.2.0 github:google/gofuzz:v1.2.0
+	Copyright 2014 Google Inc. All rights reserved
+google-shlex 20191202-snapshot-e7afc7fb github:google/shlex:e7afc7fbc51079733e9468cdfd1efcd7d196cd1d
+	Copyright 2012 Google Inc. All Rights Reserved
+google/cel-go v0.12.6 github:google/cel-go:v0.12.6
+	Copyright 2021 The ANTLR Project
+	Copyright (c) 2017, A. Stoewer <adrian.stoewer@rz.ifi.lmu.de>// All rights reserved
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2019 Google LLC
+	Copyright (c) 2017, Adrian Stoewer <adrian.stoewer@rz.ifi.lmu.de>
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2020 Google LLC
+	Copyright 2018 Google LLC
+	Copyright 2021 Google LLC
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2008 Google Inc.  All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2022 Google LLC
+	Copyright (c) 2012-2017 The ANTLR Project. All rights reserved
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+google/gnostic-models v0.6.8 github:google/gnostic-models:v0.6.8
+	Copyright 2017 Google LLC. All Rights Reserved
+	Copyright 2019 Google LLC. All Rights Reserved
+	Copyright 2020 Google LLC. All Rights Reserved
+google/go-cmp v0.5.9 github:google/go-cmp:v0.5.9
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright 2020, The Go Authors. All rights reserved
+	Copyright 2018, The Go Authors. All rights reserved
+google/renameio v0.1.0 github:google/renameio:v0.1.0
+	Copyright 2018 Google Inc.
+googleapis/gax-go v2.0.5 github:googleapis/gax-go:v2.0.5
+	Copyright 2016, Google Inc.All rights reserved
+	Copyright 2016, Google Inc.// All rights reserved
+	Copyright 2018, Google Inc.// All rights reserved
+	Copyright 2019, Google Inc.// All rights reserved
+	Copyright 2019 Google LLC
+	Copyright 2018 Google Inc.
+gopherjs 20181205-snapshot-0766667c github:gopherjs/gopherjs:0766667cb4d1cfb8d5fde1fe210ae41ead3cf589
+	Copyright (c) 2013 Richard Musiol. All rights reserved
+gorilla/handlers v1.5.1 github:gorilla/handlers:v1.5.1
+	Copyright 2013 The Gorilla Authors. All rights reserved
+	Copyright (c) 2013 The Gorilla Handlers Authors. All rights reserved
+gorilla/websocket v1.4.2 github:gorilla/websocket:v1.4.2
+	Copyright 2016 The Gorilla WebSocket Authors. All rights reserved
+	Copyright 2019 The Gorilla WebSocket Authors. All rights reserved
+	Copyright 2014 The Gorilla WebSocket Authors. All rights reserved
+	Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+	Copyright 2015 The Gorilla WebSocket Authors. All rights reserved
+	Copyright 2017 The Gorilla WebSocket Authors. All rights reserved
+	Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved
+	Copyright 2013 The Gorilla WebSocket Authors. All rights reserved
+gosuri/uitable v0.0.4 github:gosuri/uitable:v0.0.4
+	Copyright (c) 2015, Greg Osuri
+gotest.tools v3.4.0 github:gotestyourself/gotest.tools:v3.4.0
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+	Copyright 2018 gotest.tools authors
+gregjones/httpcache 20190611-snapshot-901d9072 github:gregjones/httpcache:901d90724c7919163f472a9812253fb26761123d
+	copyright goauth2 authors: https://code.google.com/p/goauth2)func cloneRequest(r *http.Request) *http.Request {	// shallow copy of the struct	r2 := new(http.Request)	*r2 = *r	// deep copy of the 
+	Copyright © 2012 Greg Jones (greg.jones@gmail.com)
+groupcache 20210331-snapshot-41bb18bf github:golang/groupcache:41bb18bfe9da5321badc438f91158cd790a33aa3
+	Copyright 2013 Google Inc.
+grpc-ecosystem/go-grpc-middleware v1.3.0 github:grpc-ecosystem/go-grpc-middleware:v1.3.0
+	Copyright 2016 Michal Witkowski. All Rights Reserved
+	Copyright 2017 Michal Witkowski. All Rights Reserved
+	Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+	Copyright 2017 David Ackroyd. All Rights Reserved
+grpc-ecosystem/go-grpc-prometheus v1.2.0 github:grpc-ecosystem/go-grpc-prometheus:v1.2.0
+	Copyright 2016 Michal Witkowski. All Rights Reserved
+grpc-go v1.54.0 github:grpc/grpc-go:v1.54.0
+	Copyright 2015-2016 gRPC authors.
+	copyright message.# (Done in two parts because Darwin "git grep" has broken support for compound# exclusion matches.)(grep -L "DO NOT EDIT" $(git grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)" --
+	Copyright 2021 gRPC authors.
+	Copyright 2018 gRPC authors.
+	Copyright 2020 The gRPC Authors
+	Copyright 2015 gRPC authors.
+	Copyright 2022 gRPC authors.
+	Copyright 2015 The gRPC Authors
+	Copyright 2018 The gRPC Authors
+	Copyright 2022 gRPC authors.
+	Copyright 2020 gRPC authors.
+	Copyright 2014 gRPC authors.
+	Copyright 2017 gRPC authors.
+	Copyright 2019 gRPC authors.
+	Copyright 2016 The gRPC Authors
+	Copyright 2016 gRPC authors.
+	Copyright 2023 gRPC authors.
+hashicorp serf v0.8.2 github:hashicorp/serf:v0.8.2
+	Copyright (c) 2017 Blake Gentry
+	Copyright 2014 CloudFlare. All rights reserved
+	Copyright (c) 2014 Armon Dadgar
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2011 Miek Gieben. All rights reserved
+	Copyright 2013 The Go Authors.  All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 Eyal Posener
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 Sean Chittenden
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright (c) 2013 Armon Dadgar
+	copyright (c) 2011 Miek Gieben
+	Copyright 2014 Google Inc.
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+	copyright (c) 2011 Miek Gieben
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright (c) 2012, 2013 Ugorji Nwoke.All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2016 Alex Dadgar
+	Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2013 Mitchell Hashimoto
+	Copyright (c) 2016 Yasuhiro Matsumoto
+	Copyright (c) 2012, 2013 Ugorji Nwoke. All rights reserved
+	copyright doctrines of fair use, fair dealing, or otherequivalents.
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright: Hashicorp 2013
+hashicorp-go-cleanhttp v0.5.2 github:hashicorp/go-cleanhttp:v0.5.2
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+hashicorp-go-msgpack v0.5.3 github:hashicorp/go-msgpack:v0.5.3
+	Copyright (c) 2012, 2013 Ugorji Nwoke. All rights reserved
+	Copyright (c) 2012, 2013 Ugorji Nwoke.All rights reserved
+hashicorp-go-rootcerts v1.0.0 github:hashicorp/go-rootcerts:v1.0.0
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+hashicorp-go-syslog v1.0.0 github:hashicorp/go-syslog:v1.0.0
+	Copyright (c) 2014 Armon Dadgar
+hashicorp-go.net v0.0.1 github:hashicorp/go.net:v0.0.1
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors.  All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	(C) Chinese (traditional).		"\u4ED6\u5011\u7232\u4EC0\u9EBD\u4E0D\u8AAA\u4E2D\u6587",		"ihqwctvzc91f659drss3x8bo0yb",	},
+	Copyright (C) 2009 Apple Inc. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+hashicorp-golang-lru v0.5.4 github:hashicorp/golang-lru:v0.5.4
+	copyright doctrines of fair use, fair dealing, or other     equivalents.
+hashicorp-logutils v1.0.0 github:hashicorp/logutils:v1.0.0
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+hashicorp-mdns v1.0.0 github:hashicorp/mdns:v1.0.0
+	Copyright (c) 2014 Armon Dadgar
+hashicorp/go-sockaddr v1.0.0 github:hashicorp/go-sockaddr:v1.0.0
+	Copyright (c) 2016 Ryan Uber
+	Copyright (c) 2014 Armon Dadgar
+	Copyright 2016 The Go Authors.  All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors.  All rights reserved
+	Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors.  All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors.  All rights reserved
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors.  All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2015 The Go Authors.  All rights reserved
+	copyright doctrines of fair use, fair dealing, or otherequivalents.
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+	Copyright 2016 The Go Authors. All rights reserved
+hashicorp/hcl v1.0.0 github:hashicorp/hcl:v1.0.0
+	copyright doctrines of fair use, fair dealing, or other equivalents.
+helm/helm v3.12.3 github:helm/helm:v3.12.3
+	Copyright (c) for portions of fs.go are held by The Go Authors, 2016 and are provided under
+	Copyright The Helm Authors.if (( ${#failed_copyright_header[@]} > 0 )); then
+	Copyright (c) for portions of rename_windows.go are held by The Go Authors, 2016 and are provided under
+	Copyright 2016 The Kubernetes Authors All Rights Reserved
+	Copyright (c) for portions of walk_test.go are held by The Go Authors, 2009 and are
+	copyright header."  printf '%s\n' "${failed_copyright_header[@]}"  exit 1
+	Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+	Copyright (c) for portions of walk.go are held by The Go Authors, 2009 and are
+	Copyright 2016 The Kubernetes Authors.
+	Copyright The Helm Authors.
+	Copyright (c) for portions of rename.go are held by The Go Authors, 2016 and are provided under
+	Copyright (c) for portions of fs_test.go are held by The Go Authors, 2016 and are provided under
+huandu/xstrings v1.4.0 github:huandu/xstrings:v1.4.0
+	Copyright 2015 Huan Du. All rights reserved
+	Copyright (c) 2015 Huan Du
+inconshreveable/mousetrap v1.1.0 github:inconshreveable/mousetrap:v1.1.0
+	Copyright 2022 Alan Shreve (@inconshreveable)
+itchyny/gojq v0.12.11 github:itchyny/gojq:v0.12.11
+	Copyright (c) 2019-2022 itchyny
+itchyny/timefmt-go v0.1.5 github:itchyny/timefmt-go:v0.1.5
+	Copyright (c) 2020-2022 itchyny
+jonboulle-clockwork v0.2.2 github:jonboulle/clockwork:v0.2.2
+	Copyright {yyyy
+jpillora-backoff 1.0.0 github:jpillora/backoff:v1.0.0
+	Copyright (c) 2017 Jaime Pillora
+jsoniter-go v1.1.12 github:json-iterator/go:v1.1.12
+	Copyright (c) 2016 json-iterator
+jsonreference v0.20.2 github:go-openapi/jsonreference:v0.20.2
+	Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
+jstemmer/go-junit-report v0.9.1 github:jstemmer/go-junit-report:v0.9.1
+	Copyright (c) 2012 Joel Stemmer
+jtolds-gls v4.20.0 github:jtolds/gls:v4.20.0
+	Copyright (c) 2013, Space Monkey, Inc.
+julienschmidt/httprouter v1.3.0 github:julienschmidt/httprouter:v1.3.0
+	Copyright 2009 The Go Authors.
+	Copyright (c) 2013, Julien SchmidtAll rights reserved
+	Copyright 2013 Julien Schmidt. All rights reserved
+jwt-go v3.2.0 github:dgrijalva/jwt-go:v3.2.0
+	Copyright (c) 2012 Dave Grijalva
+k3s-io/klog v2.100.1-k3s1 github:k3s-io/klog:v2.100.1-k3s1
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2013 Google Inc. All Rights Reserved
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+	Copyright 2020 Intel Coporation.
+k8s.io/cli-runtime v0.28.1 github:kubernetes/cli-runtime:v0.28.1
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+k8s.io/code-generator v0.27.3 github:kubernetes/code-generator:v0.27.3
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+k8s.io/component-helpers v0.28.1 github:kubernetes/component-helpers:v0.28.1
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+karrick/godirwalk v1.16.1 github:karrick/godirwalk:v1.16.1
+	Copyright (c) 2017, Karrick McDermottAll rights reserved
+kisielk-gotool v1.0.0 github:kisielk/gotool:v1.0.0
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright (c) 2013 Kamil Kisiel <kamil@kamilkisiel.net>
+	Copyright (c) 2009 The Go Authors. All rights reserved
+klauspost-compress v1.16.0 github:klauspost/compress:v1.16.0
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2018 Klaus Post. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2022"	}	d := MakeDict(rawDict, []byte(searchFor))	if d == nil {		t.Fatal("no dict", lidx)
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright (c) 2019		_, _ = fmt.Fprintln(os.Stderr, `Usage: s2c [options] file1 file2
+	Copyright 2019
+	Copyright (c) 2023"))
+	Copyright (c) 2015 Klaus Post
+	Copyright (c) 2022
+	Copyright 2016 The filepathx Authors
+	Copyright (c) 2021 Klaus Post. All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright (c) 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright (c) 2019 Klaus Post. All rights reserved
+	Copyright (c) 2023".	// Search for the longest match for that.	// This may save a few bytes.
+	Copyright (c) 2015 Klaus Post
+	Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2016 The Snappy-Go Authors. All rights reserved
+	Copyright 2016-2017 The New York Times Company
+	Copyright (c) 2015, Pierre CurtoAll rights reserved
+	Copyright (c) 2022 Klaus Post. All rights reserved
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright (c) 2023
+	Copyright 2020
+	Copyright (c) 2019		_, _ = fmt.Fprintln(os.Stderr, `Usage: s2d [options] file1 file2
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright (c) 2013, Yann Collet, released under BSD License.
+	Copyright 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+klauspost-cpuid v2.0.4 github:klauspost/cpuid:v2.0.4
+	Copyright (c) 2015 Klaus Post
+	Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
+	Copyright (c) 2020 Klaus Post, released under MIT License. See LICENSE file.
+	Copyright 2018 The Go Authors. All rights reserved
+kr-fs v0.1.0 github:kr/fs:v0.1.0
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+kr/pretty v0.3.1 github:kr/pretty:v0.3.1
+	Copyright 2012 Keith Rarick
+kubectl v0.28.1 github:kubernetes/kubectl:v0.28.1
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright {yyyy
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+kubernetes-sigs/apiserver-network-proxy konnectivity-client/v0.1.2 github:kubernetes-sigs/apiserver-network-proxy:konnectivity-client/v0.1.2
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright {yyyy
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+	copyright 2020 the kubernetes authors.
+kubernetes-sigs/structured-merge-diff v4.2.3 github:kubernetes-sigs/structured-merge-diff:v4.2.3
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2014 Google Inc. All rights reserved
+	Copyright 2020 The Kubernetes Authors.
+	Copyright {yyyy
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright (c) 2016 json-iterator
+	Copyright 2019 The Kubernetes Authors.
+kubernetes/api v0.28.1 github:kubernetes/api:v0.28.1
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+kubernetes/apiextensions-apiserver v0.27.3 github:kubernetes/apiextensions-apiserver:v0.27.3
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+kubernetes/apiserver v0.27.3 github:kubernetes/apiserver:v0.27.3
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+kubernetes/component-base v0.28.1 github:kubernetes/component-base:v0.28.1
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2015 The Kubernetes Authors.
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright 2022 The Kubernetes Authors.
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2014 The Kubernetes Authors.
+	Copyright 2023 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+kubernetes/cri-api v0.26.2 github:kubernetes/cri-api:v0.26.2
+	Copyright 2016 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright {yyyy
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+kubernetes/metrics v0.28.1 github:kubernetes/metrics:v0.28.1
+	Copyright 2018 The Kubernetes Authors.
+	Copyright 2020 The Kubernetes Authors.
+	Copyright {yyyy
+	Copyright The Kubernetes Authors.
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2017 The Kubernetes Authors.
+	Copyright 2019 The Kubernetes Authors.
+lann-builder 20181203-snapshot-47ae3079 github:lann/builder:47ae307949d02aa1f1069fdafc00ca08e1dbabac
+	Copyright (c) 2014-2015 Lann Martin
+lann-ps 20180517-snapshot-62de8c46 github:lann/ps:62de8c46ede02a7675c4c79c84883eb164cb71e3
+	Copyright (c) 2013 Michael Hendricks
+leodido/go-urn v1.2.1 github:leodido/go-urn:v1.2.1
+	Copyright (c) 2018 Leonardo Di Donato
+liggitt/tabwriter 20181228-snapshot-89fcab3d github:liggitt/tabwriter:89fcab3d43de07060e4fd4c1547430ed57e87f24
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+lithammer/dedent v1.1.0 github:lithammer/dedent:v1.1.0
+	Copyright (c) 2018 Peter Lithammer
+logfmt 20140226-snapshot-b84e30ac github:kr/logfmt:b84e30acd515aadc4b783ad4ff83aff3299bdfe0
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright (C) 2013 Keith Rarick, Blake Mizerany
+mailru/easyjson v0.7.7 github:mailru/easyjson:v0.7.7
+	Copyright (c) 2016 Mail.Ru Group
+	Copyright (c) 2009 The Go Authors. All rights reserved
+mapstructure v1.4.3 github:mitchellh/mapstructure:v1.4.3
+	Copyright (c) 2013 Mitchell Hashimoto
+markbates/errx v1.1.0 github:markbates/errx:v1.1.0
+	Copyright (c) 2019 Mark Bates
+martian v2.1.0 github:google/martian:v2.1.0
+	Copyright 2016 Google Inc. All rights reserved
+	Copyright 2018 Google Inc. All rights reserved
+	Copyright 2015 Google Inc. All rights reserved
+	copyright 2016 google inc. all rights reserved
+	Copyright 2017 Google Inc. All rights reserved
+martian v3.1.0 github:google/martian:v3.1.0
+	Copyright 2016 Google Inc. All rights reserved
+	Copyright 2018 Google Inc. All rights reserved
+	Copyright 2015 Google Inc. All rights reserved
+	copyright 2016 google inc. all rights reserved
+	Copyright 2017 Google Inc. All rights reserved
+matryer/moq v0.2.5 github:matryer/moq:v0.2.5
+	Copyright (c) 2016 Mat Ryer and David Hernandez
+mattn-go-colorable 0.1.13 github:mattn/go-colorable:v0.1.13
+	Copyright (c) 2016 Yasuhiro Matsumoto
+mattn-go-isatty v0.0.17 github:mattn/go-isatty:v0.0.17
+	Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+mattn-go-runewidth v0.0.14 github:mattn/go-runewidth:v0.0.14
+	Copyright (c) 2016 Yasuhiro Matsumoto
+mattn-go-shellwords v1.0.12 github:mattn/go-shellwords:v1.0.12
+	Copyright (c) 2017 Yasuhiro Matsumoto
+mattn-go-sqlite3 v1.14.15 github:mattn/go-sqlite3:v1.14.15
+	Copyright 2009-2010 Cybozu Labs, Inc.
+	Copyright (C) 2019 G.J.R. Timmer <gjr.timmer@gmail.com>.
+	Copyright 2011 The Go Authors. All rights reserved
+	(C) to sqlite3_autovacuum_pages(D,C,P,X) is a NULL pointer,** then the autovacuum steps callback is cancelled.  The return value** from sqlite3_autovacuum_pages() is normally SQLITE_OK, but might**
+	Copyright (C) 2018 G.J.R. Timmer <gjr.timmer@gmail.com>.
+	Copyright 2011 Kazuho Oku *  * Redistribution and use in source and binary forms, with or without * modification, are permitted provided that the following conditions are met: *  * 1. Redistribut
+	Copyright (C) 2018 segment.com <friends@segment.com>
+	Copyright (C) 2018 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+	Copyright (C) 2019 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+	Copyright (c) 2014 Yasuhiro Matsumoto
+	copyright to this source code.  In place of** a legal notice, here is a blessing:
+matttproud-golang_protobuf_extensions v1.0.4 github:matttproud/golang_protobuf_extensions:v1.0.4
+	Copyright 2013 Matt T. Proud
+	Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+	Copyright {yyyy
+	Copyright 2016 Matt T. Proud
+mergo v0.3.13 github:imdario/mergo:v0.3.13
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2014 Dario Casta
+	Copyright (c) 2013 Dario Casta
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2013 Dario Casta
+miekg/pkcs11 v1.1.1 github:miekg/pkcs11:v1.1.1
+	Copyright (c) OASIS Open 2016. All Rights Reserved
+	Copyright (c) 2013 Miek Gieben. All rights reserved
+	Copyright 2013 Miek Gieben. All rights reserved
+mitchellh-go-homedir v1.1.0 github:mitchellh/go-homedir:v1.1.0
+	Copyright (c) 2013 Mitchell Hashimoto
+mitchellh/gox v0.4.0 github:mitchellh/gox:v0.4.0
+	copyright doctrines of fair use, fair dealing, or otherequivalents.
+mittwald/go-helm-client v0.11.5 github:mittwald/go-helm-client:v0.11.5
+	Copyright (c) 2020 Mittwald CM Service
+moby/sys mountinfo/v0.6.2 github:moby/sys:mountinfo/v0.6.2
+	Copyright 2012 The Go Authors. All rights reserved
+mongodb/mongo-go-driver v1.8.3 github:mongodb/mongo-go-driver:v1.8.3
+	copyright() {    local line=
+	Copyright 2012 Keith Rarick
+	Copyright (c) 2019 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2018 Klaus Post. All rights reserved
+	Copyright 2019, The Go Authors. All rights reserved
+	Copyright (c) 2013-2016 Dave Collins <dave@davec.name> * * Permission to use, copy, modify, and distribute this software for any * purpose with or without fee is hereby granted, provided that the a
+	Copyright (c) 2017, Karrick McDermottAll rights reserved
+	Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved
+	Copyright 2019
+	Copyright (C) MongoDB, Inc. 2017-present."        echo "$1 already has copyright notice" >&2        return    fi
+	Copyright 2016 The filepathx Authors
+	Copyright (c) 2013 - 2017 Thomas Pelletier, Eric Anderton
+	Copyright (c) 2006-2010 Kirill Simonov
+	Copyright (c) 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2020, The Go Authors. All rights reserved
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright (c) 2015 Klaus Post
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+	Copyright (c) 2017 marvin
+	Copyright (c) 2017 Josh Baker
+	Copyright 2016 The Snappy-Go Authors. All rights reserved
+	Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+	Copyright 2021 by David A. Golden. All rights reserved
+	copyright=$'// Copyright (C) MongoDB, Inc. 2017-present.
+	Copyright 2013 The Go Authors. All rights reserved
+	copyright staring in 2011 when the project was ported over:
+	Copyright 2017, The Go Authors. All rights reserved
+	Copyright (C) MongoDB, Inc. 2019-present.
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright (c) 2006-2011 Kirill Simonov
+	Copyright 2011 The Snappy-Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+	Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 The Go Authors. All rights reserved
+	Copyright (c) 2014-2015 Montana Flynn (https://anonfunction.com)
+	Copyright (C) MongoDB, Inc. 2021-present.
+	Copyright (c) 2019 Mark Bates
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2018, The Go Authors. All rights reserved
+	Copyright (c) 2018 Mark Bates
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright (C) MongoDB, Inc. 2018-present.
+	Copyright 2014-2015 Stripe, Inc.----------------------------------------------------------------------
+	Copyright (c) 2019 Klaus Post. All rights reserved
+	Copyright (c) 2015, Dave Cheney <dave@cheney.net>All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright (c) 2010-2013 - Gustavo Niemeyer <gustavo@niemeyer.net>
+	Copyright 2018 by David A. Golden. All rights reserved
+	Copyright 2016-2017 The New York Times Company
+	Copyright (c) 2016 Caleb Spare
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2011-2019 Canonical Ltd
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright 2020
+	Copyright (c) 2014 youmark
+	Copyright (C) MongoDB, Inc. 2017-present.
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright (c) 2013, Yann Collet, released under BSD License.
+	Copyright (C) MongoDB, Inc. 2020-present.
+morikuni/aec v1.0.0 github:morikuni/aec:v1.0.0
+	Copyright (c) 2016 Taihei Morikuni
+murmur3 20181015-snapshot-f09979ec github:spaolacci/murmur3:f09979ecbc725b9e6d41a297405f65e7e8804acc
+	Copyright 2013, SAll rights reserved
+	Copyright 2013, S
+mwitkow/go-conntrack 20190716-snapshot-2f068394 github:mwitkow/go-conntrack:2f068394615f73e460c2f3d2c158b0ad9321cadb
+	Copyright {yyyy
+	Copyright 2016 Michal Witkowski. All Rights Reserved
+natefinch/lumberjack v2.0.0 github:natefinch/lumberjack:v2.0.0
+	Copyright (c) 2014 Nate Finch
+newrelic_platform_go 20161221-snapshot-b21fdbd4 github:yvasiyarov/newrelic_platform_go:b21fdbd4370f3717f3bbd2bf41c223bc273068e6
+	Copyright (c) 2013 Yuriy Vasiyarov. All rights reserved
+niemeyer/pretty 20200227-snapshot-a10e7cae github:niemeyer/pretty:a10e7caefd8e0d600cea437f5c3613aeb1553d56
+	Copyright 2012 Keith Rarick
+oklog/ulid v1.3.1 github:oklog/ulid:v1.3.1
+	Copyright 2013 Google Inc.  All rights reserved
+	Copyright (c) 2017 Google Inc. All rights reserved
+	Copyright 2015 Google Inc.  All rights reserved
+	Copyright 2017 Google Inc.  All rights reserved
+	Copyright 2016 The Oklog Authors
+olekukonko-tablewriter v0.0.5 github:olekukonko/tablewriter:v0.0.5
+	Copyright 2014 Oleku Konko All rights reserved
+open-telemetry/opentelemetry-go exporters/otlp/internal/retry/v1.14.0 github:open-telemetry/opentelemetry-go:exporters/otlp/internal/retry/v1.14.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go exporters/otlp/otlptrace/otlptracegrpc/v1.14.0 github:open-telemetry/opentelemetry-go:exporters/otlp/otlptrace/otlptracegrpc/v1.14.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go exporters/otlp/otlptrace/otlptracehttp/v1.14.0 github:open-telemetry/opentelemetry-go:exporters/otlp/otlptrace/otlptracehttp/v1.14.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go exporters/otlp/otlptrace/v1.14.0 github:open-telemetry/opentelemetry-go:exporters/otlp/otlptrace/v1.14.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go metric/v0.37.0 github:open-telemetry/opentelemetry-go:metric/v0.37.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go sdk/v1.14.0 github:open-telemetry/opentelemetry-go:sdk/v1.14.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go trace/v1.14.0 github:open-telemetry/opentelemetry-go:trace/v1.14.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go v1.14.0 github:open-telemetry/opentelemetry-go:v1.14.0
+	Copyright (c) 2006- Facebook
+	Copyright 2012 Twitter, Inc
+	Copyright The OpenTelemetry Authors
+	Copyright (C) 2006 - 2019, The Apache Software Foundation
+	Copyright</key>	<string>1983-2021 Apple Inc.</string>	<key>ProductName</key>	<string>macOS</string>	<key>ProductUserVisibleVersion</key>	<string>11.3</string>	<key>ProductVersion</key>	<string>
+	Copyright (c) 2006-2008 Alexander Chemeris
+	Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de>
+	Copyright (c) 2008- Patrick Collison <patrick@collison.ie>
+	Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+	Copyright</key></dict></plist>`)
+open-telemetry/opentelemetry-go-contrib instrumentation/google.golang.org/grpc/otelgrpc/v0.40.0 github:open-telemetry/opentelemetry-go-contrib:instrumentation/google.golang.org/grpc/otelgrpc/v0.40.0
+	Copyright (c) 2021 The Jaeger Authors.
+	Copyright 2017, OpenCensus Authors
+	Copyright The OpenTelemetry Authors
+	Copyright (c) 2017 Uber Technologies, Inc.
+open-telemetry/opentelemetry-go-contrib instrumentation/net/http/otelhttp/v0.35.1 github:open-telemetry/opentelemetry-go-contrib:instrumentation/net/http/otelhttp/v0.35.1
+	Copyright (c) 2021 The Jaeger Authors.
+	Copyright 2017, OpenCensus Authors
+	Copyright The OpenTelemetry Authors
+	Copyright (c) 2017 Uber Technologies, Inc.
+opencontainers-runtime-spec v1.1.0-rc.1 github:opencontainers/runtime-spec:v1.1.0-rc.1
+	Copyright 2015 The Linux Foundation.
+opencontainers/go-digest 1.0.0 github:opencontainers/go-digest:v1.0.0
+	Copyright 2017 Docker, Inc.
+	Copyright 2016 Docker, Inc.
+	Copyright 2019, 2020 OCI Contributors
+	Copyright 2020, 2020 OCI Contributors
+opencontainers/selinux v1.11.0 github:opencontainers/selinux:v1.11.0
+	Copyright {yyyy
+pkg/errors v0.9.1 github:pkg/errors:v0.9.1
+	Copyright (c) 2015, Dave Cheney <dave@cheney.net>All rights reserved
+pmezard-go-difflib 1.0.0 github:pmezard/go-difflib:v1.0.0
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+posener/complete v1.2.3 github:posener/complete:v1.2.3
+	Copyright (c) 2017 Eyal Posener
+poy/onpar v1.1.2 github:poy/onpar:v1.1.2
+	Copyright (c) 2016 Andrew Poydence
+prometheus/tsdb v0.7.1 github:prometheus/tsdb:v0.7.1
+	Copyright 2016 The Prometheus Authors
+	Copyright 2018 The Prometheus Authors
+	Copyright 2017 The Prometheus Authors
+	Copyright 2016 The etcd Authors
+	Copyright 2013 The Prometheus Authors
+	Copyright (c) 2014 Ben Johnson
+	Copyright 2019 The Prometheus Authors
+	Copyright (c) 2015,2016 Damian Gryski <damian@gryski.com>// All rights reserved
+	Copyright 2015 The etcd Authors
+pty v1.1.1 github:kr/pty:v1.1.1
+	Copyright (c) 2011 Keith Rarick
+rogpeppe/go-internal v1.10.0 github:rogpeppe/go-internal:v1.10.0
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright 2022 The Go Authors. All rights reserved
+rsc/binaryregexp v0.2.0 github:rsc/binaryregexp:v0.2.0
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+rsc/quote v3.1.0 github:rsc/quote:v3.1.0
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+rsc/sampler v1.3.0 github:rsc/sampler:v1.3.0
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+runc v1.1.4 github:opencontainers/runc:v1.1.4
+	Copyright (c) 2013 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (C) 1996-2015 Free Software Foundation, Inc.
+	Copyright (C) 1997-2020 Free Software Foundation, Inc.
+	Copyright (C) 2006-2020 Free Software Foundation, Inc.
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright (c) 2012 Xan Lopez
+	Copyright (c) 2017 Red Hat <pmoore@redhat.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright (c) 2015 Dmitri Shuralyov
+	Copyright (c) 2020 Red Hat <gscrivan@redhat.com> * Authors: Paul Moore <paul@paul-moore.com> *          Giuseppe Scrivano <gscrivan@redhat.com> */
+	Copyright (C) 2011-2020 Free Software Foundation, Inc.
+	Copyright (c) 2019 Cisco Systems <pmoore2@cisco.com>
+	Copyright (c) 2012 Dan Winship
+	Copyright (c) 2015 Bastien ROUCARIES
+	Copyright (C) 2017-2021 Open Containers Authors
+	Copyright 2017 The Go Authors. All rights reserved
+	Copyright 2009,2010 The Go Authors. All rights reserved
+	Copyright (c) 2015 Paul Moore <pmoore@redhat.com>All rights reserved
+	Copyright of the binary if any
+	Copyright (c) 2012 Paolo Borelli
+	Copyright IBM Corp. 2012 * Author: Corey Bryant <coreyb@linux.vnet.ibm.com> */
+	Copyright (c) 2012,2018 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright (c) 2012 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> *
+	Copyright (c) 2019 Cisco Systems, Inc. <pmoore2@cisco.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2017 Canonical Ltd.# Authors: Paul Moore <paul@paul-moore.com>#          Tyler Hicks <tyhicks@canonical.com>
+	Copyright (c) 2021 Microsoft Corporation <paulmoore@microsoft.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright (C) 2004-2005, 2007-2009, 2011-2015 Free Software#   Foundation, Inc.#   Written by Gary V. Vaughan, 2004
+	Copyright (c) 2014 Imagination Technologies Ltd. * Author: Markos Chandras <markos.chandras@imgtec.com> *
+	Copyright (c) 2018-2020 Oracle and/or its affiliates. * Author: Tom Hromatka <tom.hromatka@oracle.com> */
+	Copyright (c) 2020 Cisco Systems, Inc. <pmoore2@cisco.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2016 Helge Deller <deller@gmx.de> * Author: Helge Deller <deller@gmx.de>*/
+	Copyright (C) 1996-2001, 2003-2015 Free Software Foundation, Inc.#   Written by Gordon Matzigkeit, 1996
+	Copyright 2019 The Go Authors. All rights reserved
+	Copyright © 2011 Russ Ross <russ@russross.com>.
+	(C)     AC_LINK_IFELSE(     AC_LANG_POP])  if test yes != "$lt_cv_cc_needs_belf"; then    # this is probably gcc 2.8.0, egcs 1.0 or newer; no need for -belf    CFLAGS=$SAVE_CFLAGS  fi  ;;*-*so
+	Copyright (C) 2017 SUSE LLC
+	Copyright 2016 The Go Authors. All rights reserved
+	Copyright (c) 2016 Jeremy Saenz
+	Copyright (C) 2001-2020 Free Software Foundation, Inc.
+	Copyright (c) 2017 Nathan Sweet
+	Copyright (C) 2004-2015 Free Software Foundation, Inc.
+	Copyright (C) 2014-2015 Docker Inc
+	Copyright (c) 2012 Miki Tebeka <miki.tebeka@gmail.com>.
+	Copyright (c) 2012 Red Hat <pmoore@redhat.com> * Authors: Paul Moore <pmoore@redhat.com> *          Mathias Krause <minipli@googlemail.com> */
+	Copyright (c) 2014 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> *
+	Copyright (c) 2015 Matthew Heon <mheon@redhat.com>
+	Copyright (c) 2012 Red Hat <eparis@redhat.com> * Author: Eric Paris <eparis@redhat.com> */
+	Copyright (c) 2015 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2013 Red Hat <pmoore@redhat.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright (C) 1994 X Consortium
+	Copyright (C) 2014 Free Software Foundation, Inc.
+	Copyright 2014 Docker, Inc.
+	Copyright (c) 2012,2013 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2019 Cisco Systems, Inc. <pmoore2@cisco.com> * Author: Paul Moore <paul@paul-moore.com> * Additions: Michael Weiser <michael.weiser@gmx.de> */
+	Copyright (C) 1996-2020 Free Software Foundation, Inc.
+	Copyright (c) 2017 Canonical Ltd.# Author: Tyler Hicks <tyhicks@canonical.com>
+	Copyright (C) 2004-2005, 2007-2008, 2011-2015 Free Software# Foundation, Inc.# Written by Gary V. Vaughan, 2004
+	Copyright (c) 2012 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright 2018 CoreOS, Inc
+	Copyright 2015 The Linux Foundation.
+	Copyright 2015 The Go Authors. All rights reserved
+	Copyright (c) 2014 Red Hat <mjuszkiewicz@redhat.com> * Author: Marcin Juszkiewicz <mjuszkiewicz@redhat.com> */
+	Copyright (c) 2012,2016 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (C) 2004-2005, 2007, 2009, 2011-2015 Free Software#   Foundation, Inc.#   Written by Scott James Remnant, 2004.
+	(C)/!b go        :more        /\./!{          N          s|\n# | |          b more
+	Copyright 2015 Docker, Inc.
+	Copyright (c) 2019 Cisco Systems <pmoore2@cisco.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2015 Mathias Krause <minipli@googlemail.com> */
+	Copyright (C) 2017 SUSE LLC.
+	Copyright (c) 2012 Red Hat <pmoore@redhat.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright (c) 2016 Helge Deller <deller@gmx.de> *
+	Copyright (c) 2020 Cisco Systems, Inc. <pmoore2@cisco.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright 2015, 2018 CoreOS, Inc.
+	Copyright (C) 2004, 2011-2015 Free Software Foundation, Inc.#   Written by Scott James Remnant, 2004
+	Copyright (c) 2012,2016,2018 Red Hat <pmoore@redhat.com>
+	Copyright 2014 The Go Authors. All rights reserved
+	Copyright (C) 2017 SUSE LLC. All rights reserved
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright The containerd Authors.
+	Copyright 2015 CoreOS, Inc.
+	Copyright (c) 2017 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2016 Red Hat <pmoore@redhat.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright}}{{end`
+	Copyright (C) 2002-2020 Free Software Foundation, Inc.
+	Copyright (c) 2012, 2016 Philip Withnall
+	Copyright (c) 2012, 2020 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> * gperf support: Giuseppe Scrivano <gscrivan@redhat.com> */
+	Copyright (c) 2014 Simon Eskildsen
+	Copyright (c) 2021 Microsoft Corporation <paulmoore@microsoft.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2014 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2016 Helge Deller <deller@gmx.de> * Author: Helge Deller <deller@gmx.de> */
+	Copyright (c) 2018 Paul Moore <paul@paul-moore.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2012 Red Hat <pmoore@redhat.com>
+	Copyright 2020 The Go Authors. All rights reserved
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2020 Red Hat <gscrivan@redhat.com> * Author: Giuseppe Scrivano <gscrivan@redhat.com> */
+	Copyright (C) 2004-2020 Free Software Foundation, Inc.
+	Copyright (C) 2020 SUSE LLC
+	Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+	Copyright (C) 2019 Aleksa Sarai <cyphar@cyphar.com>
+	Copyright (c) 2019 Authors of Cilium
+	Copyright (C) 2019 SUSE LLC
+	Copyright (c) 2019 Cisco Systems, Inc. <pmoore2@cisco.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+	Copyright (C) 2020 Aleksa Sarai <cyphar@cyphar.com>
+	Copyright (c) 2018, 2019 Cloudflare
+	Copyright string	// Name of Author (Note: Use App.Authors, this is deprecated)	Author string	// Email of Author (Note: Use App.Authors, this is deprecated)	Email string	// Writer writer to write 
+	Copyright (C) 2011 Free Software Foundation, Inc.This config.lt script is free software; the Free Software Foundationgives unlimited permision to copy, distribute and modify it."
+	Copyright (c) 2020 Red Hat <gscrivan@redhat.com># Author: Giuseppe Scrivano <gscrivan@redhat.com>
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (C) 1999-2020 Free Software Foundation, Inc.
+	Copyright {yyyy
+	Copyright 2015 IBM * Author: Jan Willeke <willeke@linux.vnet.com.com> */
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2012 The Go Authors. All rights reserved
+	Copyright 2014 Vishvananda Ishaya.
+	Copyright 2016 SUSE LLC
+	Copyright (C) 2010-2015 Free Software Foundation, Inc.
+	Copyright IBM Corp. 2012 * Author: Ashley Lai <adlai@us.ibm.com> */
+	Copyright (c) 2015 Freescale <bogdan.purcareata@freescale.com> * Author: Bogdan Purcareata <bogdan.purcareata@freescale.com> *
+	Copyright (c) 2015 Red Hat <pmoore@redhat.com># Author: Paul Moore <paul@paul-moore.com>
+	Copyright (c) 2017 Canonical Ltd. * Author: Tyler Hicks <tyhicks@canonical.com> */
+	Copyright (c) 2012 Christian Persch
+	Copyright (c) 2016 Red Hat <pmoore@redhat.com>
+	Copyright 2013 Suryandaru Triandana <syndtr@gmail.com>All rights reserved
+	Copyright 2016, 2017 SUSE LLC
+	Copyright (c) 2018 Oracle and/or its affiliates.  All rights reserved
+	Copyright (c) 2022 Oracle and/or its affiliates.# Author: Tom Hromatka <tom.hromatka@oracle.com>
+	Copyright 2012-2015 Docker, Inc.
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (C) 2003-2020 Free Software Foundation, Inc.
+	Copyright The containerd Authors
+	Copyright (C) 2009-2020 Free Software Foundation, Inc.
+	Copyright (c) 2016 Red Hat <pmoore@redhat.com> * Author: Paul Moore <paul@paul-moore.com> */
+	Copyright (c) 2018 The Go Authors. All rights reserved
+	Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), GoogleAll rights reserved
+sean-/seed 20170313-snapshot-e2103e2c github:sean-/seed:e2103e2c35297fb7e17febb81e49b312087a2372
+	Copyright (c) 2016 Alex Dadgar
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright (c) 2017 Sean Chittenden
+sergi/go-diff v1.1.0 github:sergi/go-diff:v1.1.0
+	Copyright (c) 2006 Google Inc.// http://code.google.com/p/google-diff-match-patch/
+	Copyright (c) 2012-2016 The go-diff authors. All rights reserved
+	Copyright (c) 2012-2016 The go-diff Authors. All rights reserved
+shopspring-decimal v1.3.1 github:shopspring/decimal:v1.3.1
+	Copyright (c) 2013 Oguz Bilgic
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright (c) 2015 Spring, Inc.
+shurcooL-sanitized_anchor_name 1.0.0 github:shurcooL/sanitized_anchor_name:v1.0.0
+	Copyright (c) 2015 Dmitri Shuralyov
+sigs.k8s.io/json 20221116-snapshot-bc3834ca github:kubernetes-sigs/json:bc3834ca7abd3a90f03ef00a27ad80cb892f9c21
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright 2010 The Go Authors. All rights reserved
+	Copyright 2011 The Go Authors. All rights reserved
+	Copyright {yyyy
+	Copyright 2021 The Kubernetes Authors.
+	Copyright 2021 The Go Authors. All rights reserved
+	Copyright 2019 The Go Authors. All rights reserved
+	(C) MarshalJSON() (	return []byte(`"<&>"`), nil}
+	Copyright 2018 The Go Authors. All rights reserved
+	Copyright (c) 2009 The Go Authors. All rights reserved
+	Copyright 2016 The Go Authors. All rights reserved
+sigs.k8s.io/yaml v1.3.0 github:kubernetes-sigs/yaml:v1.3.0
+	Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+	Copyright 2013 The Go Authors. All rights reserved
+	Copyright (c) 2012 The Go Authors. All rights reserved
+	Copyright (c) 2013-2016 Dave Collins <dave@davec.name> * * Permission to use, copy, modify, and distribute this software for any * purpose with or without fee is hereby granted, provided that the a
+	Copyright {yyyy
+	Copyright (c) 2014 Sam Ghods
+	Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
+	Copyright 2011-2016 Canonical Ltd.
+spf13-afero v1.6.0 github:spf13/afero:v1.6.0
+	Copyright ©2015 The Go Authors
+	Copyright © 2015 Jerry Jacobs <jerry.jacobs@xor-gate.org>.
+	Copyright ©2015 Steve Francia <spf@spf13.com>
+	Copyright 2009 The Go Authors. All rights reserved
+	Copyright ©2018 Steve Francia <spf@spf13.com>
+	Copyright © 2016 Steve Francia <spf@spf13.com>.
+	Copyright 2016-present Bj
+	Copyright © 2018 Steve Francia <spf@spf13.com>.
+	Copyright © 2015 Steve Francia <spf@spf13.com>.
+	Copyright ©2015 The Hugo Authors
+	Copyright 2013 tsuru authors. All rights reserved
+	Copyright ©2015 The Hugo Authors
+	Copyright © 2014 Steve Francia <spf@spf13.com>.
+spf13-cobra v1.7.0 github:spf13/cobra:v1.7.0
+	Copyright 2013-2023 The Cobra Authors
+sql-migrate v1.3.1 github:rubenv/sql-migrate:v1.3.1
+	Copyright (C) 2014-2021 by Ruben Vermeersch <ruben@rocketeer.be>
+	Copyright (C) 2014-2017 by Ruben Vermeersch <ruben@rocketeer.be>
+	Copyright (C) 2012-2014 by Liam Staskawicz
+sqlx v1.3.5 github:jmoiron/sqlx:v1.3.5
+	Copyright (c) 2013, Jason Moiron
+stefanberger/go-pkcs11uri 20201008-snapshot-78d3cae3 github:stefanberger/go-pkcs11uri:78d3cae3a9805d89aa4fa80a362ca944c89a1b99
+	(c) Copyright IBM Corporation, 2020
+stoewer/go-strcase v1.2.0 github:stoewer/go-strcase:v1.2.0
+	Copyright (c) 2017, A. Stoewer <adrian.stoewer@rz.ifi.lmu.de>// All rights reserved
+	Copyright (c) 2017, Adrian Stoewer <adrian.stoewer@rz.ifi.lmu.de>
+stretchr/objx v0.5.0 github:stretchr/objx:v0.5.0
+	Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+	copyright staring in 2011 when the project was ported over:
+	Copyright (c) 2017-2018 objx contributors
+	Copyright (c) 2013, Patrick MezardAll rights reserved
+	Copyright (c) 2006-2010 Kirill Simonov
+	Copyright (c) 2013-2016 Dave Collins <dave@davec.name> * * Permission to use, copy, modify, and distribute this software for any * purpose with or without fee is hereby granted, provided that the a
+	Copyright (c) 2014 Stretchr, Inc.
+	Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+	Copyright (c) 2006-2011 Kirill Simonov
+	Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright (c) 2011-2019 Canonical Ltd
+subosito/gotenv v1.2.0 github:subosito/gotenv:v1.2.0
+	Copyright (c) 2013 Alif Rachmawadi
+swag v0.22.3 github:go-openapi/swag:v0.22.3
+	Copyright 2015 go-swagger maintainers
+syndtr-gocapability 20200815-snapshot-42c35b43 github:syndtr/gocapability:42c35b4376354fd554efc7ad35e0b7f94e3a0ffb
+	Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+	Copyright 2013 Suryandaru Triandana <syndtr@gmail.com>All rights reserved
+tidwall/match v1.1.1 github:tidwall/match:v1.1.1
+	Copyright (c) 2016 Josh Baker
+tidwall/pretty v1.2.0 github:tidwall/pretty:v1.2.0
+	Copyright (c) 2017 Josh Baker
+tmc/grpc-websocket-proxy 20220101-snapshot-673ab2c3 github:tmc/grpc-websocket-proxy:673ab2c3ae75cc01952b84b88590e30e75dcf395
+	Copyright (C) 2016 Travis Cline
+uber-go/atomic v1.10.0 github:uber-go/atomic:v1.10.0
+	Copyright (c) 2022 Uber Technologies, Inc.
+	Copyright (c) 2016-2020 Uber Technologies, Inc.
+	Copyright (c) 2020 Uber Technologies, Inc.
+	Copyright (c) 2021-2022 Uber Technologies, Inc.
+	Copyright (c) 2019 Uber Technologies, Inc.
+	Copyright (c) 2016 Uber Technologies, Inc.
+	Copyright (c) 2020-
+	Copyright (c) 2021 Uber Technologies, Inc.
+	Copyright (c) 2020-2022 Uber Technologies, Inc.
+urfave-cli v1.22.12 github:urfave/cli:v1.22.12
+	Copyright}}{{end`
+	Copyright string	// Name of Author (Note: Use App.Authors, this is deprecated)	Author string	// Email of Author (Note: Use App.Authors, this is deprecated)	Email string	// Writer writer to write 
+	Copyright of the binary if any
+	Copyright (c) 2023 Jeremy Saenz
+utter v1.0.1 github:kortschak/utter:v1.0.1
+	Copyright (c) 2013 Dave Collins <dave@davec.name>
+	Copyright (c) 2015 Dan Kortschak <dan.kortschak@adelaide.edu.au>
+	Copyright (c) 2012-2013 Dave Collins <dave@davec.name>
+	Copyright (c) 2013 Dave Collins <dave@davec.name>
+	Copyright (c) 2015 Dan Kortschak <dan.kortschak@adelaide.edu.au> * * Permission to use, copy, modify, and distribute this software for any * purpose with or without fee is hereby granted, provided 
+vishvananda-netlink v1.2.1-beta.2 github:vishvananda/netlink:v1.2.1-beta.2
+	Copyright 2014 Docker, Inc.
+	Copyright 2014 Vishvananda Ishaya.
+vishvananda-netns 20210104-snapshot-2eb08e3e github:vishvananda/netns:2eb08e3e575f00733a612d25cc5d7470f8db6f35
+	Copyright 2014 Docker, Inc.
+	Copyright 2014 Vishvananda Ishaya.
+wI2L/jsondiff v0.2.0 github:wI2L/jsondiff:v0.2.0
+	Copyright (c) 2020-2022 William Poussier <william.poussier@gmail.com>
+xdg-go/stringprep v1.0.2 github:xdg-go/stringprep:v1.0.2
+	Copyright 2018 by David A. Golden. All rights reserved
+xeipuuv-gojsonpointer 20190904-snapshot-02993c40 github:xeipuuv/gojsonpointer:02993c407bfbf5f6dae44c4f4b1cf6a39b5fc5bb
+	Copyright 2015 xeipuuv
+	Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+xeipuuv-gojsonreference 20180127-snapshot-bd5ef7bd github:xeipuuv/gojsonreference:bd5ef7bd5415a7ac448318e64f11a24cd21e594b
+	Copyright 2015 xeipuuv
+	Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+xeipuuv/gojsonschema v1.2.0 github:xeipuuv/gojsonschema:v1.2.0
+	Copyright 2013 MongoDB, Inc.
+	Copyright 2018 johandorland ( https://github.com/johandorland )
+	Copyright 2015 xeipuuv
+	Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+	Copyright 2017 johandorland ( https://github.com/johandorland )
+xgb 20160522-snapshot-27f12275 github:BurntSushi/xgb:27f122750802c950b2c869a5b63dafcf590ced95
+	Copyright (c) 2009 The XGB Authors. All rights reserved
+	Copyright          = 61	AtomNotice             = 62	AtomFontName           = 63	AtomFamilyName         = 64	AtomFullName           = 65	AtomCapHeight          = 66	AtomWmClass            = 67	A
+xhit/go-str2duration v2.1.0 github:xhit/go-str2duration:v2.1.0
+	Copyright 2010 The Go Authors. All rights reserved
+xlab/treeprint v1.2.0 github:xlab/treeprint:v1.2.0
+	Copyright © 2016 Maxim Kupriianov <max@kc.vc>
+xordataexchange-crypt 20180613-snapshot-b2862e3d github:xordataexchange/crypt:b2862e3d0a775f18c7cfe02273500ae307b61218
+	Copyright (c) 2014 XOR Data Exchange, Inc.
+yaml for Go v3.0.1 github:go-yaml/yaml:v3.0.1
+	copyright staring in 2011 when the project was ported over:
+	Copyright (c) 2006-2010 Kirill Simonov
+	Copyright (c) 2006-2011 Kirill Simonov
+	Copyright 2011-2016 Canonical Ltd.
+	Copyright (c) 2011-2019 Canonical Ltd
+yuin/goldmark v1.4.13 github:yuin/goldmark:v1.4.13
+	Copyright (c) 2019 Yusuke Inuzuka
+yvasiyarov-go-metrics 20161221-snapshot-57bccd1c github:yvasiyarov/go-metrics:57bccd1ccd43f94bb17fdd8bf3007059b802f85e
+	Copyright 2012 Richard Crowley. All rights reserved
+
+
+Licenses: 
+
+Apache License 2.0
+(bgentry-speakeasy 0.1.0, btree v1.1.2, census-instrumentation/opencensus-go v0.24.0, client-go v0.28.1, client_golang v1.16.0, cncf/udpa 20220112-snapshot-c52dc94e, container-orchestrated-devices/container-device-interface v0.5.4, containerd/btrfs v2.0.0, containerd/cgroups v1.1.0, containerd/cgroups v3.0.1, containerd/console 1.0.3, containerd/containerd v1.7.0, containerd/continuity v0.3.0, containerd/fifo v1.1.0, containerd/go-runc v1.0.0, containerd/nri v0.3.0, containerd/typeurl 1.0.2, containerd/typeurl v2.1.0, containernetworking/plugins v1.2.0, containers/ocicrypt v1.1.6, CoreOS v0.3.0, coreos-go-oidc v2.1.0, coreos-pkg 20181023-snapshot-399ea9e2, docker v23.0.1, docker-cli v23.0.1, docker-go-units v0.5.0, docker-org 20190806-snapshot-e31b211e, docker-registry 2.8.2, docker/go-metrics v0.0.1, envoyproxy/go-control-plane v0.10.3, envoyproxy/protoc-gen-validate 0.9.1, etcd-io/etcd v3.5.7, gengo 20220902-snapshot-c0856e24, github.com/AdaLogics/go-fuzz-headers 20230106-snapshot-43070de9, github.com/containerd/aufs v1.0.0, github.com/containerd/go-cni v1.1.9, github.com/containerd/ttrpc v1.2.1, github.com/containerd/zfs v1.0.0, github.com/containernetworking/cni v1.1.2, github.com/go-logr/zapr v1.2.3, github.com/gomodule/redigo v1.8.2, github.com/moby/locker 1.0.1, github.com/moby/spdystream v0.2.0, github.com/xdg-go/pbkdf2 1.0.0, go-etcd v3.3.10, go-ini-ini v1.62.0, go-jose v2.6.0, go-logr/logr v1.2.4, go-logr/stdr v1.2.2, go-openapi/jsonpointer v0.19.6, go-systemd 20190321-snapshot-95778dfb, go-systemd v22.5.0, go-zfs 20190419-snapshot-f784269b, go.opentelemetry.io/proto otlp/v0.19.0, godror/godror v0.24.2, golang-github-docker-go-connections-dev 0.4.0, golang-github-docker-libtrust-dev 20160225-snapshot-fa567046, golang-mock v1.6.0, golang-sql/civil 20190719-snapshot-cb61b32a, golang/appengine v1.6.7, golang/glog v1.0.0, google-cloud-go bigquery/v1.8.0, google-cloud-go compute/metadata/v0.2.3, google-cloud-go compute/v1.15.1, google-cloud-go datastore/v1.1.0, google-cloud-go firestore/v1.1.0, google-cloud-go pubsub/v1.3.1, google-cloud-go storage/v1.10.0, google-cloud-go v0.97.0, google-gofuzz v1.2.0, google-shlex 20191202-snapshot-e7afc7fb, google/cel-go v0.12.6, google/gnostic v0.6.9, google/gnostic-models v0.6.8, google/pprof 20210720-snapshot-4bb14d4b, google/renameio v0.1.0, googleapis/go-genproto 20230525-snapshot-28d5490b, googleapis/go-genproto 20230525-snapshot-dd9d6828, googleapis/go-genproto 20230526-snapshot-0005af68, gotest.tools v3.4.0, groupcache 20210331-snapshot-41bb18bf, grpc-ecosystem/go-grpc-middleware v1.3.0, grpc-ecosystem/go-grpc-prometheus v1.2.0, grpc-go v1.54.0, helm/helm v3.12.3, inconshreveable/mousetrap v1.1.0, intel/goresctrl v0.3.0, jonboulle-clockwork v0.2.2, jsonreference v0.20.2, k3s-io/klog v2.100.1-k3s1, k8s.io/cli-runtime v0.28.1, k8s.io/code-generator v0.27.3, k8s.io/component-helpers v0.28.1, k8s.io/kube-openapi 20230717-snapshot-26953613, k8s.io/utils 20230406-snapshot-d93618cf, Keploy.io v0.7.12, kubectl v0.28.1, kubernetes-sigs/apiserver-network-proxy konnectivity-client/v0.1.2, kubernetes-sigs/structured-merge-diff v4.2.3, kubernetes/api v0.28.1, kubernetes/apiextensions-apiserver v0.27.3, kubernetes/apimachinery v0.28.1, kubernetes/apiserver v0.27.3, kubernetes/component-base v0.28.1, kubernetes/cri-api v0.26.2, kubernetes/metrics v0.28.1, kustomize 20230601-snapshot-6ce0bf39, martian v2.1.0, martian v3.1.0, Masterminds/goutils v1.1.1, matttproud-golang_protobuf_extensions v1.0.4, minio/sha256-simd v1.0.0, moby/sys mountinfo/v0.6.2, moby/sys sequential/v0.5.0, moby/sys signal/v0.7.0, moby/sys symlink/v0.2.0, modern-go/concurrent 20180305-snapshot-bacd9c7e, modern-go/reflect2 v1.0.2, mongodb/mongo-go-driver v1.8.3, mwitkow/go-conntrack 20190716-snapshot-2f068394, NYTimes-gziphandler v1.1.1, oklog/ulid v1.3.1, OneOfOne/xxhash v1.2.2, open-telemetry/opentelemetry-go exporters/otlp/internal/retry/v1.14.0, open-telemetry/opentelemetry-go exporters/otlp/otlptrace/otlptracegrpc/v1.14.0, open-telemetry/opentelemetry-go exporters/otlp/otlptrace/otlptracehttp/v1.14.0, open-telemetry/opentelemetry-go exporters/otlp/otlptrace/v1.14.0, open-telemetry/opentelemetry-go metric/v0.37.0, open-telemetry/opentelemetry-go sdk/v1.14.0, open-telemetry/opentelemetry-go trace/v1.14.0, open-telemetry/opentelemetry-go v1.14.0, open-telemetry/opentelemetry-go-contrib instrumentation/google.golang.org/grpc/otelgrpc/v0.40.0, open-telemetry/opentelemetry-go-contrib instrumentation/net/http/otelhttp/v0.35.1, OpenCensus v0.4.1, opencontainers-runtime-spec v1.1.0-rc.1, opencontainers/go-digest 1.0.0, opencontainers/selinux v1.11.0, oras.land/oras-go v1.2.3, pquerna/cachecontrol v0.1.0, prometheus-client_model v0.4.0, prometheus-common v0.44.0, prometheus-procfs v0.10.1, prometheus/tsdb v0.7.1, runc v1.1.4, sergi/go-diff v1.1.0, sigs.k8s.io/json 20221116-snapshot-bc3834ca, sigs.k8s.io/yaml v1.3.0, soheilhy/cmux v0.1.5, spf13-afero v1.6.0, spf13-cobra v1.7.0, stefanberger/go-pkcs11uri 20201008-snapshot-78d3cae3, swag v0.22.3, vishvananda-netlink v1.2.1-beta.2, vishvananda-netns 20210104-snapshot-2eb08e3e, xdg-go/scram v1.1.0, xdg-go/stringprep v1.0.2, xeipuuv-gojsonpointer 20190904-snapshot-02993c40, xeipuuv-gojsonreference 20180127-snapshot-bd5ef7bd, xeipuuv/gojsonschema v1.2.0, yaml for Go v2.4.0, yaml for Go v3.0.1)
+
+Apache License
+Version 2.0, January 2004
+=========================
+
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions
+granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is
+based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work by
+the copyright owner or by an individual or Legal Entity authorized to submit on
+behalf of the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent to the
+Licensor or its representatives, including but not limited to communication on
+electronic mailing lists, source code control systems, and issue tracking systems
+that are managed by, or on behalf of, the Licensor for the purpose of discussing
+and improving the Work, but excluding communication that is conspicuously marked
+or otherwise designated in writing by the copyright owner as "Not a
+Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of
+whom a Contribution has been received by Licensor and subsequently incorporated
+within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or Object
+form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work to
+which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work constitutes
+direct or contributory patent infringement, then any patent licenses granted to
+You under this License for that Work shall terminate as of the date such
+litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+  a. You must give any other recipients of the Work or Derivative Works a copy of
+    this License; and
+
+  b. You must cause any modified files to carry prominent notices stating that
+    You changed the files; and
+
+  c. You must retain, in the Source form of any Derivative Works that You
+    distribute, all copyright, patent, trademark, and attribution notices from
+    the Source form of the Work, excluding those notices that do not pertain to
+    any part of the Derivative Works; and
+
+  d. If the Work includes a "NOTICE" text file as part of its distribution, then
+    any Derivative Works that You distribute must include a readable copy of the
+    attribution notices contained within such NOTICE file, excluding those
+    notices that do not pertain to any part of the Derivative Works, in at least
+    one of the following places: within a NOTICE text file distributed as part of
+    the Derivative Works; within the Source form or documentation, if provided
+    along with the Derivative Works; or, within a display generated by the
+    Derivative Works, if and wherever such third-party notices normally appear.
+    The contents of the NOTICE file are for informational purposes only and do
+    not modify the License. You may add Your own attribution notices within
+    Derivative Works that You distribute, alongside or as an addendum to the
+    NOTICE text from the Work, provided that such additional attribution notices
+    cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any character
+arising as a result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility of such
+damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations and/or
+rights consistent with this License. However, in accepting such obligations, You
+may act only on Your own behalf and on Your sole responsibility, not on behalf of
+any other Contributor, and only if You agree to indemnify, defend, and hold each
+Contributor harmless for any liability incurred by, or claims asserted against,
+such Contributor by reason of your accepting any such warranty or additional
+liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also recommend
+that a file or class name and description of purpose be included on the same
+"printed page" as the copyright notice for easier identification within
+third-party archives.
+
+  Copyright [yyyy] [name of copyright owner] Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+  or agreed to in writing, software distributed under the License is
+  distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+
+---
+
+BSD 2-clause "Simplified" License
+(karrick/godirwalk v1.16.1)
+
+BSD 2-Clause License
+
+Copyright (c) 2017, Karrick McDermott
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(BurntSushi/toml 1.2.1, go-check-check 20201130-snapshot-10cb9826, gorelic 20141212-snapshot-a9bba5b9)
+
+BSD Two Clause License
+======================
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+---
+
+BSD 2-clause "Simplified" License
+(blackfriday v1.6.0)
+
+Blackfriday is distributed under the Simplified BSD License:
+
+Copyright © 2011 Russ Ross
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided with
+    the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(gopherjs 20181205-snapshot-0766667c)
+
+Copyright (c) 2013 Richard Musiol. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(gorilla/handlers v1.5.1)
+
+Copyright (c) 2013 The Gorilla Handlers Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(gorilla/websocket v1.4.2)
+
+Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(newrelic_platform_go 20161221-snapshot-b21fdbd4)
+
+Copyright (c) 2013 Yuriy Vasiyarov. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(godbus-dbus v5.1.0)
+
+Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(pkg/errors v0.9.1)
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(yvasiyarov-go-metrics 20161221-snapshot-57bccd1c)
+
+Copyright 2012 Richard Crowley. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    1.  Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+    2.  Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY RICHARD CROWLEY ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL RICHARD CROWLEY OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(syndtr-gocapability 20200815-snapshot-42c35b43)
+
+Copyright 2013 Suryandaru Triandana <syndtr@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(sftp v1.10.1)
+
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: github.com/pkg/sftp
+Source: https://github.com/pkg/sftp
+
+Files: *
+Copyright: 2013–2016 Dave Cheney <dave@cheney.net>
+License: BSD-2-clause
+
+Files: debian/*
+Copyright: 2016 Anthony Fok <foka@debian.org>
+License: BSD-2-clause
+Comment: Debian packaging is licensed under the same terms as upstream
+
+License: BSD-2-clause
+ All rights reserved.
+ .
+
+Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(golang-github-magiconair-properties v1.8.5)
+
+Source: https://github.com/magiconair/properties
+
+Files: *
+Copyright: 2013–2020 Frank Schröder <frank.schroeder@gmail.com>
+License: BSD-2-clause
+
+Files: debian/*
+Copyright: 2015–2020 Anthony Fok <foka@debian.org>
+License: BSD-2-clause
+Comment: Debian packaging is licensed under the same terms as upstream
+
+License: BSD-2-clause
+
+Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ .
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 2-clause "Simplified" License
+(blackfriday v2.1.0)
+
+Upstream-Contact: https://github.com/russross/blackfriday/issues/new
+
+Files: *
+Copyright: 2011 Russ Ross
+License: BSD-2-clause
+
+Files: debian/*
+Copyright: 2014–2015 Tianon Gravi <tianon@debian.org>
+           2015      Martina Ferrari <tincho@debian.org>
+           2015–2020 Anthony Fok <foka@debian.org>
+           2016      Dr. Tobias Quathamer <toddy@debian.org>
+           2020      Reinhard Tartler <siretart@debian.org>
+License: BSD-2-clause
+
+License: BSD-2-clause
+
+Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(julienschmidt/httprouter v1.3.0)
+
+BSD 3-Clause License
+
+Copyright (c) 2013, Julien Schmidt
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(daviddengcn/go-colortext 1.0.0)
+
+BSD License
+===========
+
+Copyright (c) 2016, David Deng
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of go-colortext nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(hashicorp-go.net v0.0.1, liggitt/tabwriter 20181228-snapshot-89fcab3d, miekg/dns v1.1.25, rsc/binaryregexp v0.2.0, rsc/quote v3.1.0, rsc/sampler v1.3.0, sean-/seed 20170313-snapshot-e2103e2c)
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(google/uuid v1.3.0)
+
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(googleapis/google-api-go-client v0.44.0)
+
+Copyright (c) 2011 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(golang-snappy-go-dev v0.0.4)
+
+Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(golang-github-spf13-pflag-dev v1.0.5)
+
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(go-inf-inf v0.9.1)
+
+Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(alecthomas-template 20160405-snapshot-a0175ee3, go-mssqldb 0.9.0, kr-fs v0.1.0)
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(hashicorp-go-msgpack v0.5.3)
+
+Copyright (c) 2012, 2013 Ugorji Nwoke.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the author nor the names of its contributors may be used
+  to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(gorilla/mux v1.8.0)
+
+Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+	 * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+	 * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+	 * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(miekg/pkcs11 v1.1.1)
+
+Copyright (c) 2013 Miek Gieben. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Miek Gieben nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(go-flowrate 20140419-snapshot-cca7078d)
+
+Copyright (c) 2014 The Go-FlowRate Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+ * Neither the name of the go-flowrate project nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(evanphx/json-patch v5.6.0)
+
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(grpc-gateway v1.16.0)
+
+Copyright (c) 2015, Gengo, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of Gengo, Inc. nor the names of its
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(github.com/gofrs/flock v0.8.1)
+
+Copyright (c) 2015-2020, Tim Heckman
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of gofrs nor the names of its contributors may be used
+  to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(PaesslerAG/gval v1.0.0, PaesslerAG/jsonpath 0.1.1)
+
+Copyright (c) 2017, Paessler AG <support@paessler.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(antlr runtime/Go/antlr/v1.4.10, BurntSushi/toml 1.2.1, DATA-DOG-go-sqlmock v1.5.0, exp 20200223-snapshot-6cc2880d, fsnotify-fsnotify v1.6.0, github.com/munnerz/goautoneg 20191010-snapshot-a7dc8b61, glfw 20190408-snapshot-e6da0acd, glfw 20200222-snapshot-6f7a984d, Go support for Mobile devices 20190704-snapshot-d2bd2a29, Golang Protobuf v1.30.0, Golang Protobuf v1.5.3, golang.org/x/crypto v0.11.0, golang.org/x/image 20190704-snapshot-cff245a6, golang.org/x/lint 20210508-snapshot-6edffad5, golang.org/x/mod v0.9.0, golang.org/x/net v0.13.0, golang.org/x/oauth2 v0.8.0, golang.org/x/sync v0.2.0, golang.org/x/sys v0.10.0, golang.org/x/term v0.10.0, golang.org/x/time v0.3.0, golang.org/x/tools v0.8.0, golang.org/x/xerrors 20220907-snapshot-04be3eba, golang/text v0.11.0, google/go-cmp v0.5.9, google/starlark-go 20230525-snapshot-a134d8f9, grpc-gateway v2.7.0, ianlancetaylor/demangle 20200824-snapshot-28f6c0f3, klauspost-compress v1.16.0, mattn-go-colorable 0.1.13, mergo v0.3.13, phayes/freeport 20220201-snapshot-74d24b5a, pkg/diff 20210226-snapshot-20ebb0f2, rogpeppe/go-internal v1.10.0, sigs.k8s.io/json 20221116-snapshot-bc3834ca, xgb 20160522-snapshot-27f12275, xhit/go-str2duration v2.1.0)
+
+Copyright (c) <YEAR>, <OWNER>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the <ORGANIZATION> nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(gogo/protobuf v1.3.2)
+
+Copyright 2010 The Go Authors.  All rights reserved.
+https://github.com/golang/protobuf
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(chai2010-gettext-go v1.0.2)
+
+Copyright 2013 ChaiShushan <chaishushan{AT}gmail.com>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(murmur3 20181015-snapshot-f09979ec)
+
+Copyright 2013, Sébastien Paolacci.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the library nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(googleapis/gax-go v2.0.5)
+
+Copyright 2016, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(go-errgo-errgo v2.1.0)
+
+Copyright © 2013, Roger Peppe
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of this project nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(github.com/rogpeppe/fastuuid v1.2.0)
+
+Copyright © 2014, Roger Peppe
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of this project nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(cyphar/filepath-securejoin v0.2.3)
+
+License: BSD-3-Clause~Google
+
+Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+   * Neither the name of Google Inc. nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(kisielk-gotool v1.0.0)
+
+License: BSD-3-clause
+ All rights reserved.
+ .
+
+Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. Neither the name of the Google Inc. nor the names of its contributors
+    may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS
+ BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(pmezard-go-difflib 1.0.0)
+
+Source: https://github.com/pmezard/go-difflib
+
+Files: *
+Copyright: 2013 Patrick Mézard
+License: BSD-3-clause
+
+Files: debian/*
+Copyright: 2016 Dmitry Smirnov <onlyjob@debian.org>
+License: BSD-3-clause
+
+License: BSD-3-clause
+
+Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+    Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ .
+    Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ .
+    The names of its contributors may not be used to endorse or promote
+    products derived from this software without specific prior written
+    permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+BSD 3-clause "New" or "Revised" License
+(client9/misspell v0.3.4)
+
+which are covered under a BSD License.
+
+* https://golang.org/pkg/strings/#Replacer
+* https://golang.org/src/strings/replace.go
+* https://github.com/golang/go/blob/master/LICENSE
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+---
+
+Creative Commons Attribution 3.0
+(BurntSushi/toml 1.2.1)
+
+Creative Commons
+Attribution 3.0 Unported
+========================
+
+  CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL
+  SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN ATTORNEY-CLIENT
+  RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS.
+  CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE INFORMATION PROVIDED, AND
+  DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM ITS USE.
+
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS
+PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR
+OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS
+LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE
+BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY BE CONSIDERED
+TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN
+CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
+
+1. Definitions
+
+  a. "Adaptation" means a work based upon the Work, or upon the Work and other
+    pre-existing works, such as a translation, adaptation, derivative work,
+    arrangement of music or other alterations of a literary or artistic work, or
+    phonogram or performance and includes cinematographic adaptations or any
+    other form in which the Work may be recast, transformed, or adapted including
+    in any form recognizably derived from the original, except that a work that
+    constitutes a Collection will not be considered an Adaptation for the purpose
+    of this License. For the avoidance of doubt, where the Work is a musical
+    work, performance or phonogram, the synchronization of the Work in
+    timed-relation with a moving image ("synching") will be considered an
+    Adaptation for the purpose of this License.
+
+  b. "Collection" means a collection of literary or artistic works, such as
+    encyclopedias and anthologies, or performances, phonograms or broadcasts, or
+    other works or subject matter other than works listed in Section 1(f) below,
+    which, by reason of the selection and arrangement of their contents,
+    constitute intellectual creations, in which the Work is included in its
+    entirety in unmodified form along with one or more other contributions, each
+    constituting separate and independent works in themselves, which together are
+    assembled into a collective whole. A work that constitutes a Collection will
+    not be considered an Adaptation (as defined above) for the purposes of this
+    License.
+
+  c. "Distribute" means to make available to the public the original and copies
+    of the Work or Adaptation, as appropriate, through sale or other transfer of
+    ownership.
+
+  d. "Licensor" means the individual, individuals, entity or entities that
+    offer(s) the Work under the terms of this License.
+
+  e. "Original Author" means, in the case of a literary or artistic work, the
+    individual, individuals, entity or entities who created the Work or if no
+    individual or entity can be identified, the publisher; and in addition (i) in
+    the case of a performance the actors, singers, musicians, dancers, and other
+    persons who act, sing, deliver, declaim, play in, interpret or otherwise
+    perform literary or artistic works or expressions of folklore; (ii) in the
+    case of a phonogram the producer being the person or legal entity who first
+    fixes the sounds of a performance or other sounds; and, (iii) in the case of
+    broadcasts, the organization that transmits the broadcast.
+
+  f. "Work" means the literary and/or artistic work offered under the terms of
+    this License including without limitation any production in the literary,
+    scientific and artistic domain, whatever may be the mode or form of its
+    expression including digital form, such as a book, pamphlet and other
+    writing; a lecture, address, sermon or other work of the same nature; a
+    dramatic or dramatico-musical work; a choreographic work or entertainment in
+    dumb show; a musical composition with or without words; a cinematographic
+    work to which are assimilated works expressed by a process analogous to
+    cinematography; a work of drawing, painting, architecture, sculpture,
+    engraving or lithography; a photographic work to which are assimilated works
+    expressed by a process analogous to photography; a work of applied art; an
+    illustration, map, plan, sketch or three-dimensional work relative to
+    geography, topography, architecture or science; a performance; a broadcast; a
+    phonogram; a compilation of data to the extent it is protected as a
+    copyrightable work; or a work performed by a variety or circus performer to
+    the extent it is not otherwise considered a literary or artistic work.
+
+  g. "You" means an individual or entity exercising rights under this License who
+    has not previously violated the terms of this License with respect to the
+    Work, or who has received express permission from the Licensor to exercise
+    rights under this License despite a previous violation.
+
+  h. "Publicly Perform" means to perform public recitations of the Work and to
+    communicate to the public those public recitations, by any means or process,
+    including by wire or wireless means or public digital performances; to make
+    available to the public Works in such a way that members of the public may
+    access these Works from a place and at a place individually chosen by them;
+    to perform the Work to the public by any means or process and the
+    communication to the public of the performances of the Work, including by
+    public digital performance; to broadcast and rebroadcast the Work by any
+    means including signs, sounds or images.
+
+  i. "Reproduce" means to make copies of the Work by any means including without
+    limitation by sound or visual recordings and the right of fixation and
+    reproducing fixations of the Work, including storage of a protected
+    performance or phonogram in digital form or other electronic medium.
+
+2. Fair Dealing Rights. Nothing in this License is intended to reduce, limit, or
+restrict any uses free from copyright or rights arising from limitations or
+exceptions that are provided for in connection with the copyright protection
+under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License, Licensor
+hereby grants You a worldwide, royalty-free, non-exclusive, perpetual (for the
+duration of the applicable copyright) license to exercise the rights in the Work
+as stated below:
+
+  a. to Reproduce the Work, to incorporate the Work into one or more Collections,
+    and to Reproduce the Work as incorporated in the Collections;
+
+  b. to create and Reproduce Adaptations provided that any such Adaptation,
+    including any translation in any medium, takes reasonable steps to clearly
+    label, demarcate or otherwise identify that changes were made to the original
+    Work. For example, a translation could be marked "The original work was
+    translated from English to Spanish," or a modification could indicate "The
+    original work has been modified.";
+
+  c. to Distribute and Publicly Perform the Work including as incorporated in
+    Collections; and,
+
+  d. to Distribute and Publicly Perform Adaptations.
+
+  e. 
+
+    For the avoidance of doubt:
+
+      i. Non-waivable Compulsory License Schemes. In those jurisdictions in which
+        the right to collect royalties through any statutory or compulsory
+        licensing scheme cannot be waived, the Licensor reserves the exclusive
+        right to collect such royalties for any exercise by You of the rights
+        granted under this License;
+
+      ii. Waivable Compulsory License Schemes. In those jurisdictions in which
+        the right to collect royalties through any statutory or compulsory
+        licensing scheme can be waived, the Licensor waives the exclusive right
+        to collect such royalties for any exercise by You of the rights granted
+        under this License; and,
+
+      iii. Voluntary License Schemes. The Licensor waives the right to collect
+        royalties, whether individually or, in the event that the Licensor is a
+        member of a collecting society that administers voluntary licensing
+        schemes, via that society, from any exercise by You of the rights granted
+        under this License.
+
+The above rights may be exercised in all media and formats whether now known or
+hereafter devised. The above rights include the right to make such modifications
+as are technically necessary to exercise the rights in other media and formats.
+Subject to Section 8(f), all rights not expressly granted by Licensor are hereby
+reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made subject
+to and limited by the following restrictions:
+
+  a. You may Distribute or Publicly Perform the Work only under the terms of this
+    License. You must include a copy of, or the Uniform Resource Identifier (URI)
+    for, this License with every copy of the Work You Distribute or Publicly
+    Perform. You may not offer or impose any terms on the Work that restrict the
+    terms of this License or the ability of the recipient of the Work to exercise
+    the rights granted to that recipient under the terms of the License. You may
+    not sublicense the Work. You must keep intact all notices that refer to this
+    License and to the disclaimer of warranties with every copy of the Work You
+    Distribute or Publicly Perform. When You Distribute or Publicly Perform the
+    Work, You may not impose any effective technological measures on the Work
+    that restrict the ability of a recipient of the Work from You to exercise the
+    rights granted to that recipient under the terms of the License. This Section
+    4(a) applies to the Work as incorporated in a Collection, but this does not
+    require the Collection apart from the Work itself to be made subject to the
+    terms of this License. If You create a Collection, upon notice from any
+    Licensor You must, to the extent practicable, remove from the Collection any
+    credit as required by Section 4(b), as requested. If You create an
+    Adaptation, upon notice from any Licensor You must, to the extent
+    practicable, remove from the Adaptation any credit as required by Section
+    4(b), as requested.
+
+  b. If You Distribute, or Publicly Perform the Work or any Adaptations or
+    Collections, You must, unless a request has been made pursuant to Section
+    4(a), keep intact all copyright notices for the Work and provide, reasonable
+    to the medium or means You are utilizing: (i) the name of the Original Author
+    (or pseudonym, if applicable) if supplied, and/or if the Original Author
+    and/or Licensor designate another party or parties (e.g., a sponsor
+    institute, publishing entity, journal) for attribution ("Attribution
+    Parties") in Licensor's copyright notice, terms of service or by other
+    reasonable means, the name of such party or parties; (ii) the title of the
+    Work if supplied; (iii) to the extent reasonably practicable, the URI, if
+    any, that Licensor specifies to be associated with the Work, unless such URI
+    does not refer to the copyright notice or licensing information for the Work;
+    and (iv) , consistent with Section 3(b), in the case of an Adaptation, a
+    credit identifying the use of the Work in the Adaptation (e.g., "French
+    translation of the Work by Original Author," or "Screenplay based on original
+    Work by Original Author"). The credit required by this Section 4 (b) may be
+    implemented in any reasonable manner; provided, however, that in the case of
+    a Adaptation or Collection, at a minimum such credit will appear, if a credit
+    for all contributing authors of the Adaptation or Collection appears, then as
+    part of these credits and in a manner at least as prominent as the credits
+    for the other contributing authors. For the avoidance of doubt, You may only
+    use the credit required by this Section for the purpose of attribution in the
+    manner set out above and, by exercising Your rights under this License, You
+    may not implicitly or explicitly assert or imply any connection with,
+    sponsorship or endorsement by the Original Author, Licensor and/or
+    Attribution Parties, as appropriate, of You or Your use of the Work, without
+    the separate, express prior written permission of the Original Author,
+    Licensor and/or Attribution Parties.
+
+  c. Except as otherwise agreed in writing by the Licensor or as may be otherwise
+    permitted by applicable law, if You Reproduce, Distribute or Publicly Perform
+    the Work either by itself or as part of any Adaptations or Collections, You
+    must not distort, mutilate, modify or take other derogatory action in
+    relation to the Work which would be prejudicial to the Original Author's
+    honor or reputation. Licensor agrees that in those jurisdictions (e.g.
+    Japan), in which any exercise of the right granted in Section 3(b) of this
+    License (the right to make Adaptations) would be deemed to be a distortion,
+    mutilation, modification or other derogatory action prejudicial to the
+    Original Author's honor and reputation, the Licensor will waive or not
+    assert, as appropriate, this Section, to the fullest extent permitted by the
+    applicable national law, to enable You to reasonably exercise Your right
+    under Section 3(b) of this License (right to make Adaptations) but not
+    otherwise.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS
+THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING
+THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT
+LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A PARTICULAR
+PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR
+THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE. SOME
+JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION
+MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN
+NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY SPECIAL,
+INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF THIS
+LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+  a. This License and the rights granted hereunder will terminate automatically
+    upon any breach by You of the terms of this License. Individuals or entities
+    who have received Adaptations or Collections from You under this License,
+    however, will not have their licenses terminated provided such individuals or
+    entities remain in full compliance with those licenses. Sections 1, 2, 5, 6,
+    7, and 8 will survive any termination of this License.
+
+  b. Subject to the above terms and conditions, the license granted here is
+    perpetual (for the duration of the applicable copyright in the Work).
+    Notwithstanding the above, Licensor reserves the right to release the Work
+    under different license terms or to stop distributing the Work at any time;
+    provided, however that any such election will not serve to withdraw this
+    License (or any other license that has been, or is required to be, granted
+    under the terms of this License), and this License will continue in full
+    force and effect unless terminated as stated above.
+
+8. Miscellaneous
+
+  a. Each time You Distribute or Publicly Perform the Work or a Collection, the
+    Licensor offers to the recipient a license to the Work on the same terms and
+    conditions as the license granted to You under this License.
+
+  b. Each time You Distribute or Publicly Perform an Adaptation, Licensor offers
+    to the recipient a license to the original Work on the same terms and
+    conditions as the license granted to You under this License.
+
+  c. If any provision of this License is invalid or unenforceable under
+    applicable law, it shall not affect the validity or enforceability of the
+    remainder of the terms of this License, and without further action by the
+    parties to this agreement, such provision shall be reformed to the minimum
+    extent necessary to make such provision valid and enforceable.
+
+  d. No term or provision of this License shall be deemed waived and no breach
+    consented to unless such waiver or consent shall be in writing and signed by
+    the party to be charged with such waiver or consent.
+
+  e. This License constitutes the entire agreement between the parties with
+    respect to the Work licensed here. There are no understandings, agreements or
+    representations with respect to the Work not specified here. Licensor shall
+    not be bound by any additional provisions that may appear in any
+    communication from You. This License may not be modified without the mutual
+    written agreement of the Licensor and You.
+
+  f. The rights granted under, and the subject matter referenced, in this License
+    were drafted utilizing the terminology of the Berne Convention for the
+    Protection of Literary and Artistic Works (as amended on September 28, 1979),
+    the Rome Convention of 1961, the WIPO Copyright Treaty of 1996, the WIPO
+    Performances and Phonograms Treaty of 1996 and the Universal Copyright
+    Convention (as revised on July 24, 1971). These rights and subject matter
+    take effect in the relevant jurisdiction in which the License terms are
+    sought to be enforced according to the corresponding provisions of the
+    implementation of those treaty provisions in the applicable national law. If
+    the standard suite of rights granted under applicable copyright law includes
+    additional rights not granted under this License, such additional rights are
+    deemed to be included in the License; this License is not intended to
+    restrict the license of any rights under applicable law.
+
+
+  Creative Commons Notice
+
+  Creative Commons is not a party to this License, and makes no warranty
+  whatsoever in connection with the Work. Creative Commons will not be liable
+  to You or any party on any legal theory for any damages whatsoever, including
+  without limitation any general, special, incidental or consequential damages
+  arising in connection to this license. Notwithstanding the foregoing two (2)
+  sentences, if Creative Commons has expressly identified itself as the
+  Licensor hereunder, it shall have all rights and obligations of Licensor.
+
+  Except for the limited purpose of indicating to the public that the Work is
+  licensed under the CCPL, Creative Commons does not authorize the use by
+  either party of the trademark "Creative Commons" or any related trademark or
+  logo of Creative Commons without the prior written consent of Creative
+  Commons. Any permitted use will be in compliance with Creative Commons'
+  then-current trademark usage guidelines, as may be published on its website
+  or otherwise made available upon request from time to time. For the avoidance
+  of doubt, this trademark restriction does not form part of this License.
+
+  Creative Commons may be contacted at http://creativecommons.org/.
+
+---
+
+Creative Commons Attribution Share Alike 4.0
+(docker/go-metrics v0.0.1)
+
+Creative Commons Attribution Share Alike 4.0
+============================================
+
+Creative Commons Attribution-ShareAlike 4.0 International
+
+Creative Commons Corporation (“Creative Commons”) is not a law firm and does not
+provide legal services or legal advice. Distribution of Creative Commons public
+licenses does not create a lawyer-client or other relationship. Creative Commons
+makes its licenses and related information available on an “as-is” basis.
+Creative Commons gives no warranties regarding its licenses, any material
+licensed under their terms and conditions, or any related information. Creative
+Commons disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions
+that creators and other rights holders may use to share original works of
+authorship and other material subject to copyright and certain other rights
+specified in the public license below. The following considerations are for
+informational purposes only, are not exhaustive, and do not form part of our
+licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those
+authorized to give the public permission to use material in ways otherwise
+restricted by copyright and certain other rights. Our licenses are irrevocable.
+Licensors should read and understand the terms and conditions of the license they
+choose before applying it. Licensors should also secure all rights necessary
+before applying our licenses so that the public can reuse the material as
+expected. Licensors should clearly mark any material not subject to the license.
+This includes other CC-licensed material, or material used under an exception or
+limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor
+grants the public permission to use the licensed material under specified terms
+and conditions. If the licensor’s permission is not necessary for any reason-for
+example, because of any applicable exception or limitation to copyright-then that
+use is not regulated by the license. Our licenses grant only permissions under
+copyright and certain other rights that a licensor has authority to grant. Use of
+the licensed material may still be restricted for other reasons, including
+because others have copyright or other rights in the material. A licensor may
+make special requests, such as asking that all changes be marked or described.
+
+Although not required by our licenses, you are encouraged to respect those
+requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution-ShareAlike 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be
+bound by the terms and conditions of this Creative Commons Attribution-ShareAlike
+4.0 International Public License ("Public License"). To the extent this Public
+License may be interpreted as a contract, You are granted the Licensed Rights in
+consideration of Your acceptance of these terms and conditions, and the Licensor
+grants You such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and conditions.
+
+Section 1 - Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar Rights that
+is derived from or based upon the Licensed Material and in which the Licensed
+Material is translated, altered, arranged, transformed, or otherwise modified in
+a manner requiring permission under the Copyright and Similar Rights held by the
+Licensor. For purposes of this Public License, where the Licensed Material is a
+musical work, performance, or sound recording, Adapted Material is always
+produced where the Licensed Material is synched in timed relation with a moving
+image.
+
+b. Adapter's License means the license You apply to Your Copyright and Similar
+Rights in Your contributions to Adapted Material in accordance with the terms and
+conditions of this Public License.
+
+c. BY-SA Compatible License means a license listed at
+creativecommons.org/compatiblelicenses, approved by Creative Commons as
+essentially the equivalent of this Public License.
+
+d. Copyright and Similar Rights means copyright and/or similar rights closely
+related to copyright including, without limitation, performance, broadcast, sound
+recording, and Sui Generis Database Rights, without regard to how the rights are
+labeled or categorized. For purposes of this Public License, the rights specified
+in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+e. Effective Technological Measures means those measures that, in the absence of
+proper authority, may not be circumvented under laws fulfilling obligations under
+Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or
+similar international agreements.
+
+f. Exceptions and Limitations means fair use, fair dealing, and/or any other
+exception or limitation to Copyright and Similar Rights that applies to Your use
+of the Licensed Material.
+
+g. License Elements means the license attributes listed in the name of a Creative
+Commons Public License. The License Elements of this Public License are
+Attribution and ShareAlike.
+
+h. Licensed Material means the artistic or literary work, database, or other
+material to which the Licensor applied this Public License.
+
+i. Licensed Rights means the rights granted to You subject to the terms and
+conditions of this Public License, which are limited to all Copyright and Similar
+Rights that apply to Your use of the Licensed Material and that the Licensor has
+authority to license.
+
+j. Licensor means the individual(s) or entity(ies) granting rights under this
+Public License.
+
+k. Share means to provide material to the public by any means or process that
+requires permission under the Licensed Rights, such as reproduction, public
+display, public performance, distribution, dissemination, communication, or
+importation, and to make material available to the public including in ways that
+members of the public may access the material from a place and at a time
+individually chosen by them.
+
+l. Sui Generis Database Rights means rights other than copyright resulting from
+Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996
+on the legal protection of databases, as amended and/or succeeded, as well as
+other essentially equivalent rights anywhere in the world.
+
+m. You means the individual or entity exercising the Licensed Rights under this
+Public License. Your has a corresponding meaning.
+
+Section 2 - Scope.
+
+a. License grant.
+
+1. Subject to the terms and conditions of this Public License, the Licensor
+hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive,
+irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+A. reproduce and Share the Licensed Material, in whole or in part; and
+
+B. produce, reproduce, and Share Adapted Material.
+
+2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and
+Limitations apply to Your use, this Public License does not apply, and You do not
+need to comply with its terms and conditions.
+
+3. Term. The term of this Public License is specified in Section 6(a).
+
+4. Media and formats; technical modifications allowed. The Licensor authorizes
+You to exercise the Licensed Rights in all media and formats whether now known or
+hereafter created, and to make technical modifications necessary to do so. The
+Licensor waives and/or agrees not to assert any right or authority to forbid You
+from making technical modifications necessary to exercise the Licensed Rights,
+including technical modifications necessary to circumvent Effective Technological
+Measures. For purposes of this Public License, simply making modifications
+authorized by this Section 2(a)(4) never produces Adapted Material.
+
+5. Downstream recipients.
+
+A. Offer from the Licensor - Licensed Material. Every recipient of the Licensed
+Material automatically receives an offer from the Licensor to exercise the
+Licensed Rights under the terms and conditions of this Public License.
+
+B. Additional offer from the Licensor - Adapted Material. Every recipient of
+Adapted Material from You automatically receives an offer from the Licensor to
+exercise the Licensed Rights in the Adapted Material under the conditions of the
+Adapter’s License You apply.
+
+C. No downstream restrictions. You may not offer or impose any additional or
+different terms or conditions on, or apply any Effective Technological Measures
+to, the Licensed Material if doing so restricts exercise of the Licensed Rights
+by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes or may be construed
+as permission to assert or imply that You are, or that Your use of the Licensed
+Material is, connected with, or sponsored, endorsed, or granted official status
+by, the Licensor or others designated to receive attribution as provided in
+Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+1. Moral rights, such as the right of integrity, are not licensed under this
+Public License, nor are publicity, privacy, and/or other similar personality
+rights; however, to the extent possible, the Licensor waives and/or agrees not to
+assert any such rights held by the Licensor to the limited extent necessary to
+allow You to exercise the Licensed Rights, but not otherwise.
+
+2. Patent and trademark rights are not licensed under this Public License.
+
+3. To the extent possible, the Licensor waives any right to collect royalties
+from You for the exercise of the Licensed Rights, whether directly or through a
+collecting society under any voluntary or waivable statutory or compulsory
+licensing scheme. In all other cases the Licensor expressly reserves any right to
+collect such royalties.
+
+Section 3 - License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following
+conditions.
+
+a. Attribution.
+
+1. If You Share the Licensed Material (including in modified form), You must:
+
+A. retain the following if it is supplied by the Licensor with the Licensed
+Material:
+
+i. identification of the creator(s) of the Licensed Material and any others
+designated to receive attribution, in any reasonable manner requested by the
+Licensor (including by pseudonym if designated);
+
+ii. a copyright notice;
+
+iii. a notice that refers to this Public License;
+
+iv. a notice that refers to the disclaimer of warranties;
+
+v. a URI or hyperlink to the Licensed Material to the extent reasonably
+practicable;
+
+B. indicate if You modified the Licensed Material and retain an indication of any
+previous modifications; and
+
+C. indicate the Licensed Material is licensed under this Public License, and
+include the text of, or the URI or hyperlink to, this Public License.
+
+2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner
+based on the medium, means, and context in which You Share the Licensed Material.
+For example, it may be reasonable to satisfy the conditions by providing a URI or
+hyperlink to a resource that includes the required information.
+
+3. If requested by the Licensor, You must remove any of the information required
+by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+b. ShareAlike.
+
+In addition to the conditions in Section 3(a), if You Share Adapted Material You
+produce, the following conditions also apply.
+
+1. The Adapter’s License You apply must be a Creative Commons license with the
+same License Elements, this version or later, or a BY-SA Compatible License.
+
+2. You must include the text of, or the URI or hyperlink to, the Adapter's
+License You apply. You may satisfy this condition in any reasonable manner based
+on the medium, means, and context in which You Share Adapted Material.
+
+3. You may not offer or impose any additional or different terms or conditions on,
+or apply any Effective Technological Measures to, Adapted Material that restrict
+exercise of the rights granted under the Adapter's License You apply.
+
+Section 4 - Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your
+use of the Licensed Material:
+
+a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract,
+reuse, reproduce, and Share all or a substantial portion of the contents of the
+database;
+
+b. if You include all or a substantial portion of the database contents in a
+database in which You have Sui Generis Database Rights, then the database in
+which You have Sui Generis Database Rights (but not its individual contents) is
+Adapted Material, including for purposes of Section 3(b); and
+
+c. You must comply with the conditions in Section 3(a) if You Share all or a
+substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace Your
+obligations under this Public License where the Licensed Rights include other
+Copyright and Similar Rights.
+
+Section 5 - Disclaimer of Warranties and Limitation of Liability.
+
+a. Unless otherwise separately undertaken by the Licensor, to the extent
+possible, the Licensor offers the Licensed Material as-is and as-available, and
+makes no representations or warranties of any kind concerning the Licensed
+Material, whether express, implied, statutory, or other. This includes, without
+limitation, warranties of title, merchantability, fitness for a particular
+purpose, non-infringement, absence of latent or other defects, accuracy, or the
+presence or absence of errors, whether or not known or discoverable. Where
+disclaimers of warranties are not allowed in full or in part, this disclaimer may
+not apply to You.
+
+b. To the extent possible, in no event will the Licensor be liable to You on any
+legal theory (including, without limitation, negligence) or otherwise for any
+direct, special, indirect, incidental, consequential, punitive, exemplary, or
+other losses, costs, expenses, or damages arising out of this Public License or
+use of the Licensed Material, even if the Licensor has been advised of the
+possibility of such losses, costs, expenses, or damages. Where a limitation of
+liability is not allowed in full or in part, this limitation may not apply to
+You.
+
+c. The disclaimer of warranties and limitation of liability provided above shall
+be interpreted in a manner that, to the extent possible, most closely
+approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 - Term and Termination.
+
+a. This Public License applies for the term of the Copyright and Similar Rights
+licensed here. However, if You fail to comply with this Public License, then Your
+rights under this Public License terminate automatically.
+
+b. Where Your right to use the Licensed Material has terminated under Section
+6(a), it reinstates:
+
+1. automatically as of the date the violation is cured, provided it is cured
+within 30 days of Your discovery of the violation; or
+
+2. upon express reinstatement by the Licensor.
+
+c. For the avoidance of doubt, this Section 6(b) does not affect any right the
+Licensor may have to seek remedies for Your violations of this Public License.
+
+d. For the avoidance of doubt, the Licensor may also offer the Licensed Material
+under separate terms or conditions or stop distributing the Licensed Material at
+any time; however, doing so will not terminate this Public License.
+
+e. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 - Other Terms and Conditions.
+
+a. The Licensor shall not be bound by any additional or different terms or
+conditions communicated by You unless expressly agreed.
+
+b. Any arrangements, understandings, or agreements regarding the Licensed
+Material not stated herein are separate from and independent of the terms and
+conditions of this Public License.
+
+Section 8 - Interpretation.
+
+a. For the avoidance of doubt, this Public License does not, and shall not be
+interpreted to, reduce, limit, restrict, or impose conditions on any use of the
+Licensed Material that could lawfully be made without permission under this
+Public License.
+
+b. To the extent possible, if any provision of this Public License is deemed
+unenforceable, it shall be automatically reformed to the minimum extent necessary
+to make it enforceable. If the provision cannot be reformed, it shall be severed
+from this Public License without affecting the enforceability of the remaining
+terms and conditions.
+
+c. No term or condition of this Public License will be waived and no failure to
+comply consented to unless expressly agreed to by the Licensor.
+
+d. Nothing in this Public License constitutes or may be interpreted as a
+limitation upon, or waiver of, any privileges and immunities that apply to the
+Licensor or You, including from the legal processes of any jurisdiction or
+authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative
+Commons may elect to apply one of its public licenses to material it publishes
+and in those instances will be considered the “Licensor.” Except for the limited
+purpose of indicating that material is shared under a Creative Commons public
+license or as otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the use of the
+trademark “Creative Commons” or any other trademark or logo of Creative Commons
+without its prior written consent including, without limitation, in connection
+with any unauthorized modifications to any of its public licenses or any other
+arrangements, understandings, or agreements concerning use of licensed material.
+For the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+
+---
+
+ISC License
+(go-spew v1.1.1)
+
+ISC License
+
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE
+
+---
+
+ISC License
+(utter v1.0.1)
+
+ISC License (ISCL)
+==================
+
+Copyright (c) 4-digit year, Company or Person's Name
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+---
+
+MIT License
+(github.com/konsorten/go-windows-terminal-sequences v1.0.1)
+
+(The MIT License)
+
+Copyright (c) 2017 marvin + konsorten GmbH (open-source@konsorten.de)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(josharian/intern v1.0.0)
+
+2020 Roger Shimizu <rosh@debian.org>
+License: Expat
+Comment: Debian packaging is licensed under the same terms as upstream
+
+License: Expat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE
+
+---
+
+MIT License
+(beorn7-perks v1.0.1)
+
+Copyright (C) 2013 Blake Mizerany
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(alecthomas-kingpin v2.2.6)
+
+Copyright (C) 2014 Alec Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(olekukonko-tablewriter v0.0.5)
+
+Copyright (C) 2014 by Oleku Konko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(go humanize v1.0.0)
+
+Copyright (c) 2005-2008  Dustin Sallings <dustin@spy.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(creack/pty v1.1.18, pty v1.1.1)
+
+Copyright (c) 2011 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall
+be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(diskv v2.0.1)
+
+Copyright (c) 2011-2012 Peter Bourgon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(jstemmer/go-junit-report v0.9.1)
+
+Copyright (c) 2012 Joel Stemmer
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(sergi/go-diff v1.1.0)
+
+Copyright (c) 2012-2016 The go-diff Authors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(errcheck v1.5.0-alpha)
+
+Copyright (c) 2013 Kamil Kisiel
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(kisielk-gotool v1.0.0)
+
+Copyright (c) 2013 Kamil Kisiel <kamil@kamilkisiel.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(lann-ps 20180517-snapshot-62de8c46)
+
+Copyright (c) 2013 Michael Hendricks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(jtolds-gls v4.20.0)
+
+Copyright (c) 2013, Space Monkey, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(go-chi v1.5.4)
+
+Copyright (c) 2015-present Peter Kieltyka (https://github.com/pkieltyka), Google Inc.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(dominikh/go-tools v0.0.1-2020.1.4)
+
+Copyright (c) 2016 Dominik Honnef
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(mailru/easyjson v0.7.7)
+
+Copyright (c) 2016 Mail.Ru Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(goconvey v1.6.4)
+
+Copyright (c) 2016 SmartyStreets, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(go-chi/render v1.0.1)
+
+Copyright (c) 2016-Present https://github.com/go-chi authors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(creasty/defaults v1.5.2)
+
+Copyright (c) 2017-present Yuki Iwanaga
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(github.com/vektah/gqlparser v2.2.0)
+
+Copyright (c) 2018 Adam Scarr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(gregjones/httpcache 20190611-snapshot-901d9072)
+
+Copyright © 2012 Greg Jones (greg.jones@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(mitchellh/go-testing-interface v1.0.0)
+
+Files: *
+Copyright: 2016 Mitchell Hashimoto
+License: Expat
+
+Files: debian/*
+Copyright:
+    2018-2019 Dmitry Smirnov <onlyjob@debian.org>
+License: Expat
+
+License: Expat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE
+
+---
+
+MIT License
+(posener/complete v1.2.3)
+
+Files: *
+Copyright: 2017 Eyal Posener <eyal@stratoscale.com>
+License: Expat
+
+Files: debian/*
+Copyright: 2018 Alexandre Viau <aviau@debian.org>
+License: Expat
+Comment: Debian packaging is licensed under the same terms as upstream
+
+License: Expat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE
+
+---
+
+MIT License
+(GoDoc Text v0.2.0)
+
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: github.com/kr/text
+Source: https://github.com/kr/text/
+
+Files: *
+Copyright: 2013 Keith Rarick <kr@xph.us>
+License: Expat
+
+Files: debian/*
+Copyright: 2013 Tonnerre Lombard <tonnerre@ancient-solutions.com>
+License: Expat
+
+License: Expat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE
+
+---
+
+MIT License
+(mitchellh-iochan v1.0.0)
+
+License: Expat
+
+License: Expat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE
+
+---
+
+MIT License
+(golang-github-ryanuber-columnize 20180625-snapshot-9b3edd62)
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(lann-builder 20181203-snapshot-47ae3079)
+
+MIT License
+
+Copyright (c) 2014-2015 Lann Martin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(shurcooL-sanitized_anchor_name 1.0.0)
+
+MIT License
+
+Copyright (c) 2015 Dmitri Shuralyov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(go-cli v2.3.0)
+
+MIT License
+
+Copyright (c) 2016 Jeremy Saenz & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(matryer/moq v0.2.5)
+
+MIT License
+
+Copyright (c) 2016 Mat Ryer and David Hernandez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(jsoniter-go v1.1.12)
+
+MIT License
+
+Copyright (c) 2016 json-iterator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(sean-/seed 20170313-snapshot-e2103e2c)
+
+MIT License
+
+Copyright (c) 2017 Sean Chittenden
+Copyright (c) 2016 Alex Dadgar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(leodido/go-urn v1.2.1)
+
+MIT License
+
+Copyright (c) 2018 Leonardo Di Donato
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(foxcpp/go-mockdns v1.0.0)
+
+MIT License
+
+Copyright © 2019 Max Mazurov <fox.cpp@disroot.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(gosuri/uitable v0.0.4)
+
+MIT License
+===========
+
+Copyright (c) 2015, Greg Osuri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(daviddengcn/go-colortext 1.0.0)
+
+MIT License
+===========
+
+Copyright (c) 2016 David Deng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(logfmt 20140226-snapshot-b84e30ac)
+
+See http://godoc.org/github.com/kr/logfmt for format, and other documentation and examples.
+
+Copyright (C) 2013 Keith Rarick, Blake Mizerany
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(cespare/xxhash v1.1.0)
+
+Source: https://github.com/cespare/xxhash
+
+Files: *
+Copyright: 2016 Caleb Spare <cespare@gmail.com>
+License: Expat
+
+Files: debian/*
+Copyright: 2017 Alexandre Viau <aviau@debian.org>
+License: Expat
+Comment: Debian packaging is licensed under the same terms as upstream
+
+License: Expat
+
+Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(jwt-go v3.2.0)
+
+Source: https://github.com/dgrijalva/jwt-go
+
+Files: *
+Copyright: 2012 Dave Grijalva
+License: Expat
+
+Files: debian/*
+Copyright: 2015 Tim Potter <tpot@hpe.com>
+License: Expat
+Comment: Debian packaging is licensed under the same terms as upstream
+
+License: Expat
+ Copyright (c) 2012 Dave Grijalva
+ .
+
+Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and
+ to permit persons to whom the Software is furnished to do so, subject
+ to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(mitchellh-copystructure v1.2.0)
+
+Source: https://github.com/mitchellh/copystructure
+
+Files: *
+Copyright: 2014 Mitchell Hashimoto
+License: Expat
+
+Files: debian/*
+Copyright: 2016 Dmitry Smirnov <onlyjob@debian.org>
+License: Expat
+
+License: Expat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE
+
+---
+
+MIT License
+(blang-semver v4.0.0)
+
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(alecthomas-kingpin v2.3.2, alecthomas-units 20211218-snapshot-b94a6e3c, araddon-dateparse 20210429-snapshot-6b43995a, bugsnag-bugsnag-go 20141110-snapshot-b1d15302, BurntSushi/toml 1.2.1, cenkalti/backoff v4.2.1, cespare/xxhash v2.2.0, cilium/ebpf v0.9.1, cpuguy83-go-md2man 2.0.2, docker-org v0.7.0, exponent-io/jsonpath 20210407-snapshot-1de76d71, felixge/httpsnoop v1.0.3, frankban/quicktest v1.14.3, fvbommel/sortorder 1.1.0, github.com/99designs/gqlgen v0.15.1, github.com/antihax/optional 1.0.0, github.com/go-kit/log v0.2.1, github.com/gobuffalo/logger v1.0.6, github.com/gobuffalo/packd 1.0.1, github.com/golang-jwt/jwt v4.4.2, github.com/rivo/uniseg v0.4.2, Go Logrus v1.9.0, Go Testify v1.8.2, go-errors-errors v1.4.2, go-gorp/gorp v3.1.0, go-restful v3.10.1, go-task/slim-sprig 20230315-snapshot-52ccab3e, go-toml v1.9.5, go-zap v1.24.0, go.etcd.io/bbolt v1.3.7, go.uber.org/goleak v1.2.1, go.uber.org/multierr v1.11.0, gomega v1.27.6, govalidator 20210307-snapshot-f21760c4, huandu/xstrings v1.4.0, itchyny/gojq v0.12.11, itchyny/timefmt-go v0.1.5, kr/pretty v0.3.1, Masterminds-semver v3.2.1, Masterminds-squirrel v1.5.4, Masterminds/sprig v3.2.3, mattn-go-colorable 0.1.13, mattn-go-isatty v0.0.17, mattn-go-runewidth v0.0.14, mattn-go-sqlite3 v1.14.15, Microsoft-go-winio v0.6.0, Microsoft-hcsshim v0.10.0-rc.7, mittwald/go-helm-client v0.11.5, monochromegane/go-gitignore 20200625-snapshot-205db1a8, mozilla-services/pkcs7 20200128-snapshot-432b2356, niemeyer/pretty 20200227-snapshot-a10e7cae, onsi/ginkgo v2.9.4, poy/onpar v1.1.2, pq v1.10.9, smartystreets-assertions 20180927-snapshot-b2de0cb4, spf13-cast v1.5.0, sql-migrate v1.3.1, sqlx v1.3.5, stretchr/objx v0.5.0, tmc/grpc-websocket-proxy 20220101-snapshot-673ab2c3, uber-go/atomic v1.10.0, urfave-cli v1.22.12, vcs-go v1.13.3, wI2L/jsondiff v0.2.0, xiang90-probing 20190116-snapshot-43a291ad, xlab/treeprint v1.2.0, yaml for Go v3.0.1, yuin/goldmark v1.4.13)
+
+The MIT License
+===============
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+MIT License
+(go-oci8 v0.1.1)
+
+The MIT License (MIT)
+
+
+
+Copyright (c) 2014-2018 Yasuhiro Matsumoto, http://mattn.kaoriya.net <mattn.jp@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(ugorji's go v1.1.4)
+
+The MIT License (MIT)
+
+Copyright (c) 2012-2015 Ugorji Nwoke.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(subosito/gotenv v1.2.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Alif Rachmawadi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(armon-go-metrics 20180917-snapshot-f0300d17, armon/circbuf 20150827-snapshot-bbbad097)
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Armon Dadgar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(coreos/bbolt v1.3.2)
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(fatih-color v1.13.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(bugsnag/panicwrap 20160225-snapshot-e2c28503, mapstructure v1.4.3, mitchellh-go-homedir v1.1.0, mitchellh-reflectwalk v1.0.2)
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(armon-go-radix v1.0.0, armon/go-socks5 20160902-snapshot-e7533296, hashicorp-go-syslog v1.0.0, hashicorp-mdns v1.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Armon Dadgar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(benbjohnson-clock v1.1.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(go-stack-stack v1.8.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Chris Hines
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(danieljoos/wincred v1.1.2)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Joos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(mitchellh-go-wordwrap v1.0.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(natefinch/lumberjack v2.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Nate Finch 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(golang-github-ghodss-yaml-dev 1.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Sam Ghods
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(github.com/spf13/jwalterweatherman v1.1.0, go-viper v1.8.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Steve Francia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(tchap-go-patricia v2.3.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 The AUTHORS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(bketelsen/crypt v0.0.4, xordataexchange-crypt 20180613-snapshot-b2862e3d)
+
+The MIT License (MIT)
+
+Copyright (c) 2014 XOR Data Exchange, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(MakeNowJust-heredoc v1.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 TSUYUSATO Kitsune
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(agnivade/levenshtein v1.1.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Agniva De Sarker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(chzyer-readline 20180828-snapshot-2972be24, chzyer/logex v1.1.10)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Chzyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(fatih-camelcase v1.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(klauspost-cpuid v2.0.4)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Klaus Post
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(go-ansiterm d185dfc1b5a126116ea5a19e148e29d16b4574c9)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(go-kit-kit v0.8.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Peter Bourgon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(shopspring-decimal v1.3.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Spring, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(k0kubun-pp v3.1.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Takashi Kokubun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(go-logfmt-logfmt v0.5.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 go-logfmt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(client9/misspell v0.3.4)
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2017 Nick Galbreath
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(go-resty/resty v1.12.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(bshuster-repo/logrus-logstash-hook v1.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Boaz Shuster
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(go-playground-universal-translator v0.18.0, go-playground/locales v0.14.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Go Playground
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(tidwall/gjson v1.14.0, tidwall/match v1.1.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Josh Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(gobwas-glob 0.2.3)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Sergey Kamardin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(golang-github-shopify-logrus-bugsnag-dev 20171204-snapshot-577dee27)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Shopify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(morikuni/aec v1.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Taihei Morikuni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(chzyer/test 20190214-snapshot-a1ea475d)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 chzyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(jpillora-backoff 1.0.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Jaime Pillora
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(tidwall/pretty v1.2.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Josh Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+MIT License
+(mattn-go-shellwords v1.0.12)
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(stoewer/go-strcase v1.2.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2017, Adrian Stoewer <adrian.stoewer@rz.ifi.lmu.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(github.com/markbates/oncer v1.0.0, github.com/markbates/safe v1.0.1)
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Mark Bates
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(lithammer/dedent v1.1.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Peter Lithammer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+---
+
+MIT License
+(markbates/errx v1.1.0)
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Mark Bates
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+---
+
+MIT License
+(gobuffalo/packr v2.8.3)
+
+The MIT License (MIT)
+Copyright (c) 2016 Mark Bates
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+---
+
+Mozilla Public License 2.0
+(armon-consul-api 20180202-snapshot-eb2c6b5b, Consul api/v1.1.0, Consul sdk/v0.1.1, errwrap v1.1.0, Go CLI v1.1.5, go-immutable-radix v1.0.0, go-sql-driver v1.6.0, golang-github-hashicorp-memberlist v0.1.3, hashicorp serf v0.8.2, hashicorp-go-cleanhttp v0.5.2, hashicorp-go-multierror v1.1.1, hashicorp-go-rootcerts v1.0.0, hashicorp-go-uuid v1.0.1, hashicorp-golang-lru v0.5.4, hashicorp-logutils v1.0.0, hashicorp/go-sockaddr v1.0.0, hashicorp/hcl v1.0.0, mitchellh/gox v0.4.0)
+
+Mozilla Public License
+Version 2.0
+======================
+
+
+1. Definitions
+--------------
+
+  1.1. "Contributor"
+
+  means each individual or legal entity that creates, contributes to the creation
+  of, or owns Covered Software.
+
+  1.2. "Contributor Version"
+
+  means the combination of the Contributions of others (if any) used by a
+  Contributor and that particular Contributor's Contribution.
+
+  1.3. "Contribution"
+
+  means Covered Software of a particular Contributor.
+
+  1.4. "Covered Software"
+
+  means Source Code Form to which the initial Contributor has attached the notice
+  in Exhibit A, the Executable Form of such Source Code Form, and Modifications
+  of such Source Code Form, in each case including portions thereof.
+
+  1.5. "Incompatible With Secondary Licenses"
+
+  means
+
+    a. 
+
+      that the initial Contributor has attached the notice described in Exhibit B
+      to the Covered Software; or
+
+    b. 
+
+      that the Covered Software was made available under the terms of version 1.1
+      or earlier of the License, but not also under the terms of a Secondary
+      License.
+
+  1.6. "Executable Form"
+
+  means any form of the work other than Source Code Form.
+
+  1.7. "Larger Work"
+
+  means a work that combines Covered Software with other material, in a separate
+  file or files, that is not Covered Software.
+
+  1.8. "License"
+
+  means this document.
+
+  1.9. "Licensable"
+
+  means having the right to grant, to the maximum extent possible, whether at the
+  time of the initial grant or subsequently, any and all of the rights conveyed
+  by this License.
+
+  1.10. "Modifications"
+
+  means any of the following:
+
+    a. 
+
+      any file in Source Code Form that results from an addition to, deletion
+      from, or modification of the contents of Covered Software; or
+
+    b. 
+
+      any new file in Source Code Form that contains any Covered Software.
+
+  1.11. "Patent Claims" of a Contributor
+
+  means any patent claim(s), including without limitation, method, process, and
+  apparatus claims, in any patent Licensable by such Contributor that would be
+  infringed, but for the grant of the License, by the making, using, selling,
+  offering for sale, having made, import, or transfer of either its Contributions
+  or its Contributor Version.
+
+  1.12. "Secondary License"
+
+  means either the GNU General Public License, Version 2.0, the GNU Lesser
+  General Public License, Version 2.1, the GNU Affero General Public License,
+  Version 3.0, or any later versions of those licenses.
+
+  1.13. "Source Code Form"
+
+  means the form of the work preferred for making modifications.
+
+  1.14. "You" (or "Your")
+
+  means an individual or a legal entity exercising rights under this License. For
+  legal entities, "You" includes any entity that controls, is controlled by, or
+  is under common control with You. For purposes of this definition, "control"
+  means (a) the power, direct or indirect, to cause the direction or management
+  of such entity, whether by contract or otherwise, or (b) ownership of more than
+  fifty percent (50%) of the outstanding shares or beneficial ownership of such
+  entity.
+
+
+2. License Grants and Conditions
+--------------------------------
+
+
+  2.1. Grants
+
+  Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive
+  license:
+
+    a. 
+
+      under intellectual property rights (other than patent or trademark)
+      Licensable by such Contributor to use, reproduce, make available, modify,
+      display, perform, distribute, and otherwise exploit its Contributions,
+      either on an unmodified basis, with Modifications, or as part of a Larger
+      Work; and
+
+    b. 
+
+      under Patent Claims of such Contributor to make, use, sell, offer for sale,
+      have made, import, and otherwise transfer either its Contributions or its
+      Contributor Version.
+
+
+  2.2. Effective Date
+
+  The licenses granted in Section 2.1 with respect to any Contribution become
+  effective for each Contribution on the date the Contributor first distributes
+  such Contribution.
+
+
+  2.3. Limitations on Grant Scope
+
+  The licenses granted in this Section 2 are the only rights granted under this
+  License. No additional rights or licenses will be implied from the distribution
+  or licensing of Covered Software under this License. Notwithstanding
+  Section 2.1(b) above, no patent license is granted by a Contributor:
+
+    a. 
+
+      for any code that a Contributor has removed from Covered Software; or
+
+    b. 
+
+      for infringements caused by: (i) Your and any other third party's
+      modifications of Covered Software, or (ii) the combination of its
+      Contributions with other software (except as part of its Contributor
+      Version); or
+
+    c. 
+
+      under Patent Claims infringed by Covered Software in the absence of its
+      Contributions.
+
+  This License does not grant any rights in the trademarks, service marks, or
+  logos of any Contributor (except as may be necessary to comply with the notice
+  requirements in Section 3.4).
+
+
+  2.4. Subsequent Licenses
+
+  No Contributor makes additional grants as a result of Your choice to distribute
+  the Covered Software under a subsequent version of this License (see
+  Section 10.2) or under the terms of a Secondary License (if permitted under the
+  terms of Section 3.3).
+
+
+  2.5. Representation
+
+  Each Contributor represents that the Contributor believes its Contributions are
+  its original creation(s) or it has sufficient rights to grant the rights to its
+  Contributions conveyed by this License.
+
+
+  2.6. Fair Use
+
+  This License is not intended to limit any rights You have under applicable
+  copyright doctrines of fair use, fair dealing, or other equivalents.
+
+
+  2.7. Conditions
+
+  Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+  Section 2.1.
+
+
+3. Responsibilities
+-------------------
+
+
+  3.1. Distribution of Source Form
+
+  All distribution of Covered Software in Source Code Form, including any
+  Modifications that You create or to which You contribute, must be under the
+  terms of this License. You must inform recipients that the Source Code Form of
+  the Covered Software is governed by the terms of this License, and how they can
+  obtain a copy of this License. You may not attempt to alter or restrict the
+  recipients' rights in the Source Code Form.
+
+
+  3.2. Distribution of Executable Form
+
+  If You distribute Covered Software in Executable Form then:
+
+    a. 
+
+      such Covered Software must also be made available in Source Code Form, as
+      described in Section 3.1, and You must inform recipients of the Executable
+      Form how they can obtain a copy of such Source Code Form by reasonable
+      means in a timely manner, at a charge no more than the cost of distribution
+      to the recipient; and
+
+    b. 
+
+      You may distribute such Executable Form under the terms of this License, or
+      sublicense it under different terms, provided that the license for the
+      Executable Form does not attempt to limit or alter the recipients' rights
+      in the Source Code Form under this License.
+
+
+  3.3. Distribution of a Larger Work
+
+  You may create and distribute a Larger Work under terms of Your choice,
+  provided that You also comply with the requirements of this License for the
+  Covered Software. If the Larger Work is a combination of Covered Software with
+  a work governed by one or more Secondary Licenses, and the Covered Software is
+  not Incompatible With Secondary Licenses, this License permits You to
+  additionally distribute such Covered Software under the terms of such Secondary
+  License(s), so that the recipient of the Larger Work may, at their option,
+  further distribute the Covered Software under the terms of either this License
+  or such Secondary License(s).
+
+
+  3.4. Notices
+
+  You may not remove or alter the substance of any license notices (including
+  copyright notices, patent notices, disclaimers of warranty, or limitations of
+  liability) contained within the Source Code Form of the Covered Software,
+  except that You may alter any license notices to the extent required to remedy
+  known factual inaccuracies.
+
+
+  3.5. Application of Additional Terms
+
+  You may choose to offer, and to charge a fee for, warranty, support, indemnity
+  or liability obligations to one or more recipients of Covered Software.
+  However, You may do so only on Your own behalf, and not on behalf of any
+  Contributor. You must make it absolutely clear that any such warranty, support,
+  indemnity, or liability obligation is offered by You alone, and You hereby
+  agree to indemnify every Contributor for any liability incurred by such
+  Contributor as a result of warranty, support, indemnity or liability terms You
+  offer. You may include additional disclaimers of warranty and limitations of
+  liability specific to any jurisdiction.
+
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this License with
+respect to some or all of the Covered Software due to statute, judicial order, or
+regulation then You must: (a) comply with the terms of this License to the
+maximum extent possible; and (b) describe the limitations and the code they
+affect. Such description must be placed in a text file included with all
+distributions of the Covered Software under this License. Except to the extent
+prohibited by statute or regulation, such description must be sufficiently
+detailed for a recipient of ordinary skill to be able to understand it.
+
+
+5. Termination
+--------------
+
+  5.1. The rights granted under this License will terminate automatically if You
+  fail to comply with any of its terms. However, if You become compliant, then
+  the rights granted under this License from a particular Contributor are
+  reinstated (a) provisionally, unless and until such Contributor explicitly and
+  finally terminates Your grants, and (b) on an ongoing basis, if such
+  Contributor fails to notify You of the non-compliance by some reasonable means
+  prior to 60 days after You have come back into compliance. Moreover, Your
+  grants from a particular Contributor are reinstated on an ongoing basis if such
+  Contributor notifies You of the non-compliance by some reasonable means, this
+  is the first time You have received notice of non-compliance with this License
+  from such Contributor, and You become compliant prior to 30 days after Your
+  receipt of the notice.
+
+  5.2. If You initiate litigation against any entity by asserting a patent
+  infringement claim (excluding declaratory judgment actions, counter-claims, and
+  cross-claims) alleging that a Contributor Version directly or indirectly
+  infringes any patent, then the rights granted to You by any and all
+  Contributors for the Covered Software under Section 2.1 of this License shall
+  terminate.
+
+  5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+  license agreements (excluding distributors and resellers) which have been
+  validly granted by You or Your distributors under this License prior to
+  termination shall survive termination.
+
+
+6. Disclaimer of Warranty
+-------------------------
+
+Covered Software is provided under this License on an "as is" basis, without
+warranty of any kind, either expressed, implied, or statutory, including, without
+limitation, warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose or non-infringing. The entire risk as
+to the quality and performance of the Covered Software is with You. Should any
+Covered Software prove defective in any respect, You (not any Contributor) assume
+the cost of any necessary servicing, repair, or correction. This disclaimer of
+warranty constitutes an essential part of this License. No use of any Covered
+Software is authorized under this License except under this disclaimer.
+
+
+7. Limitation of Liability
+--------------------------
+
+Under no circumstances and under no legal theory, whether tort (including
+negligence), contract, or otherwise, shall any Contributor, or anyone who
+distributes Covered Software as permitted above, be liable to You for any direct,
+indirect, special, incidental, or consequential damages of any character
+including, without limitation, damages for lost profits, loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses, even if such party shall have been informed of the possibility
+of such damages. This limitation of liability shall not apply to liability for
+death or personal injury resulting from such party's negligence to the extent
+applicable law prohibits such limitation. Some jurisdictions do not allow the
+exclusion or limitation of incidental or consequential damages, so this exclusion
+and limitation may not apply to You.
+
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the courts of a
+jurisdiction where the defendant maintains its principal place of business and
+such litigation shall be governed by laws of that jurisdiction, without reference
+to its conflict-of-law provisions. Nothing in this Section shall prevent a
+party's ability to bring cross-claims or counter-claims.
+
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject matter
+hereof. If any provision of this License is held to be unenforceable, such
+provision shall be reformed only to the extent necessary to make it enforceable.
+Any law or regulation which provides that the language of a contract shall be
+construed against the drafter shall not be used to construe this License against
+a Contributor.
+
+
+10. Versions of the License
+---------------------------
+
+
+  10.1. New Versions
+
+  Mozilla Foundation is the license steward. Except as provided in Section 10.3,
+  no one other than the license steward has the right to modify or publish new
+  versions of this License. Each version will be given a distinguishing version
+  number.
+
+
+  10.2. Effect of New Versions
+
+  You may distribute the Covered Software under the terms of the version of the
+  License under which You originally received the Covered Software, or under the
+  terms of any subsequent version published by the license steward.
+
+
+  10.3. Modified Versions
+
+  If you create software not governed by this License, and you want to create a
+  new license for such software, you may create and use a modified version of
+  this License if you rename the license and remove any references to the name of
+  the license steward (except to note that such modified license differs from
+  this License).
+
+
+  10.4. Distributing Source Code Form that is Incompatible With Secondary
+  Licenses
+
+  If You choose to distribute Source Code Form that is Incompatible With
+  Secondary Licenses under the terms of this version of the License, the notice
+  described in Exhibit B of this License must be attached.
+
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public License,
+  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+  obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as defined
+  by the Mozilla Public License, v. 2.0.
+
+---
+
+Public Domain
+(pascaldekloe/goe 20180627-snapshot-57f6aae5)
+
+Public domain code is not subject to any license.
+
+---
+
+The Unlicense
+(nelsam/hel v2.3.3)
+
+The Unlicense
+=============
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to the
+detriment of our heirs and successors. We intend this dedication to be an overt
+act of relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to http://unlicense.org/
+
+---
+
+Universal Permissive License v1.0
+(godror/godror v0.24.2)
+
+The Universal Permissive License (UPL), Version 1.0
+===================================================
+
+Copyright (c) <year> <copyright holders>
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely licensable
+by each licensor hereunder covering either (i) the unmodified Software as
+contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+below), to deal in both
+
+(a) the Software, and
+
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one
+is included with the Software (each a “Larger Work” to which the Software is
+contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make, use,
+sell, offer for sale, import, export, have made, and have sold the Software and
+the Larger Work(s), and to sublicense the foregoing rights on either these or
+other terms.
+
+This license is subject to the following condition:
+
+The above copyright notice and either this complete permission notice or at a
+minimum a reference to the UPL must be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+zlib License
+(bugsnag-osext 20130617-snapshot-0dd3f918)
+
+The zlib/libpng License
+=======================
+
+Copyright (c) <year> <copyright holders>
+
+This software is provided 'as-is', without any express or implied warranty. In no
+event will the authors be held liable for any damages arising from the use of
+this software.
+
+Permission is granted to anyone to use this software for any purpose, including
+commercial applications, and to alter it and redistribute it freely, subject to
+the following restrictions:
+
+      1. The origin of this software must not be misrepresented; you must not
+      claim that you wrote the original software. If you use this software in a
+      product, an acknowledgment in the product documentation would be
+      appreciated but is not required.
+
+      2. Altered source versions must be plainly marked as such, and must not be
+      misrepresented as being the original software.
+
+      3. This notice may not be removed or altered from any source distribution.
+

--- a/stable/k8s-agent/README.md
+++ b/stable/k8s-agent/README.md
@@ -1,0 +1,4 @@
+# Nutanix Kubernetes Onboarding Agent Helm Chart
+
+## Nutanix Kubernetes Onboarding Agent Documentation
+https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Kubernetes-Engine:top-k8s-ds-onboarding-k8s-clu-pc-t.html

--- a/stable/k8s-agent/templates/hook-postdelete.yaml
+++ b/stable/k8s-agent/templates/hook-postdelete.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nke-k8s-agent-postdelete
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nke-k8s-agent-postdelete
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nke-k8s-agent-postdelete
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nke-k8s-agent-postdelete
+subjects:
+- kind: ServiceAccount
+  name: nke-k8s-agent-postdelete
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hook-postdelete
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  {{- if eq .Values.agent.image.privateRegistry true}}
+  imagePullSecrets:
+  - name: nutanix-k8s-agent-pull-secret
+  {{- end }}
+  securityContext:
+    runAsUser: 9999
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: nke-k8s-agent-postdelete
+  containers:
+  - name: hook-postdelete-container
+    image: "{{ .Values.agent.image.repository }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+    command: ["/k8s-agent/k8s-agent"]
+    args:
+      [
+        "--chart-hook=post-delete",
+        "--pc-endpoint={{ required "Endpoint is required" .Values.pc.endpoint }}",
+        "--pc-port={{ .Values.pc.port }}",
+        "--username={{ required "Username is required" .Values.pc.username }}",
+        "--password={{ required "Password is required" .Values.pc.password }}",
+        "--insecure={{ .Values.pc.insecure }}",
+        "--k8s-cluster-name={{ required "Name of kubernetes cluster is required" .Values.k8sClusterName }}",
+        "--k8s-distribution={{ required "Kubernetes distribution is required" .Values.k8sDistribution }}",
+        "--k8s-cluster-category={{ .Values.categoryMappings }}",
+        "--update-config-in-min={{ .Values.agent.updateConfigInMin }}",
+        "--update-metrics-in-min={{ .Values.agent.updateMetricsInMin }}",
+      ]
+    securityContext:
+      runAsUser: 9999
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0

--- a/stable/k8s-agent/templates/hook-postinstall.yaml
+++ b/stable/k8s-agent/templates/hook-postinstall.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hook-postinstall
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  {{- if eq .Values.agent.image.privateRegistry true}}
+  imagePullSecrets:
+  - name: nutanix-k8s-agent-pull-secret
+  {{- end }}
+  securityContext:
+    runAsUser: 9999
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: {{ .Values.agent.name }}
+  containers:
+  - name: hook-postinstall-container
+    image: "{{ .Values.agent.image.repository }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+    command: ["/k8s-agent/k8s-agent"]
+    args:
+      [
+        "--chart-hook=post-install",
+        "--pc-endpoint={{ required "Endpoint is required" .Values.pc.endpoint }}",
+        "--pc-port={{ .Values.pc.port }}",
+        "--username={{ required "Username is required" .Values.pc.username }}",
+        "--password={{ required "Password is required" .Values.pc.password }}",
+        "--insecure={{ .Values.pc.insecure }}",
+        "--k8s-cluster-name={{ required "Name of kubernetes cluster is required" .Values.k8sClusterName }}",
+        "--k8s-distribution={{ required "Kubernetes distribution is required" .Values.k8sDistribution }}",
+        "--k8s-cluster-category={{ .Values.categoryMappings }}",
+        "--update-config-in-min={{ .Values.agent.updateConfigInMin }}",
+        "--update-metrics-in-min={{ .Values.agent.updateMetricsInMin }}",
+      ]
+    securityContext:
+      runAsUser: 9999
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0

--- a/stable/k8s-agent/templates/hook-postupgrade.yaml
+++ b/stable/k8s-agent/templates/hook-postupgrade.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hook-postupgrade
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "post-upgrade"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  {{- if eq .Values.agent.image.privateRegistry true}}
+  imagePullSecrets:
+  - name: nutanix-k8s-agent-pull-secret
+  {{- end }}
+  securityContext:
+    runAsUser: 9999
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: {{ .Values.agent.name }}
+  containers:
+  - name: hook-postupgrade-container
+    image: "{{ .Values.agent.image.repository }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+    command: ["/k8s-agent/k8s-agent"]
+    args:
+      [
+        "--chart-hook=post-upgrade",
+        "--pc-endpoint={{ required "Endpoint is required" .Values.pc.endpoint }}",
+        "--pc-port={{ .Values.pc.port }}",
+        "--username={{ required "Username is required" .Values.pc.username }}",
+        "--password={{ required "Password is required" .Values.pc.password }}",
+        "--insecure={{ .Values.pc.insecure }}",
+        "--k8s-cluster-name={{ required "Name of kubernetes cluster is required" .Values.k8sClusterName }}",
+        "--k8s-distribution={{ required "Kubernetes distribution is required" .Values.k8sDistribution }}",
+        "--k8s-cluster-category={{ .Values.categoryMappings }}",
+        "--update-config-in-min={{ .Values.agent.updateConfigInMin }}",
+        "--update-metrics-in-min={{ .Values.agent.updateMetricsInMin }}",
+      ]
+    securityContext:
+      runAsUser: 9999
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0

--- a/stable/k8s-agent/templates/hook-predelete.yaml
+++ b/stable/k8s-agent/templates/hook-predelete.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.agent.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  {{.Values.agent.name}}-config
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+data:
+  agent-config.yaml: |
+  {{- if .Values.agent.config.registration }}
+    registration:
+      delete:
+        force: {{ .Values.agent.config.registration.delete.force | default false  }}
+  {{- end  }}   
+  {{- if .Values.agent.config.kubeconfig }} 
+    kubeconfig:
+      delete:
+        force: {{ .Values.agent.config.kubeconfig.delete.force | default false  }}
+  {{- end  }}    
+{{- end }}          
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hook-predelete
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+     "helm.sh/hook": "pre-delete"
+     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  {{- if eq .Values.agent.image.privateRegistry true}}
+  imagePullSecrets:
+  - name: nutanix-k8s-agent-pull-secret
+  {{- end }}
+  serviceAccountName: {{ .Values.agent.name }}
+  volumes:
+  - name: predelete-config
+    configMap:
+      name: {{.Values.agent.name}}-config
+  containers:
+  - name: hook-predelete-container
+    image: "{{ .Values.agent.image.repository }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+    command: ["/k8s-agent/k8s-agent"]
+    args:
+      [
+        "--chart-hook=pre-delete",
+        "--pc-endpoint={{ required "Endpoint is required" .Values.pc.endpoint }}",
+        "--pc-port={{ .Values.pc.port }}",
+        "--username={{ required "Username is required" .Values.pc.username }}",
+        "--password={{ required "Password is required" .Values.pc.password }}",
+        "--insecure={{ .Values.pc.insecure }}",
+        "--k8s-cluster-name={{ required "Name of kubernetes cluster is required" .Values.k8sClusterName }}",
+        "--k8s-distribution={{ required "Kubernetes distribution is required" .Values.k8sDistribution }}",
+        "--k8s-cluster-category={{ .Values.categoryMappings }}",
+        "--update-config-in-min={{ .Values.agent.updateConfigInMin }}",
+        "--update-metrics-in-min={{ .Values.agent.updateMetricsInMin }}",
+      ]
+    securityContext:
+      runAsUser: 9999
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+    volumeMounts:
+      - name: predelete-config
+        mountPath: /k8s-agent/config
+        readOnly: true    
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0  

--- a/stable/k8s-agent/templates/hook-preinstall.yaml
+++ b/stable/k8s-agent/templates/hook-preinstall.yaml
@@ -1,0 +1,123 @@
+{{- if eq .Values.agent.image.privateRegistry true}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nutanix-k8s-agent-pull-secret
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "1"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.agent.image.imageCredentials.dockerconfig }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+{{- if eq .Values.k8sDistribution "OCP"}}
+- apiGroups:
+  - 'config.openshift.io'
+  resources:
+  - 'infrastructures'
+  verbs:
+  - 'get'
+{{- end }}
+- apiGroups:
+  - "apps"
+  resources:
+  - "deployments"
+  verbs:
+  - "get"
+  - "list"
+- apiGroups:
+  - '*'
+  resources:
+  - 'namespaces'
+  verbs:
+  - 'get'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.agent.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hook-preinstall
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  {{- if eq .Values.agent.image.privateRegistry true}}
+  imagePullSecrets:
+  - name: nutanix-k8s-agent-pull-secret
+  {{- end }}
+  securityContext:
+    runAsUser: 9999
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName:  {{ .Values.agent.name }}
+  containers:
+  - name: hook-preinstall-container
+    image: "{{ .Values.agent.image.repository }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+    command: ["/k8s-agent/k8s-agent"]
+    args:
+      [
+        "--chart-hook=pre-install",
+        "--pc-endpoint={{ required "Endpoint is required" .Values.pc.endpoint }}",
+        "--pc-port={{ .Values.pc.port }}",
+        "--username={{ required "Username is required" .Values.pc.username }}",
+        "--password={{ required "Password is required" .Values.pc.password }}",
+        "--insecure={{ .Values.pc.insecure }}",
+        "--k8s-cluster-name={{ required "Name of kubernetes cluster is required" .Values.k8sClusterName }}",
+        "--k8s-distribution={{ required "Kubernetes distribution is required" .Values.k8sDistribution }}",
+        "--k8s-cluster-category={{ .Values.categoryMappings }}",
+        "--update-config-in-min={{ .Values.agent.updateConfigInMin }}",
+        "--update-metrics-in-min={{ .Values.agent.updateMetricsInMin }}",
+      ]
+    securityContext:
+      runAsUser: 9999
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0

--- a/stable/k8s-agent/templates/nutanix_agent_deployment.yaml
+++ b/stable/k8s-agent/templates/nutanix_agent_deployment.yaml
@@ -1,0 +1,162 @@
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "k8s-agent.namespace" -}}
+  {{- if .Values.agent.namespaceOverride -}}
+    {{- .Values.agent.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.agent.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+type: kubernetes.io/basic-auth
+data:
+  username: {{ required "PC username is required" .Values.pc.username | b64enc}}
+  password: {{ required "PC user password is required" .Values.pc.password | b64enc}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.agent.name }}
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.agent.name }} # This deployment applies to any Pods matching the specified label
+  template: # This deployment will create a set of pods using the configurations in this template
+    metadata:
+      labels: # The labels that will be applied to all of the pods in this deployment
+        app: {{ .Values.agent.name }}
+    spec: # Spec for the container which will run in the Pod
+      {{- if eq .Values.agent.image.privateRegistry true}}
+      imagePullSecrets:
+      - name: nutanix-k8s-agent-pull-secret
+      {{- end }}
+      securityContext:
+        runAsUser: 9999
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: {{ .Values.agent.name }}
+      containers:
+        - name: {{ .Values.agent.name }}
+          image: "{{ .Values.agent.image.repository }}/{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          command: ["/k8s-agent/k8s-agent"]
+          volumeMounts:
+            - name: pc-creds-volume
+              mountPath: /certs
+              readOnly: true
+          args:
+            [
+              "--pc-endpoint={{ required "Endpoint is required" .Values.pc.endpoint }}",
+              "--pc-port={{ .Values.pc.port }}",
+              "--insecure={{ .Values.pc.insecure }}",
+              "--k8s-cluster-name={{ required "Name of kubernetes cluster is required" .Values.k8sClusterName }}",
+              "--k8s-distribution={{ required "Kubernetes distribution is required" .Values.k8sDistribution }}",
+              "--k8s-cluster-category={{ .Values.categoryMappings }}",
+              "--update-config-in-min={{ .Values.agent.updateConfigInMin }}",
+              "--update-metrics-in-min={{ .Values.agent.updateMetricsInMin }}",
+            ]
+          ports:
+            - containerPort: {{ .Values.agent.port }} # Should match the port number that the Go application listens on
+          livenessProbe: # To check the health of the Pod
+            httpGet:
+              path: /health
+              port: {{ .Values.agent.port }}
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+          readinessProbe: # To check if the Pod is ready to serve traffic or not
+            httpGet:
+              path: /readiness
+              port: {{ .Values.agent.port }}
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          securityContext:
+            runAsUser: 9999
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: pc-creds-volume
+          secret:
+            secretName: {{ .Values.agent.name }}
+---
+# Case for creating ConfigMap with default categoryMappings
+{{- if eq .Values.categoryMappings "" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ntnx-cluster-configmap
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+data:
+  KubernetesClusterName: {{ .Values.k8sClusterName }}
+{{- else }}
+# Case for creating ConfigMap with user provided categoryMappings
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ntnx-cluster-configmap
+  namespace: {{ (include "k8s-agent.namespace" .) | quote }}
+data:
+  {{- $categoryMappings := .Values.categoryMappings | default "" | quote }}
+  {{- $categoryMappings := $categoryMappings | replace "\"" "" }}
+  {{- $mappings := ( split "," $categoryMappings) }}
+  {{- range $idx, $mapping := $mappings }}
+  {{- $mapping := ( split "=" $mapping ) }}
+  {{ $mapping._0 }}: {{ $mapping._1 | quote }}
+  {{- end }}
+{{- end }}

--- a/stable/k8s-agent/values.schema.json
+++ b/stable/k8s-agent/values.schema.json
@@ -1,0 +1,248 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://example.com/example.json",
+    "type": "object",
+    "default": {},
+    "title": "Root Schema",
+    "required": [
+        "agent",
+        "pc",
+        "k8sClusterName",
+        "k8sDistribution",
+        "categoryMappings"
+    ],
+    "properties": {
+        "agent": {
+            "type": "object",
+            "default": {},
+            "title": "The agent Schema",
+            "required": [
+                "namespaceOverride",
+                "name",
+                "port",
+                "image",
+                "updateConfigInMin",
+                "updateMetricsInMin"
+            ],
+            "properties": {
+                "namespaceOverride": {
+                    "type": "string",
+                    "default": "ntnx-system",
+                    "title": "The namespaceOverride Schema",
+                    "examples": [
+                        "ntnx-system"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The name Schema",
+                    "examples": [
+                        "nutanix-agent"
+                    ]
+                },
+                "port": {
+                    "type": "integer",
+                    "default": 8080,
+                    "title": "The port Schema",
+                    "examples": [
+                        8080
+                    ]
+                },
+                "image": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The image Schema",
+                    "required": [
+                        "repository",
+                        "pullPolicy",
+                        "tag"
+                    ],
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "default": "quay.io/karbon/k8s-agent",
+                            "title": "The repository Schema",
+                            "examples": [
+                                "quay.io/karbon/k8s-agent"
+                            ]
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "default": "IfNotPresent",
+                            "title": "The pullPolicy Schema",
+                            "examples": [
+                                "IfNotPresent"
+                            ]
+                        },
+                        "tag": {
+                            "type": "string",
+                            "default": "0",
+                            "title": "The tag Schema",
+                            "examples": [
+                                "1.3.0"
+                            ]
+                        }
+                    },
+                    "examples": [
+                        {
+                            "repository": "quay.io/karbon/k8s-agent",
+                            "pullPolicy": "IfNotPresent",
+                            "tag": "365"
+                        }
+                    ]
+                },
+                "updateConfigInMin": {
+                    "type": "integer",
+                    "default": 10,
+                    "title": "The updateConfigInMin Schema",
+                    "examples": [
+                        10
+                    ]
+                },
+                "updateMetricsInMin": {
+                    "type": "integer",
+                    "default": 360,
+                    "title": "The updateMetricsInMin Schema",
+                    "examples": [
+                        360
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "namespaceOverride": "ntnx-system",
+                    "name": "nutanix-agent",
+                    "port": 8080,
+                    "image": {
+                        "repository": "quay.io/karbon/k8s-agent",
+                        "pullPolicy": "IfNotPresent",
+                        "tag": "365"
+                    },
+                    "updateConfigInMin": 10,
+                    "updateMetricsInMin": 360
+                }
+            ]
+        },
+        "pc": {
+            "type": "object",
+            "default": {},
+            "title": "The pc Schema",
+            "required": [
+                "port",
+                "insecure",
+                "endpoint",
+                "username",
+                "password"
+            ],
+            "properties": {
+                "port": {
+                    "type": "integer",
+                    "default": 9440,
+                    "title": "The port Schema",
+                    "examples": [
+                        9440
+                    ]
+                },
+                "insecure": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The insecure Schema",
+                    "examples": [
+                        false
+                    ]
+                },
+                "endpoint": {
+                    "type": "string",
+                    "default": "xxx.xxx.xxx.xxx",
+                    "title": "The endpoint Schema",
+                    "examples": [
+                        "10.47.3.5",
+                        "prism-central.mycompany.com"
+                    ]
+                },
+                "username": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The username Schema",
+                    "examples": [
+                        "user1",
+                        "ca_user1@test.com"
+                    ]
+                },
+                "password": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The password Schema",
+                    "examples": [
+                        "PC user password"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "port": 9440,
+                    "insecure": false,
+                    "endpoint": "xxx.xxx.xxx.xxx",
+                    "username": "user1",
+                    "password": "xxxxxxxxx"
+                }
+            ]
+        },
+        "k8sClusterName": {
+            "type": "string",
+            "default": "",
+            "title": "The k8sClusterName Schema",
+            "examples": [
+                "dept1-cluster"
+            ]
+        },
+        "k8sDistribution": {
+            "type": "string",
+            "default": "",
+            "title": "The k8sDistribution Schema",
+            "pattern": "^(CAPX|OCP|NKE|EKSA|NKP)$",
+            "examples": [
+                "NKE",
+                "OCP",
+                "EKSA",
+                "NKP"
+            ]
+        },
+        "categoryMappings": {
+            "type": "string",
+            "default": "",
+            "title": "The categoryMappings Schema",
+            "examples": [
+                "key1=value1",
+                "key1=value1,key2=value2"
+            ]
+        }
+    },
+    "examples": [
+        {
+            "agent": {
+                "namespaceOverride": "ntnx-system",
+                "name": "nutanix-agent",
+                "port": 8080,
+                "image": {
+                    "repository": "quay.io/karbon/k8s-agent",
+                    "pullPolicy": "IfNotPresent",
+                    "tag": "365"
+                },
+                "updateConfigInMin": 10,
+                "updateMetricsInMin": 360
+            },
+            "pc": {
+                "port": 9440,
+                "insecure": false,
+                "endpoint": "xxx.xxx.xxx.xxx",
+                "username": "user1",
+                "password": "xxxxxxxxx"
+            },
+            "k8sClusterName": "dept1-cluster",
+            "k8sDistribution": "OCP",
+            "categoryMappings": ""
+        }
+    ]
+}

--- a/stable/k8s-agent/values.yaml
+++ b/stable/k8s-agent/values.yaml
@@ -1,0 +1,31 @@
+agent:
+  namespaceOverride: ntnx-system
+  name: nutanix-agent
+  port: 8080
+  image:
+    repository: docker.io/nutanix
+    name: nke-k8s-agent
+    pullPolicy: IfNotPresent
+    tag: "replace_image_tag"
+    privateRegistry: true
+    imageCredentials:
+      dockerconfig: replace_base64_encoded_creds
+  updateConfigInMin: 10
+  updateMetricsInMin: 360
+  config:
+    registration:
+      delete:
+        force: false
+    kubeconfig:
+      delete:
+        force: false  
+
+pc:
+  port: 9440
+  insecure: false #set this to true if PC does not have https enabled
+  endpoint: "" # eg: ip or fqdn
+  username: "" # eg: admin or any other user with Kubernetes Infrastructure provision role
+  password: ""
+k8sClusterName: ""
+k8sDistribution: "CAPX" # eg: CAPX or NKE or OCP or EKSA or NKP
+categoryMappings: "" # "one or more comma separated key=value" eg: "key1=value1" or "key1=value1\,key2=value2"


### PR DESCRIPTION
**What type of PR is this?**
 Feature - https://jira.nutanix.com/browse/NCN-109556

**What this PR does/ why we need it**:
This PR adds the Kubernetes agent (k8s-agent) Helm charts into our Helm charts repository.
The purpose is to integrate the Nutanix Konnector agent as an addon in NKP clusters.

From NKP v2.17, the k8s-agent will be deployed by default as an addon.

Having the charts in this repo allows the Helm repository to serve these charts to NKP during cluster provisioning or upgrade.

The original charts are located at : [https://github.com/nutanix-core/k8s-agent/tree/main/config/helm-chart](https://github.com/nutanix-core/k8s-agent/tree/main/config/helm-chart)


**Which issue(s) this PR fixes**:
no issue

**Special notes for your reviewer**:
Please verify the chart structure aligns with existing repo standards
**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
