### PR TITLE
chore: bump multus to v4.2.4

### DIFF
--- a/stable/multus/Chart.yaml
+++ b/stable/multus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: multus
 description: A Helm chart for Multus CNI - Meta CNI plugin for attaching multiple network interfaces to pods
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v4.2.4"
 home: https://github.com/k8snetworkplumbingwg/multus-cni
 sources:

--- a/stable/multus/Chart.yaml
+++ b/stable/multus/Chart.yaml
@@ -3,7 +3,7 @@ name: multus
 description: A Helm chart for Multus CNI - Meta CNI plugin for attaching multiple network interfaces to pods
 type: application
 version: 0.1.0
-appVersion: "v4.2.2"
+appVersion: "v4.2.4"
 home: https://github.com/k8snetworkplumbingwg/multus-cni
 sources:
   - https://github.com/k8snetworkplumbingwg/multus-cni

--- a/stable/multus/README.md
+++ b/stable/multus/README.md
@@ -102,16 +102,16 @@ The image tag follows this priority order:
    - Set `image.tag` to override everything
    ```yaml
    image:
-     tag: "v4.2.2-custom"
+     tag: "v4.2.4-custom"
    ```
 
 2. **Base version with suffix** (default):
    - Uses Chart.AppVersion + image.suffix
-   - Default: `v4.2.2-thick`
+   - Default: `v4.2.4-thick`
    ```yaml
    image:
      tag: ""  # Empty
-     suffix: "-thick"  # Results in: v4.2.2-thick
+     suffix: "-thick"  # Results in: v4.2.4-thick
    ```
 
 3. **Base version with different suffix**:
@@ -119,7 +119,7 @@ The image tag follows this priority order:
    ```yaml
    image:
      tag: ""  # Empty
-     suffix: "-thin"  # Results in: v4.2.2-thin
+     suffix: "-thin"  # Results in: v4.2.4-thin
    ```
 
 4. **Base version without suffix**:
@@ -127,7 +127,7 @@ The image tag follows this priority order:
    ```yaml
    image:
      tag: ""  # Empty
-     suffix: ""  # Results in: v4.2.2
+     suffix: ""  # Results in: v4.2.4
    ```
 
 ### For Cilium as Primary CNI:

--- a/stable/multus/templates/daemonset.yaml
+++ b/stable/multus/templates/daemonset.yaml
@@ -64,9 +64,12 @@ spec:
         image: "{{ .Values.image.repository }}:{{ include "multus.imageTag" . }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         command:
-          - "sh"
-          - "-c"
-          - "cp /usr/src/multus-cni/bin/multus-shim /host/opt/cni/bin/multus-shim && cp /usr/src/multus-cni/bin/passthru /host/opt/cni/bin/passthru"
+          - "/usr/src/multus-cni/bin/install_multus"
+        args:
+          - "-d"
+          - "/host/opt/cni/bin"
+          - "-t"
+          - "thick"
         resources:
           requests:
             cpu: "10m"

--- a/stable/multus/values.yaml
+++ b/stable/multus/values.yaml
@@ -69,7 +69,7 @@ podLabels: {}
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 100m
     memory: 128Mi


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Upgrade multus to v4.2.4-thick which brings key fixes such as -
1. https://github.com/k8snetworkplumbingwg/multus-cni/pull/1445 
2. Bumping go version to 1.24


**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.nutanix.com/browse/NCN-112995

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
