### PR TITLE
chore(traefik-forward-auth): bump chart to v3.3.0

### DIFF
--- a/staging/traefik-forward-auth/Chart.yaml
+++ b/staging/traefik-forward-auth/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v1
-appVersion: "3.1.0"
+appVersion: "3.3.0"
 description: Minimal forward authentication service that provides OIDC based login and authentication for the traefik reverse proxy
 name: traefik-forward-auth
-version: 0.3.10
+version: 0.3.11
 keywords:
   - traefik-forward-auth
   - traefik

--- a/staging/traefik-forward-auth/values.yaml
+++ b/staging/traefik-forward-auth/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mesosphere/traefik-forward-auth
-  tag: 3.1.0
+  tag: v3.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
image was 3.1.0 (chart 0.3.10) since 2023; app has since released v3.2.0, v3.2.1, v3.3.0, all dependency bumps, a go version bump, a race-condition fix in the user info cache, and arm64 image builds. No CLI flag, env var, or config changes.

Full diff: https://github.com/mesosphere/traefik-forward-auth/compare/v3.1.0...v3.3.0

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
