### PR TITLE
fix: istio ambient upgrade redundant envs

### DIFF
--- a/staging/istio-helm-base/Chart.yaml
+++ b/staging/istio-helm-base/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: istio-helm-base
-version: 1.25.0
+version: 1.25.1
 appVersion: 1.29.0
 description: Helm chart for deploying Istio base resources and CRDs
 keywords:

--- a/staging/istio-helm-cni/Chart.yaml
+++ b/staging/istio-helm-cni/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: istio-helm-cni
-version: 1.25.0
+version: 1.25.1
 appVersion: 1.29.0
 description: Helm chart for deploying Istio CNI plugin
 keywords:

--- a/staging/istio-helm-gateway/Chart.yaml
+++ b/staging/istio-helm-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: istio-helm-gateway
-version: 1.25.0
+version: 1.25.1
 appVersion: 1.29.0
 description: Helm chart for deploying Istio ingress gateway
 keywords:

--- a/staging/istio-helm-istiod/Chart.yaml
+++ b/staging/istio-helm-istiod/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: istio-helm-istiod
-version: 1.25.0
+version: 1.25.1
 appVersion: 1.29.0
 description: Helm chart for deploying Istio control plane (istiod) with monitoring
 keywords:

--- a/staging/istio-helm-ztunnel/Chart.yaml
+++ b/staging/istio-helm-ztunnel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-helm-ztunnel
 # 1.24.0 supports migration to ambient mesh mode from sidecar
 # Tracker: https://jira.nutanix.com/browse/NCN-112389
-version: 1.25.0
+version: 1.25.1
 appVersion: 1.29.0
 description: Helm chart for deploying Istio ztunnel for ambient mesh mode
 keywords:

--- a/staging/istio-helm-ztunnel/charts/ztunnel/templates/daemonset.yaml
+++ b/staging/istio-helm-ztunnel/charts/ztunnel/templates/daemonset.yaml
@@ -162,9 +162,15 @@ spec:
               resource: limits.cpu
               divisor: "1"
         {{- with .Values.env }}
+        {{/* CA_ADDRESS and XDS_ADDRESS are already rendered above; skip them here so a
+             legacy override (ztunnel.env.CA_ADDRESS/XDS_ADDRESS) can't create a duplicate
+             env entry that strict server-side apply rejects. */}}
+        {{- $reserved := list "CA_ADDRESS" "XDS_ADDRESS" }}
         {{- range $key, $val := . }}
+        {{- if not (has $key $reserved) }}
         - name: {{ $key }}
           value: "{{ $val }}"
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.peerCaCrl.enabled }}


### PR DESCRIPTION
***Summary***
 - `ztunnel.env.CA_ADDRESS/XDS_ADDRESS` is rendered twice once from chart's internal block and one from user config override while enabling ambient mode in 2.17 NKP. In 2.18, all HRs are server-side apply, which is making this redunandant envs fail.
 - Thus, in template of ztunnel daemonset, skipping these envs when entered from config overrdie